### PR TITLE
[serapi] Add document creation `NewDoc` protocol call.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,9 @@ _Version 0.6.0_:
             @palmskog,
  * [sercomp] add `--mode` option to better control output,
  * [sercomp] add `compser` for deserialization (inverse of `sercomp`)
+ * [serapi]  Allow custom document creation using the `NewDoc` call.
+             Use the `--no_init` option to avoid automatic creation
+             on init. (@ejgallego)
 
 _Version 0.5.7_:
 

--- a/serapi/serapi_paths.mli
+++ b/serapi/serapi_paths.mli
@@ -10,30 +10,11 @@
 
 (************************************************************************)
 (* Coq serialization API/Plugin                                         *)
-(* Copyright 2016-2018 MINES ParisTech                                  *)
+(* Copyright 2016-2018 MINES ParisTech -- Dual License LGPL 2.1 / GPL3+ *)
 (* Written by: Emilio J. Gallego Arias                                  *)
 (************************************************************************)
 (* Status: Very Experimental                                            *)
 (************************************************************************)
 
-type async_flags = {
-  enable_async : string option;
-  async_full   : bool;
-  deep_edits   : bool;
-}
-
-val process_stm_flags : async_flags -> Stm.AsyncOpts.stm_opt
-
-type coq_opts = {
-
-  (* callback to handle async feedback *)
-  fb_handler   : Feedback.feedback -> unit;
-
-  (* callback to load cma/cmo files *)
-  ml_load      : (string -> unit) option;
-
-  (* Enable Coq Debug mode *)
-  debug        : bool;
-}
-
-val coq_init : coq_opts -> unit
+(* Default load path for Coq's stdlib *)
+val coq_loadpath_default : implicit:bool -> coq_path:string -> Mltop.coq_path list

--- a/serapi/serapi_protocol.mli
+++ b/serapi/serapi_protocol.mli
@@ -27,7 +27,7 @@ open Sexplib.Conv
 (* Basic Protocol Objects                                                     *)
 (******************************************************************************)
 type coq_object =
-    CoqString    of string
+  | CoqString    of string
   | CoqSList     of string list
   | CoqPp        of Pp.t
   (* | CoqRichpp    of Richpp.richpp *)
@@ -147,6 +147,22 @@ type add_opts = {
 }
 
 (******************************************************************************)
+(* Init / new document                                                        *)
+(******************************************************************************)
+type newdoc_opts = {
+
+  (* name of the top-level module *)
+  top_name     : string;
+
+  (* Initial LoadPath. [XXX: Use the coq_pkg record?] *)
+  iload_path   : Mltop.coq_path list sexp_option;
+
+  (* Libs to require in STM init *)
+  require_libs : (string * string option * bool option) list sexp_option;
+
+}
+
+(******************************************************************************)
 (* Help                                                                       *)
 (******************************************************************************)
 
@@ -157,6 +173,7 @@ type add_opts = {
 (******************************************************************************)
 
 type cmd =
+  | NewDoc     of newdoc_opts
   | Add        of add_opts  * string
   | Cancel     of Stateid.t list
   | Exec       of Stateid.t
@@ -200,4 +217,3 @@ type answer =
   (* implicit : bool; *)
 (*   async    : Sertop_init.async_flags; *)
 (* } *)
-

--- a/serlib/ser_mltop.ml
+++ b/serlib/ser_mltop.ml
@@ -16,24 +16,22 @@
 (* Status: Very Experimental                                            *)
 (************************************************************************)
 
-type async_flags = {
-  enable_async : string option;
-  async_full   : bool;
-  deep_edits   : bool;
-}
+open Sexplib.Conv
 
-val process_stm_flags : async_flags -> Stm.AsyncOpts.stm_opt
+module Names = Ser_names
 
-type coq_opts = {
+type add_ml =
+  [%import: Mltop.add_ml]
+  [@@deriving sexp]
 
-  (* callback to handle async feedback *)
-  fb_handler   : Feedback.feedback -> unit;
+type vo_path_spec =
+  [%import: Mltop.vo_path_spec]
+  [@@deriving sexp]
 
-  (* callback to load cma/cmo files *)
-  ml_load      : (string -> unit) option;
+type coq_path_spec =
+  [%import: Mltop.coq_path_spec]
+  [@@deriving sexp]
 
-  (* Enable Coq Debug mode *)
-  debug        : bool;
-}
-
-val coq_init : coq_opts -> unit
+type coq_path =
+  [%import: Mltop.coq_path]
+  [@@deriving sexp]

--- a/sertop/complib.ml
+++ b/sertop/complib.ml
@@ -1,0 +1,246 @@
+(************************************************************************)
+(*         *   The Coq Proof Assistant / The Coq Development Team       *)
+(*  v      *   INRIA, CNRS and contributors - Copyright 1999-2018       *)
+(* <O___,, *       (see CREDITS file for the list of authors)           *)
+(*   \VV/  **************************************************************)
+(*    //   *    This file is distributed under the terms of the         *)
+(*         *     GNU Lesser General Public License Version 2.1          *)
+(*         *     (see LICENSE file for the text of the license)         *)
+(************************************************************************)
+
+(************************************************************************)
+(* Coq serialization API/Plugin                                         *)
+(* Copyright 2016-2018 MINES ParisTech -- Dual License LGPL 2.1 / GPL3+ *)
+(* Written by: Emilio J. Gallego Arias                                  *)
+(************************************************************************)
+(* Status: Very Experimental                                            *)
+(************************************************************************)
+
+type stats = {
+  mutable specs  : int;
+  mutable proofs : int;
+  mutable misc   : int;
+}
+
+let stats = {
+  specs  = 0;
+  proofs = 0;
+  misc   = 0;
+}
+
+(* XXX: Move to sertop_stats.ml *)
+let do_stats =
+  let proof_loc = ref None in
+  fun ?loc (vrn : Vernacexpr.vernac_control) ->
+  let open Vernacexpr in
+  let incS ?loc f =
+    Option.cata (fun loc ->
+        let n_lines = Loc.(loc.line_nb_last - loc.line_nb + 1) in
+        Format.printf "@[Adding %d lines@]@\n%!" n_lines;
+        f + n_lines) f loc
+  in
+  match Vernacprop.under_control vrn with
+  (* Definition *)
+  | VernacDefinition (_,_,_)
+  | VernacFixpoint   (_,_)
+  | VernacInductive  (_,_,_,_)
+  | VernacCoFixpoint (_,_)
+  | VernacNotation   (_,_,_) ->
+    stats.specs <- incS ?loc stats.specs
+
+  (* Proofs *)
+  | VernacStartTheoremProof (_,_) ->
+    stats.specs <- incS ?loc stats.specs;
+    Option.iter (fun loc -> proof_loc := Some Loc.(loc.line_nb_last)) loc
+
+  | VernacProof (_,_)               -> ()
+  (* XXX: Should we use the +1 rule here, what happens for proofs:
+     Proof. exact: L. Qed.
+   *)
+  | VernacEndProof _                -> Option.iter (fun ll -> Option.iter (fun loc ->
+                                         stats.proofs <- stats.proofs + (Loc.(loc.line_nb) - ll) + 1
+                                       ) loc ) !proof_loc;
+                                       proof_loc := None
+  (* This is tricky.. *)
+  (* This is Ltac := ... *)
+  | VernacExtend (("VernacDeclareTacticDefinition",_),_)
+                                    -> stats.proofs <- incS ?loc stats.proofs;
+
+  | _                               -> if Option.is_empty !proof_loc then stats.misc <- incS ?loc stats.misc
+
+(*
+  match vrn with
+  | VernacLoad (_,_) -> (??)
+  | VernacTime _ -> (??)
+  | VernacRedirect (_,_) -> (??)
+  | VernacTimeout (_,_) -> (??)
+  | VernacFail _ -> (??)
+  | VernacError _ -> (??)
+  | VernacSyntaxExtension (_,_) -> (??)
+  | VernacOpenCloseScope (_,_) -> (??)
+  | VernacDelimiters (_,_) -> (??)
+  | VernacBindScope (_,_) -> (??)
+  | VernacInfix (_,_,_,_) -> (??)
+  | VernacNotationAddFormat (_,_,_) -> (??)
+  | VernacStartTheoremProof (_,_,_) -> (??)
+  | VernacExactProof _ -> (??)
+  | VernacAssumption (_,_,_) -> (??)
+  | VernacScheme _ -> (??)
+  | VernacCombinedScheme (_,_) -> (??)
+  | VernacUniverse _ -> (??)
+  | VernacConstraint _ -> (??)
+  | VernacBeginSection _ -> (??)
+  | VernacEndSegment _ -> (??)
+  | VernacRequire (_,_,_) -> (??)
+  | VernacImport (_,_) -> (??)
+  | VernacCanonical _ -> (??)
+  | VernacCoercion (_,_,_,_) -> (??)
+  | VernacIdentityCoercion (_,_,_,_) -> (??)
+  | VernacNameSectionHypSet (_,_) -> (??)
+  | VernacInstance (_,_,_,_,_) -> (??)
+  | VernacContext _ -> (??)
+  | VernacDeclareInstances (_,_) -> (??)
+  | VernacDeclareClass _ -> (??)
+  | VernacDeclareModule (_,_,_,_) -> (??)
+  | VernacDefineModule (_,_,_,_,_) -> (??)
+  | VernacDeclareModuleType (_,_,_,_) -> (??)
+  | VernacInclude _ -> (??)
+  | VernacSolveExistential (_,_) -> (??)
+  | VernacAddLoadPath (_,_,_) -> (??)
+  | VernacRemoveLoadPath _ -> (??)
+  | VernacAddMLPath (_,_) -> (??)
+  | VernacDeclareMLModule _ -> (??)
+  | VernacChdir _ -> (??)
+  | VernacWriteState _ -> (??)
+  | VernacRestoreState _ -> (??)
+  | VernacResetName _ -> (??)
+  | VernacResetInitial  -> (??)
+  | VernacBack _ -> (??)
+  | VernacBackTo _ -> (??)
+  | VernacCreateHintDb (_,_) -> (??)
+  | VernacRemoveHints (_,_) -> (??)
+  | VernacHints (_,_,_) -> (??)
+  | VernacSyntacticDefinition (_,_,_,_) -> (??)
+  | VernacDeclareImplicits (_,_) -> (??)
+  | VernacArguments (_,_,_,_) -> (??)
+  | VernacArgumentsScope (_,_) -> (??)
+  | VernacReserve _ -> (??)
+  | VernacGeneralizable _ -> (??)
+  | VernacSetOpacity _ -> (??)
+  | VernacSetStrategy _ -> (??)
+  | VernacUnsetOption _ -> (??)
+  | VernacSetOption (_,_) -> (??)
+  | VernacAddOption (_,_) -> (??)
+  | VernacRemoveOption (_,_) -> (??)
+  | VernacMemOption (_,_) -> (??)
+  | VernacPrintOption _ -> (??)
+  | VernacCheckMayEval (_,_,_) -> (??)
+  | VernacGlobalCheck _ -> (??)
+  | VernacDeclareReduction (_,_) -> (??)
+  | VernacPrint _ -> (??)
+  | VernacSearch (_,_,_) -> (??)
+  | VernacLocate _ -> (??)
+  | VernacRegister (_,_) -> (??)
+  | VernacComments _ -> (??)
+  | VernacStm _ -> (??)
+  | VernacAbort _ -> (??)
+  | VernacAbortAll  -> (??)
+  | VernacRestart  -> (??)
+  | VernacUndo _ -> (??)
+  | VernacUndoTo _ -> (??)
+  | VernacBacktrack (_,_,_) -> (??)
+  | VernacFocus _ -> (??)
+  | VernacUnfocus  -> (??)
+  | VernacUnfocused  -> (??)
+  | VernacBullet _ -> (??)
+  | VernacProgram _ -> (??)
+  | VernacSubproof _ -> (??)
+  | VernacEndSubproof  -> (??)
+  | VernacShow _ -> (??)
+  | VernacCheckGuard  -> (??)
+  | VernacProofMode _ -> (??)
+  | VernacToplevelControl _ -> (??)
+  | VernacExtend (_,_) -> (??)
+  | VernacPolymorphic (_,_) -> (??)
+  | VernacLocal (_,_) -> (??)
+*)
+
+let create_from_file ~in_file ~async ~iload_path =
+
+  let open Sertop_init in
+
+  let stm_options =
+    { enable_async = async;
+      async_full   = false;
+      deep_edits   = false;
+    } in
+
+  let ndoc = { Stm.doc_type = Stm.VoDoc in_file;
+               require_libs = ["Coq.Init.Prelude", None, Some true];
+               iload_path;
+               stm_options  = Sertop_init.process_stm_flags stm_options;
+               } in
+  Stm.new_doc ndoc
+
+let process_vernac ~mode ~pp ~doc ~st (CAst.{loc;v=vrn} as ast) =
+  let open Format in
+  let doc, n_st, tip = Stm.add ~doc ~ontop:st false ast in
+  if tip <> `NewTip then
+    (eprintf "Fatal Error, got no `NewTip`"; exit 1);
+  let open Sertop_arg in
+  let () = match mode with
+    | C_parse -> ()
+    | C_stats ->
+      do_stats ?loc vrn
+    | C_sexp ->
+      printf "@[%a@]@\n%!" pp (Ser_vernacexpr.sexp_of_vernac_control vrn)
+  in
+  doc, n_st
+
+let close_document ~mode =
+  if mode = Sertop_arg.C_stats then
+    Format.printf "Statistics:@\nSpecs:  %d@\nProofs: %d@\nMisc:   %d@\n%!"
+      stats.specs stats.proofs stats.misc
+
+(* Command line processing *)
+let comp_version = Ser_version.ser_git_version
+
+type compfun
+  =  Sertop_arg.comp_mode
+  -> bool
+  -> Sertop_ser.ser_printer
+  -> string option
+  -> string
+  -> Mltop.coq_path list
+  -> Mltop.coq_path list
+  -> Mltop.coq_path list
+  -> string -> bool -> bool -> bool -> unit
+
+open Cmdliner
+
+let maincomp ~ext ~name ~desc ~(compfun:compfun) =
+  let input_file =
+    let doc = "Input " ^ ext ^ " file." in
+    Arg.(required & pos 0 (some string) None & info [] ~docv:("FILE"^ext) ~doc)
+  in
+
+  let comp_cmd =
+    let doc = name ^ " Coq Compiler" in
+    let man = [
+      `S "DESCRIPTION";
+      `P desc;
+    ]
+    in
+
+    let open Sertop_arg in
+    Term.(const compfun $ comp_mode $ debug $ printer $ async $ prelude $ ml_include_path $ load_path $ rload_path $ input_file $ omit_loc $ omit_att $ exn_on_opaque ),
+    Term.info name ~version:comp_version ~doc ~man
+  in
+
+  try match Term.eval comp_cmd with
+    | `Error _ -> exit 1
+    | _        -> exit 0
+  with any ->
+    let (e, info) = CErrors.push any in
+    Format.eprintf "Error: %a@\n%!" Pp.pp_with (CErrors.iprint (e, info));
+    exit 1

--- a/sertop/complib.mli
+++ b/sertop/complib.mli
@@ -10,30 +10,45 @@
 
 (************************************************************************)
 (* Coq serialization API/Plugin                                         *)
-(* Copyright 2016-2018 MINES ParisTech                                  *)
+(* Copyright 2016-2018 MINES ParisTech -- Dual License LGPL 2.1 / GPL3+ *)
 (* Written by: Emilio J. Gallego Arias                                  *)
 (************************************************************************)
 (* Status: Very Experimental                                            *)
 (************************************************************************)
 
-type async_flags = {
-  enable_async : string option;
-  async_full   : bool;
-  deep_edits   : bool;
-}
+open Sexplib
+open Sertop_arg
 
-val process_stm_flags : async_flags -> Stm.AsyncOpts.stm_opt
+val create_from_file
+  :  in_file:string
+  -> async:string option
+  -> iload_path:Mltop.coq_path list
+  -> Stm.doc * Stateid.t
 
-type coq_opts = {
+val process_vernac
+  :  mode:comp_mode
+  -> pp:(Format.formatter -> Sexp.t -> unit)
+  -> doc:Stm.doc
+  -> st:Stateid.t
+  -> Vernacexpr.vernac_control CAst.t
+  -> Stm.doc * Stateid.t
 
-  (* callback to handle async feedback *)
-  fb_handler   : Feedback.feedback -> unit;
+val close_document : mode:comp_mode -> unit
 
-  (* callback to load cma/cmo files *)
-  ml_load      : (string -> unit) option;
+type compfun
+  =  comp_mode
+  -> bool
+  -> Sertop_ser.ser_printer
+  -> string option
+  -> string
+  -> Mltop.coq_path list
+  -> Mltop.coq_path list
+  -> Mltop.coq_path list
+  -> string -> bool -> bool -> bool -> unit
 
-  (* Enable Coq Debug mode *)
-  debug        : bool;
-}
-
-val coq_init : coq_opts -> unit
+val maincomp
+  :  ext:string
+  -> name:string
+  -> desc:string
+  -> compfun:compfun
+  -> unit

--- a/sertop/compser.ml
+++ b/sertop/compser.ml
@@ -11,21 +11,6 @@
 open Ser_vernacexpr
 open Sexplib
 
-let process_vernac ~mode pp ~doc st (CAst.{loc;v=vrn} as ast) =
-  let open Format in
-  let doc, n_st, tip = Stm.add ~doc ~ontop:st false ast in
-  if tip <> `NewTip then
-    (eprintf "Fatal Error, got no `NewTip`"; exit 1);
-  let open Sertop_arg in
-  let () = match mode with
-    | C_parse -> ()
-    | C_stats -> ()
-    | C_sexp ->
-      printf "@[%a@]@\n @[%a@]@\n%!" Pp.pp_with (Pp.pr_opt Topfmt.pr_loc loc)
-        pp (sexp_of_vernac_control vrn);
-  in
-  doc, n_st
-
 let compser mode debug printer async coq_path ml_path lp1 lp2 in_file omit_loc omit_att exn_on_opaque =
 
   (* serlib initialization *)
@@ -33,27 +18,22 @@ let compser mode debug printer async coq_path ml_path lp1 lp2 in_file omit_loc o
 
   let open Sertop_init in
 
+  (* coq initialization *)
+  coq_init {
+    fb_handler   = (fun _ -> ());  (* XXXX *)
+    ml_load      = None;
+    debug;
+  };
+
+  (* document initialization *)
+  let iload_path = Serapi_paths.coq_loadpath_default ~implicit:true ~coq_path @ ml_path @ lp1 @ lp2 in
+  let doc, sid = Complib.create_from_file ~in_file ~async ~iload_path in
+
+  (* main loop *)
   let in_chan = open_in in_file                          in
   let pp_sexp = Sertop_ser.select_printer printer        in
 
-  let iload_path = coq_loadpath_default ~implicit:true ~coq_path @ ml_path @ lp1 @ lp2 in
-
-  let doc,sid = coq_init {
-    fb_handler   = (fun _ -> ());
-
-    aopts        = { enable_async = async;
-                     async_full   = false;
-                     deep_edits   = false;
-                   };
-    iload_path;
-    require_libs = ["Coq.Init.Prelude", None, Some true];
-    top_name     = "CompSer";
-    ml_load      = None;
-    debug;
-  } in
-
   let stt = ref (doc, sid) in
-
   try
     while true; do
       let line = input_line in_chan in
@@ -61,40 +41,15 @@ let compser mode debug printer async coq_path ml_path lp1 lp2 in_file omit_loc o
         let vs = Sexp.of_string line in
         let vrn = vernac_control_of_sexp vs in
         let ast = CAst.make vrn in
-        stt := process_vernac ~mode pp_sexp ~doc:(fst !stt) (snd !stt) ast
+        stt := Complib.process_vernac ~mode ~pp:pp_sexp ~doc:(fst !stt) ~st:(snd !stt) ast
       end
     done
   with End_of_file ->
     let _ = Stm.finish ~doc:(fst !stt) in
     close_in in_chan
 
-(* Command line processing *)
-let compser_version = Ser_version.ser_git_version
+let _ =
+  Complib.maincomp ~ext:".sexp" ~name:"compser"
+    ~desc:"Experimental Coq Compiler with deserialization support."
+    ~compfun:compser
 
-open Cmdliner
-
-let input_file =
-  let doc = "Input sexp file." in
-  Arg.(required & pos 0 (some string) None & info [] ~docv:"FILE.sexp" ~doc)
-
-let sertop_cmd =
-  let doc = "CompSer Coq Compiler" in
-  let man = [
-    `S "DESCRIPTION";
-    `P "Experimental Sexp Coq Compiler."
-  ]
-  in
-  let open Sertop_arg in
-  Term.(const compser $ comp_mode $ debug $ printer $ async $ prelude $ ml_include_path $ load_path $ rload_path $ input_file $ omit_loc $ omit_att $ exn_on_opaque ),
-  Term.info "compser" ~version:compser_version ~doc ~man
-
-let main () =
-  try match Term.eval sertop_cmd with
-    | `Error _ -> exit 1
-    | _        -> exit 0
-  with any ->
-    let (e, info) = CErrors.push any in
-    Format.eprintf "Error: %a@\n%!" Pp.pp_with (CErrors.iprint (e, info));
-    exit 1
-
-let _ = main ()

--- a/sertop/sercomp.ml
+++ b/sertop/sercomp.ml
@@ -16,179 +16,11 @@
 (* Status: Very Experimental                                            *)
 (************************************************************************)
 
-open Ser_vernacexpr
-
-type stats = {
-  mutable specs  : int;
-  mutable proofs : int;
-  mutable misc   : int;
-}
-
-let stats = {
-  specs  = 0;
-  proofs = 0;
-  misc   = 0;
-}
-
-(* XXX: Move to sertop_stats.ml *)
-let do_stats =
-  let proof_loc = ref None in
-  fun ?loc (vrn : Vernacexpr.vernac_control) ->
-  let open Vernacexpr in
-  let incS ?loc f =
-    Option.cata (fun loc ->
-        let n_lines = Loc.(loc.line_nb_last - loc.line_nb + 1) in
-        Format.printf "@[Adding %d lines@]@\n%!" n_lines;
-        f + n_lines) f loc
-  in
-  match Vernacprop.under_control vrn with
-  (* Definition *)
-  | VernacDefinition (_,_,_)
-  | VernacFixpoint   (_,_)
-  | VernacInductive  (_,_,_,_)
-  | VernacCoFixpoint (_,_)
-  | VernacNotation   (_,_,_) ->
-    stats.specs <- incS ?loc stats.specs
-
-  (* Proofs *)
-  | VernacStartTheoremProof (_,_) ->
-    stats.specs <- incS ?loc stats.specs;
-    Option.iter (fun loc -> proof_loc := Some Loc.(loc.line_nb_last)) loc
-
-  | VernacProof (_,_)               -> ()
-  (* XXX: Should we use the +1 rule here, what happens for proofs:
-     Proof. exact: L. Qed.
-   *)
-  | VernacEndProof _                -> Option.iter (fun ll -> Option.iter (fun loc ->
-                                         stats.proofs <- stats.proofs + (Loc.(loc.line_nb) - ll) + 1
-                                       ) loc ) !proof_loc;
-                                       proof_loc := None
-  (* This is tricky.. *)
-  (* This is Ltac := ... *)
-  | VernacExtend (("VernacDeclareTacticDefinition",_),_)
-                                    -> stats.proofs <- incS ?loc stats.proofs;
-
-  | _                               -> if Option.is_empty !proof_loc then stats.misc <- incS ?loc stats.misc
-
-(*
-  match vrn with
-  | VernacLoad (_,_) -> (??)
-  | VernacTime _ -> (??)
-  | VernacRedirect (_,_) -> (??)
-  | VernacTimeout (_,_) -> (??)
-  | VernacFail _ -> (??)
-  | VernacError _ -> (??)
-  | VernacSyntaxExtension (_,_) -> (??)
-  | VernacOpenCloseScope (_,_) -> (??)
-  | VernacDelimiters (_,_) -> (??)
-  | VernacBindScope (_,_) -> (??)
-  | VernacInfix (_,_,_,_) -> (??)
-  | VernacNotationAddFormat (_,_,_) -> (??)
-  | VernacStartTheoremProof (_,_,_) -> (??)
-  | VernacExactProof _ -> (??)
-  | VernacAssumption (_,_,_) -> (??)
-  | VernacScheme _ -> (??)
-  | VernacCombinedScheme (_,_) -> (??)
-  | VernacUniverse _ -> (??)
-  | VernacConstraint _ -> (??)
-  | VernacBeginSection _ -> (??)
-  | VernacEndSegment _ -> (??)
-  | VernacRequire (_,_,_) -> (??)
-  | VernacImport (_,_) -> (??)
-  | VernacCanonical _ -> (??)
-  | VernacCoercion (_,_,_,_) -> (??)
-  | VernacIdentityCoercion (_,_,_,_) -> (??)
-  | VernacNameSectionHypSet (_,_) -> (??)
-  | VernacInstance (_,_,_,_,_) -> (??)
-  | VernacContext _ -> (??)
-  | VernacDeclareInstances (_,_) -> (??)
-  | VernacDeclareClass _ -> (??)
-  | VernacDeclareModule (_,_,_,_) -> (??)
-  | VernacDefineModule (_,_,_,_,_) -> (??)
-  | VernacDeclareModuleType (_,_,_,_) -> (??)
-  | VernacInclude _ -> (??)
-  | VernacSolveExistential (_,_) -> (??)
-  | VernacAddLoadPath (_,_,_) -> (??)
-  | VernacRemoveLoadPath _ -> (??)
-  | VernacAddMLPath (_,_) -> (??)
-  | VernacDeclareMLModule _ -> (??)
-  | VernacChdir _ -> (??)
-  | VernacWriteState _ -> (??)
-  | VernacRestoreState _ -> (??)
-  | VernacResetName _ -> (??)
-  | VernacResetInitial  -> (??)
-  | VernacBack _ -> (??)
-  | VernacBackTo _ -> (??)
-  | VernacCreateHintDb (_,_) -> (??)
-  | VernacRemoveHints (_,_) -> (??)
-  | VernacHints (_,_,_) -> (??)
-  | VernacSyntacticDefinition (_,_,_,_) -> (??)
-  | VernacDeclareImplicits (_,_) -> (??)
-  | VernacArguments (_,_,_,_) -> (??)
-  | VernacArgumentsScope (_,_) -> (??)
-  | VernacReserve _ -> (??)
-  | VernacGeneralizable _ -> (??)
-  | VernacSetOpacity _ -> (??)
-  | VernacSetStrategy _ -> (??)
-  | VernacUnsetOption _ -> (??)
-  | VernacSetOption (_,_) -> (??)
-  | VernacAddOption (_,_) -> (??)
-  | VernacRemoveOption (_,_) -> (??)
-  | VernacMemOption (_,_) -> (??)
-  | VernacPrintOption _ -> (??)
-  | VernacCheckMayEval (_,_,_) -> (??)
-  | VernacGlobalCheck _ -> (??)
-  | VernacDeclareReduction (_,_) -> (??)
-  | VernacPrint _ -> (??)
-  | VernacSearch (_,_,_) -> (??)
-  | VernacLocate _ -> (??)
-  | VernacRegister (_,_) -> (??)
-  | VernacComments _ -> (??)
-  | VernacStm _ -> (??)
-  | VernacAbort _ -> (??)
-  | VernacAbortAll  -> (??)
-  | VernacRestart  -> (??)
-  | VernacUndo _ -> (??)
-  | VernacUndoTo _ -> (??)
-  | VernacBacktrack (_,_,_) -> (??)
-  | VernacFocus _ -> (??)
-  | VernacUnfocus  -> (??)
-  | VernacUnfocused  -> (??)
-  | VernacBullet _ -> (??)
-  | VernacProgram _ -> (??)
-  | VernacSubproof _ -> (??)
-  | VernacEndSubproof  -> (??)
-  | VernacShow _ -> (??)
-  | VernacCheckGuard  -> (??)
-  | VernacProofMode _ -> (??)
-  | VernacToplevelControl _ -> (??)
-  | VernacExtend (_,_) -> (??)
-  | VernacPolymorphic (_,_) -> (??)
-  | VernacLocal (_,_) -> (??)
-*)
-
-let process_vernac ~mode pp ~doc st (CAst.{loc;v=vrn} as ast) =
-  let open Format in
-  let doc, n_st, tip = Stm.add ~doc ~ontop:st false ast in
-  if tip <> `NewTip then
-    (eprintf "Fatal Error, got no `NewTip`"; exit 1);
-  let open Sertop_arg in
-  let () = match mode with
-    | C_parse -> ()
-    | C_stats ->
-      do_stats ?loc vrn
-    | C_sexp ->
-      (* We don't print the file location for now *)
-      (* printf "@[%a@]@\n @[%a@]@\n%!" Pp.pp_with (Pp.pr_opt_no_spc Topfmt.pr_loc loc) *)
-      printf "@[%a@]@\n%!" pp (sexp_of_vernac_control vrn)
-  in
-  doc, n_st
-
 let parse_document ~mode pp ~doc sid in_pa =
   let stt = ref (doc, sid) in
   try while true do
       let east = Stm.parse_sentence ~doc:(fst !stt) (snd !stt) in_pa in
-      stt := process_vernac ~mode pp ~doc:(fst !stt) (snd !stt) east
+      stt := Complib.process_vernac ~mode ~pp ~doc:(fst !stt) ~st:(snd !stt) east
     done
   with any ->
     let (e, _info) = CErrors.push any in
@@ -198,13 +30,7 @@ let parse_document ~mode pp ~doc sid in_pa =
       let (e, info) = CErrors.push any in
       Format.eprintf "Error: %a@\n%!" Pp.pp_with (CErrors.iprint (e, info));
       exit 1
-
- (* Format.eprintf "Error in parsing@\n%!" (\* XXX: add loc *\) *)
-
-let close_document ~mode =
-  if mode = Sertop_arg.C_stats then
-    let open Format in
-    printf "Statistics:@\nSpecs:  %d@\nProofs: %d@\nMisc:   %d@\n%!" stats.specs stats.proofs stats.misc
+    (* Format.eprintf "Error in parsing@\n%!" (\* XXX: add loc *\) *)
 
 let sercomp mode debug printer async coq_path ml_path lp1 lp2 in_file omit_loc omit_att exn_on_opaque =
 
@@ -213,62 +39,33 @@ let sercomp mode debug printer async coq_path ml_path lp1 lp2 in_file omit_loc o
 
   let open Sertop_init in
 
+  (* coq initialization *)
+  coq_init {
+    (* XXXX *)
+    fb_handler   = (fun _ -> ());
+    ml_load      = None;
+    debug;
+  };
+
+  (* document initialization *)
+  let iload_path = Serapi_paths.coq_loadpath_default ~implicit:true ~coq_path @ ml_path @ lp1 @ lp2 in
+  let doc, sid = Complib.create_from_file ~in_file ~async ~iload_path in
+
+  (* main loop *)
+
+  (* let pp_opt  fb   = Sertop_util.feedback_opt_filter fb                in
+   * let pp_feed fb   = Option.iter (fun fb -> pp_answer (SP.Feedback fb)) (pp_opt fb) in *)
+
   let in_chan = open_in in_file                          in
   let in_strm = Stream.of_channel in_chan                in
   let in_pa   = Pcoq.Parsable.make ~file:(Loc.InFile in_file) in_strm in
   let pp_sexp = Sertop_ser.select_printer printer        in
 
-  let iload_path = coq_loadpath_default ~implicit:true ~coq_path @ ml_path @ lp1 @ lp2 in
-
-  (* let pp_opt  fb   = Sertop_util.feedback_opt_filter fb                in
-   * let pp_feed fb   = Option.iter (fun fb -> pp_answer (SP.Feedback fb)) (pp_opt fb) in *)
-
-  let doc,sid = coq_init {
-    (* XXXX *)
-    fb_handler   = (fun _ -> ());
-
-    aopts        = { enable_async = async;
-                     async_full   = false;
-                     deep_edits   = false;
-                   };
-    iload_path;
-    require_libs = ["Coq.Init.Prelude", None, Some true];
-    top_name     = "SerComp";
-    ml_load      = None;
-    debug;
-  } in
-
   parse_document ~mode pp_sexp ~doc sid in_pa;
   close_in in_chan;
-  close_document ~mode
+  Complib.close_document ~mode
 
-(* Command line processing *)
-let sercomp_version = Ser_version.ser_git_version
-
-open Cmdliner
-
-let input_file =
-  let doc = "Input .v file." in
-  Arg.(required & pos 0 (some string) None & info [] ~docv:"FILE.v" ~doc)
-
-let sertop_cmd =
-  let doc = "SerComp Coq Compiler" in
-  let man = [
-    `S "DESCRIPTION";
-    `P "Experimental Coq Compiler with serialization support. Currently it just prints some stats on the file."
-  ]
-  in
-  let open Sertop_arg in
-  Term.(const sercomp $ comp_mode $ debug $ printer $ async $ prelude $ ml_include_path $ load_path $ rload_path $ input_file $ omit_loc $ omit_att $ exn_on_opaque ),
-  Term.info "sercomp" ~version:sercomp_version ~doc ~man
-
-let main () =
-  try match Term.eval sertop_cmd with
-    | `Error _ -> exit 1
-    | _        -> exit 0
-  with any ->
-    let (e, info) = CErrors.push any in
-    Format.eprintf "Error: %a@\n%!" Pp.pp_with (CErrors.iprint (e, info));
-    exit 1
-
-let _ = main ()
+let _ =
+  Complib.maincomp ~ext:".v" ~name:"sercomp"
+    ~desc:"Experimental Coq Compiler with serialization support."
+    ~compfun:sercomp

--- a/sertop/sertop.ml
+++ b/sertop/sertop.ml
@@ -19,7 +19,7 @@
 open Cmdliner
 
 let sertop_version = Ser_version.ser_git_version
-let sertop printer print0 debug lheader coq_path ml_path lp1 lp2 std_impl async async_full deep_edits omit_loc omit_att exn_on_opaque =
+let sertop printer print0 debug lheader coq_path ml_path no_init lp1 lp2 std_impl async async_full deep_edits omit_loc omit_att exn_on_opaque =
 
   let open  Sertop_init         in
   let open! Sertop_sexp         in
@@ -38,6 +38,8 @@ let sertop printer print0 debug lheader coq_path ml_path lp1 lp2 std_impl async 
        lheader;
 
        coq_path;
+
+       no_init;
        loadpath;
        std_impl;
 
@@ -69,7 +71,7 @@ let sertop_cmd =
   ]
   in
   Term.(const sertop
-        $ printer $ print0 $ debug $ length $ prelude $ ml_include_path $ load_path $ rload_path $ implicit_stdlib
+        $ printer $ print0 $ debug $ length $ prelude $ ml_include_path $ no_init $ load_path $ rload_path $ implicit_stdlib
         $ async $ async_full $ deep_edits $ omit_loc $ omit_att $ exn_on_opaque ),
   Term.info "sertop" ~version:sertop_version ~doc ~man
 

--- a/sertop/sertop_arg.ml
+++ b/sertop/sertop_arg.ml
@@ -68,6 +68,12 @@ let length =
 
 (* We handle the conversion here *)
 
+let no_init =
+  let doc = "Omits the creation of a new document; this means the user \
+             will have to call `(NewDoc ...)` before Coq can be used \
+             and set there the proper loadpath, requires, ..." in
+  Arg.(value & flag & info ["no_init"] ~doc)
+
 let coq_lp_conv ~implicit (unix_path,lp) = Mltop.{
     path_spec = VoPath {
         coq_path  = Libnames.dirpath_of_string lp;
@@ -114,7 +120,11 @@ let exn_on_opaque : bool Term.t =
 (* sertop options *)
 type comp_mode = | C_parse | C_stats | C_sexp
 
-let comp_mode_args = Arg.(enum ["parse", C_parse; "stats", C_stats; "sexp", C_sexp])
+let comp_mode_args =
+  Arg.(enum
+         [ "parse", C_parse
+         ; "stats", C_stats
+         ; "sexp",  C_sexp])
 
 let comp_mode_doc = Arg.doc_alts
   [ "parse: parse the file and remain silent (except for Coq output)"
@@ -123,5 +133,5 @@ let comp_mode_doc = Arg.doc_alts
   ]
 
 let comp_mode =
-  Arg.(value & opt comp_mode_args C_stats & info ["mode"] ~doc:comp_mode_doc)
+  Arg.(value & opt comp_mode_args C_parse & info ["mode"] ~doc:comp_mode_doc)
 

--- a/sertop/sertop_arg.mli
+++ b/sertop/sertop_arg.mli
@@ -30,10 +30,11 @@ val length          : bool Term.t
 val rload_path      : Mltop.coq_path list Term.t
 val load_path       : Mltop.coq_path list Term.t
 val ml_include_path : Mltop.coq_path list Term.t
+val no_init         : bool Term.t
 
 (* sertop options *)
 type comp_mode = | C_parse | C_stats | C_sexp
-val  comp_mode : comp_mode Term.t
+val comp_mode : comp_mode Term.t
 
 (* debug options *)
 val omit_loc : bool Term.t

--- a/sertop/sertop_async.ml
+++ b/sertop/sertop_async.ml
@@ -34,22 +34,29 @@ let read_cmd cmd_sexp : [`Error of Sexp.t | `Ok of string * cmd ] =
 (* Initialize Coq. *)
 let sertop_init ~(fb_out : Sexp.t -> unit) ~iload_path ~require_libs ~debug =
   let open! Sertop_init in
+
   let fb_handler fb = Sertop_ser.sexp_of_answer (Feedback fb) |> fb_out in
-  let no_asyncf     = {
-    enable_async = None;
-    async_full   = false;
-    deep_edits   = false;
-  }                                                 in
-  let coq_opts = {
+
+  coq_init {
     fb_handler;
-    iload_path;
-    require_libs;
-    aopts        = no_asyncf;
-    top_name     = "SerTopJS";
-    ml_load      = None;
+    ml_load = None;
     debug;
-  } in
-  Sertop_init.coq_init coq_opts
+  };
+
+  let stm_options = process_stm_flags
+    { enable_async = None;
+      async_full   = false;
+      deep_edits   = false;
+    } in
+
+  let open Stm in
+  let doc_type = Interactive Names.(DirPath.make [Id.of_string "SerTopJS"]) in
+  let ndoc = { doc_type;
+               require_libs;
+               iload_path;
+               stm_options;
+               } in
+  new_doc ndoc
 
 let async_mut = Mutex.create ()
 

--- a/sertop/sertop_init.ml
+++ b/sertop/sertop_init.ml
@@ -27,31 +27,18 @@ type coq_opts = {
   (* callback to handle async feedback *)
   fb_handler   : Feedback.feedback -> unit;
 
-  (* Initial LoadPath XXX: Use the coq_pkg record? *)
-  iload_path   : Mltop.coq_path list;
-
-  (* Libs to require in STM init *)
-  require_libs : (string * string option * bool option) list;
-
-  (* Async flags *)
-  aopts        : async_flags;
-
-  (* name of the top-level module *)
-  top_name     : string;
-
   (* callback to load cma/cmo files *)
   ml_load      : (string -> unit) option;
 
   (* Enable Coq Debug mode *)
   debug        : bool;
+
 }
 
 (**************************************************************************)
 (* Low-level, internal Coq initialization                                 *)
 (**************************************************************************)
 let coq_init opts =
-
-  let open Names in
 
   if opts.debug then begin
     Printexc.record_backtrace true;
@@ -79,87 +66,54 @@ let coq_init opts =
   (* Feedback setup                                                         *)
   (**************************************************************************)
 
-  (* Whether to forward Glob output to the IDE. *)
-  let dumpglob = false in
-  let dump_opt =
-    if dumpglob then begin
-      Dumpglob.feedback_glob ();
-      "-feedback-glob"
-    end else begin
-      Dumpglob.noglob ();
-      "-no-glob"
-    end
-  in
-
   (* Initialize logging. *)
   ignore (Feedback.add_feeder opts.fb_handler);
-
-  (**************************************************************************)
-  (* Async setup                                                            *)
-  (**************************************************************************)
-
-  (* Set async flags; IMPORTANT, this has to happen before STM.init () ! *)
-  let stm_options = Option.cata (fun coqtop ->
-
-      let open Stm.AsyncOpts in
-      let opts =
-        { default_opts with
-          async_proofs_mode = APon;
-          (* Imitate CoqIDE *)
-          async_proofs_full = opts.aopts.async_full;
-          async_proofs_never_reopen_branch = not opts.aopts.deep_edits;
-          async_proofs_n_workers    = 3;
-          async_proofs_n_tacworkers = 3;
-        } in
-      (* async_proofs_worker_priority); *)
-      AsyncTaskQueue.async_proofs_flags_for_workers := [dump_opt];
-      CoqworkmgrApi.(init High);
-      (* Uh! XXXX *)
-      for i = 0 to Array.length Sys.argv - 1 do
-        Array.set Sys.argv i "-m"
-      done;
-      Array.set Sys.argv 0 coqtop;
-      opts
-    ) Stm.AsyncOpts.default_opts opts.aopts.enable_async in
 
   (**************************************************************************)
   (* Start the STM!!                                                        *)
   (**************************************************************************)
   Stm.init_core ();
 
-  (* Flags.debug := true; *)
-
-  (* We need to declare a toplevel module name. *)
-  let sertop_dp = DirPath.make [Id.of_string opts.top_name] in
-
-  (* Return the initial state of the STM *)
-  let ndoc = { Stm.doc_type = Stm.Interactive sertop_dp;
-               require_libs = opts.require_libs;
-               iload_path   = opts.iload_path;
-               stm_options;
-             } in
-  Stm.new_doc ndoc
+  (* End of initialization *)
+  ()
 
 (******************************************************************************)
-(* Coq Prelude Loading Defaults (to be improved)                              *)
+(* Async setup                                                                *)
 (******************************************************************************)
 
-let coq_loadpath_default ~implicit ~coq_path =
-  let open Mltop in
-  let mk_path prefix = coq_path ^ "/" ^ prefix in
-  let mk_lp ~ml ~root ~dir ~implicit =
-    { recursive = true;
-      path_spec = VoPath {
-          unix_path = mk_path dir;
-          coq_path  = root;
-          has_ml    = ml;
-          implicit;
-        };
-    } in
-  (* in 8.8 we can use Libnames.default_* *)
-  let coq_root     = Names.(DirPath.make [Id.of_string "Coq"]) in
-  let default_root = Names.(DirPath.empty) in
-  [mk_lp ~ml:AddRecML ~root:coq_root     ~implicit       ~dir:"plugins";
-   mk_lp ~ml:AddNoML  ~root:coq_root     ~implicit       ~dir:"theories";
-   mk_lp ~ml:AddRecML ~root:default_root ~implicit:false ~dir:"user-contrib";
-  ]
+(* Set async flags; IMPORTANT, this has to happen before STM.init () ! *)
+let process_stm_flags opts = Option.cata (fun coqtop ->
+
+    (* Whether to forward Glob output to the IDE. *)
+    let dumpglob = false in
+
+    let dump_opt =
+      if dumpglob then begin
+        Dumpglob.feedback_glob ();
+        "-feedback-glob"
+      end else begin
+        Dumpglob.noglob ();
+        "-no-glob"
+      end
+    in
+
+    let open Stm.AsyncOpts in
+    let opts =
+      { default_opts with
+        async_proofs_mode = APon;
+        (* Imitate CoqIDE *)
+        async_proofs_full = opts.async_full;
+        async_proofs_never_reopen_branch = not opts.deep_edits;
+        async_proofs_n_workers    = 3;
+        async_proofs_n_tacworkers = 3;
+      } in
+    (* async_proofs_worker_priority); *)
+    AsyncTaskQueue.async_proofs_flags_for_workers := [dump_opt];
+    CoqworkmgrApi.(init High);
+    (* Uh! XXXX *)
+    for i = 0 to Array.length Sys.argv - 1 do
+      Array.set Sys.argv i "-m"
+    done;
+    Array.set Sys.argv 0 coqtop;
+    opts
+  ) Stm.AsyncOpts.default_opts opts.enable_async

--- a/sertop/sertop_ser.ml
+++ b/sertop/sertop_ser.ml
@@ -100,6 +100,7 @@ module Tok        = Ser_tok
 module Ppextend   = Ser_ppextend
 module Notation_gram = Ser_notation_gram
 module Genarg     = Ser_genarg
+module Mltop      = Ser_mltop
 
 (* Alias fails due to the [@@default in protocol] *)
 (* module Stm        = Ser_stm *)
@@ -210,6 +211,14 @@ type answer =
 type add_opts =
   [%import: Serapi_protocol.add_opts
   [@with
+     Sexplib.Conv.sexp_option := sexp_option;
+  ]]
+  [@@deriving sexp]
+
+type newdoc_opts =
+  [%import: Serapi_protocol.newdoc_opts
+  [@with
+     Sexplib.Conv.sexp_list   := sexp_list;
      Sexplib.Conv.sexp_option := sexp_option;
   ]]
   [@@deriving sexp]

--- a/sertop/sertop_sexp.mli
+++ b/sertop/sertop_sexp.mli
@@ -22,7 +22,7 @@
 
 type ser_opts = {
   (* Input output Options *)
-  in_chan  : in_channel;        (* Input/Output channels                                *)
+  in_chan  : in_channel;        (* Input/Output channels                      *)
   out_chan : out_channel;
                                 (* Printers                                   *)
   printer  : Sertop_ser.ser_printer;
@@ -32,7 +32,8 @@ type ser_opts = {
   lheader  : bool;              (* Print lenght header (deprecated)           *)
 
   (* Coq options *)
-  coq_path : string;            (* Coq standard library location *)
+  no_init  : bool;              (* Whether to create the initial document     *)
+  coq_path : string;            (* Coq standard library location              *)
   std_impl : bool;              (* Whether the standard library should be loaded with implicit paths *)
                                 (* -R and -Q options                          *)
   loadpath : Mltop.coq_path list; (* From -R and -Q options usually *)


### PR DESCRIPTION
The protocol now supports a method:
```lisp
(NewDoc ((top_name "Module")
         (iload_path (path_1 ... path_n)
         (require_libs (require_1 ... require_n))))
```
where `path_i` is of type
```ocaml
Mltop.coq_path = {
  path_spec: coq_path_spec;
  recursive: bool;
}

type coq_path_spec =
  | VoPath of vo_path_spec
  | MlPath of string

type vo_path_spec = {
  unix_path : string;
  coq_path  : Names.DirPath.t;
  implicit  : bool;
  has_ml    : add_ml;
}
```
and `require_i` is of type:
```ocaml
string * string option * bool option
```
where `(module, root, import)` corresponds to `From root Require import module`

`iload_path` and `require_libs` are optional, if absent, SerAPI will
resort to the defaults.

By default, invoking `sertop` will create a document with the standard
paths and `Prelude` loaded. To avoid that, use the commit line option
`--no_init`.

**Important** in practice the user still can only use
this option to create one single document using `NewDoc`, as the
protocol doesn't yet include per-document addressing.

This PR improves a certain number of things, including `compser` and
`sercomp` will now create documents with the proper module path cc: #84.

This also improves #49 and #59.
