### PR TITLE
Test for Functional Scheme and rename tactic

### DIFF
--- a/tests/genarg/dune
+++ b/tests/genarg/dune
@@ -39,10 +39,22 @@
  (deps (:input fix.v))
  (action (ignore-stdout (run sercomp --exn_on_opaque %{input}))))
 
+; Broken
+; (alias
+; (name runtest)
+; (deps (:input functional_scheme.v))
+; (action (ignore-stdout (run sercomp --exn_on_opaque %{input}))))
+
 (alias
  (name runtest)
  (deps (:input intros.v))
  (action (ignore-stdout (run sercomp --exn_on_opaque %{input}))))
+
+; Broken
+; (alias
+; (name runtest)
+; (deps (:input rename.v))
+; (action (ignore-stdout (run sercomp --exn_on_opaque %{input}))))
 
 (alias
  (name runtest)

--- a/tests/genarg/functional_scheme.v
+++ b/tests/genarg/functional_scheme.v
@@ -1,0 +1,22 @@
+Require Import FunInd.
+Require Import ZArith.
+
+Inductive Qpositive : Set :=
+  | nR : Qpositive -> Qpositive
+  | dL : Qpositive -> Qpositive
+  | One : Qpositive.
+
+Fixpoint Qpositive_c (p q n : nat) {struct n} : Qpositive :=
+  match n with
+  | O => One
+  | S n' =>
+      match p - q with
+      | O => match q - p with
+             | O => One
+             | v => dL (Qpositive_c p v n')
+             end
+      | v => nR (Qpositive_c v q n')
+      end
+  end.
+
+Functional Scheme Qpositive_c_ind := Induction for Qpositive_c Sort Prop.

--- a/tests/genarg/rename.v
+++ b/tests/genarg/rename.v
@@ -1,0 +1,10 @@
+Require Import ZArith.
+
+Open Scope Z_scope.
+
+Lemma Zplus0 : forall n, n + 0 = n.
+Proof.
+intros n.
+rename n into m.
+auto with zarith.
+Qed.


### PR DESCRIPTION
I found two more more problems with `sercomp`: `Functional Scheme` (from the `FunInd` module) and the `rename` tactic.

Dune tests are added but commented out for now.