### PR TITLE
[serlib] add test for Hint Rewrite

### DIFF
--- a/tests/genarg/dune
+++ b/tests/genarg/dune
@@ -44,6 +44,12 @@
 (deps (:input functional_scheme.v))
 (action (ignore-stdout (run sercomp --exn_on_opaque %{input}))))
 
+; Broken
+; (alias
+; (name runtest)
+; (deps (:input hint_rewrite.v))
+; (action (ignore-stdout (run sercomp --exn_on_opaque %{input}))))
+
 (alias
  (name runtest)
  (deps (:input intros.v))

--- a/tests/genarg/hint_rewrite.v
+++ b/tests/genarg/hint_rewrite.v
@@ -1,0 +1,24 @@
+Set Implicit Arguments.
+
+Section Definitions.
+Variables (A : Type).
+Implicit Types f g : A -> A -> A.
+Implicit Types i : A -> A.
+
+Definition involutive i := forall x,
+  i (i x) = x.
+End Definitions.
+
+Definition neg (x:bool) : bool :=
+  match x with
+  | true => false
+  | false => true
+  end.
+
+Lemma neg_neg : involutive neg.
+Proof.
+intros x.
+destruct x; auto.
+Qed.
+
+Hint Rewrite neg_neg : rew_neg_neg.


### PR DESCRIPTION
I get errors when serializing occurrences of `Hint Rewrite`. Here is a test for that in the conventional way.