### PR TITLE
[serlib] test for Add Field

### DIFF
--- a/tests/genarg/add_field.v
+++ b/tests/genarg/add_field.v
@@ -1,0 +1,7 @@
+Require Import Qfield.
+
+Add Field Qfield : Qsft
+ (decidable Qeq_bool_eq,
+  completeness Qeq_eq_bool,
+  constants [Qcst],
+  power_tac Qpower_theory [Qpow_tac]).

--- a/tests/genarg/dune
+++ b/tests/genarg/dune
@@ -1,3 +1,9 @@
+; Broken
+; (alias
+;  (name runtest)
+;  (deps (:input add_field.v))
+;  (action (ignore-stdout (run sercomp --exn_on_opaque %{input}))))
+
 (alias
  (name runtest)
  (deps (:input auto.v))


### PR DESCRIPTION
Here is a test for the `Add Field` command, which gives errors related to `field_mods` arguments.