### PR TITLE
[serlib] compser tool with failed deserialization example

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,7 @@ _Version 0.6.0_:
             https://github.com/proofengineering/serapi-tests, thanks to
             @palmskog,
  * [sercomp] add `--mode` option to better control output,
+ * [sercomp] add `compser` for deserialization (inverse of `sercomp`)
 
 _Version 0.5.7_:
 

--- a/sertop/compser.ml
+++ b/sertop/compser.ml
@@ -1,0 +1,100 @@
+(************************************************************************)
+(*         *   The Coq Proof Assistant / The Coq Development Team       *)
+(*  v      *   INRIA, CNRS and contributors - Copyright 1999-2018       *)
+(* <O___,, *       (see CREDITS file for the list of authors)           *)
+(*   \VV/  **************************************************************)
+(*    //   *    This file is distributed under the terms of the         *)
+(*         *     GNU Lesser General Public License Version 2.1          *)
+(*         *     (see LICENSE file for the text of the license)         *)
+(************************************************************************)
+
+open Ser_vernacexpr
+open Sexplib
+
+let process_vernac ~mode pp ~doc st (CAst.{loc;v=vrn} as ast) =
+  let open Format in
+  let doc, n_st, tip = Stm.add ~doc ~ontop:st false ast in
+  if tip <> `NewTip then
+    (eprintf "Fatal Error, got no `NewTip`"; exit 1);
+  let open Sertop_arg in
+  let () = match mode with
+    | C_parse -> ()
+    | C_stats -> ()
+    | C_sexp ->
+      printf "@[%a@]@\n @[%a@]@\n%!" Pp.pp_with (Pp.pr_opt Topfmt.pr_loc loc)
+        pp (sexp_of_vernac_control vrn);
+  in
+  doc, n_st
+
+let compser mode debug printer async coq_path ml_path lp1 lp2 in_file omit_loc omit_att exn_on_opaque =
+
+  (* serlib initialization *)
+  Serlib_init.init ~omit_loc ~omit_att ~exn_on_opaque;
+
+  let open Sertop_init in
+
+  let in_chan = open_in in_file                          in
+  let pp_sexp = Sertop_ser.select_printer printer        in
+
+  let iload_path = coq_loadpath_default ~implicit:true ~coq_path @ ml_path @ lp1 @ lp2 in
+
+  let doc,sid = coq_init {
+    fb_handler   = (fun _ -> ());
+
+    aopts        = { enable_async = async;
+                     async_full   = false;
+                     deep_edits   = false;
+                   };
+    iload_path;
+    require_libs = ["Coq.Init.Prelude", None, Some true];
+    top_name     = "CompSer";
+    ml_load      = None;
+    debug;
+  } in
+
+  let stt = ref (doc, sid) in
+
+  try
+    while true; do
+      let line = input_line in_chan in
+      if String.trim line <> "" then begin
+        let vs = Sexp.of_string line in
+        let vrn = vernac_control_of_sexp vs in
+        let ast = CAst.make vrn in
+        stt := process_vernac ~mode pp_sexp ~doc:(fst !stt) (snd !stt) ast
+      end
+    done
+  with End_of_file ->
+    let _ = Stm.finish ~doc:(fst !stt) in
+    close_in in_chan
+
+(* Command line processing *)
+let compser_version = Ser_version.ser_git_version
+
+open Cmdliner
+
+let input_file =
+  let doc = "Input sexp file." in
+  Arg.(required & pos 0 (some string) None & info [] ~docv:"FILE.sexp" ~doc)
+
+let sertop_cmd =
+  let doc = "CompSer Coq Compiler" in
+  let man = [
+    `S "DESCRIPTION";
+    `P "Experimental Sexp Coq Compiler."
+  ]
+  in
+  let open Sertop_arg in
+  Term.(const compser $ comp_mode $ debug $ printer $ async $ prelude $ ml_include_path $ load_path $ rload_path $ input_file $ omit_loc $ omit_att $ exn_on_opaque ),
+  Term.info "compser" ~version:compser_version ~doc ~man
+
+let main () =
+  try match Term.eval sertop_cmd with
+    | `Error _ -> exit 1
+    | _        -> exit 0
+  with any ->
+    let (e, info) = CErrors.push any in
+    Format.eprintf "Error: %a@\n%!" Pp.pp_with (CErrors.iprint (e, info));
+    exit 1
+
+let _ = main ()

--- a/sertop/dune
+++ b/sertop/dune
@@ -1,13 +1,13 @@
 (library
  (name sertoplib)
- (modules :standard \ sertop sercomp sertop_js sertop_async)
+ (modules :standard \ sertop sercomp compser sertop_js sertop_async)
  (wrapped false)
  (preprocess (staged_pps ppx_import ppx_sexp_conv))
  (libraries cmdliner serapi serlib_ssr serlib_firstorder serlib_funind serlib_setoid_ring))
 
 (executables
- (public_names sertop sercomp)
- (modules sertop sercomp)
+ (public_names sertop sercomp compser)
+ (modules sertop sercomp compser)
  (link_flags -linkall)
  (libraries sertoplib))
 

--- a/tests/genarg/dune
+++ b/tests/genarg/dune
@@ -98,3 +98,8 @@
  (name runtest)
  (deps (:input symmetry.v))
  (action (ignore-stdout (run sercomp --exn_on_opaque %{input}))))
+
+(alias
+ (name runtest)
+ (deps (:input tactic_notation.v))
+ (action (ignore-stdout (run sercomp --exn_on_opaque %{input}))))

--- a/tests/genarg/tactic_notation.v
+++ b/tests/genarg/tactic_notation.v
@@ -1,0 +1,30 @@
+Require ZArith.BinInt.
+
+Definition ltac_int_to_nat (x:BinInt.Z) : nat :=
+  match x with
+  | BinInt.Z0 => 0%nat
+  | BinInt.Zpos p => BinPos.nat_of_P p
+  | BinInt.Zneg p => 0%nat
+  end.
+
+Ltac number_to_nat N :=
+  match type of N with
+  | nat => constr:(N)
+  | BinInt.Z => let N' := constr:(ltac_int_to_nat N) in eval compute in N'
+  end.
+
+Lemma dup_lemma : forall P, P -> P -> P.
+Proof using. auto. Qed.
+
+Ltac dup_tactic N :=
+  match number_to_nat N with
+  | 0 => idtac
+  | S 0 => idtac
+  | S ?N' => apply dup_lemma; [ | dup_tactic N' ]
+  end.
+
+Tactic Notation "dup" constr(N) :=
+  dup_tactic N.
+
+Tactic Notation "dup" :=
+  dup 2.


### PR DESCRIPTION
Here is a PR that's not necessarily meant to be merged. The primary purpose is to demonstrate the deserialization `Anomaly` errors we are getting in some projects (currently: TLC, stdpp, Binary Rational Numbers).

This branch rebases the current `v8.9` on the `v8.9+sercomp_mode` branch to get the `sercomp` updates. I then added a deserialization program `compser` based on this `sercomp`.

Here is how to reproduce the error from the smallest example I could construct.
```shell
$ sercomp --mode=sexp tests/genarg/tactic_notation.v > tactic_notation.sexp
$ compser --mode=sexp tactic_notation.sexp
```

The output is a bunch of sexps and then the following:
```
compser: internal error, uncaught exception:
         "Anomaly: Unknown tactic alias: SerComp.dup_#_2C9A39DD."
```
Note that this is when parsing the sexp resulting from the last line in `tests/genarg/tactic_notation.v`.