### PR TITLE
[sertop] Set Coq module name correctly from module file.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,7 @@ _Version 0.6.0_:
             @palmskog,
  * [sercomp] add `--mode` option to better control output,
  * [sercomp] add `compser` for deserialization (inverse of `sercomp`)
+             (@palmskog),
  * [serapi]  Allow custom document creation using the `NewDoc` call.
              Use the `--no_init` option to avoid automatic creation
              on init. (@ejgallego)

--- a/sertop/sertop_sexp.ml
+++ b/sertop/sertop_sexp.ml
@@ -120,11 +120,13 @@ let ser_loop ser_opts =
   let coq_path = ser_opts.coq_path in
 
   (* Init Coq *)
-  let _ = Sertop_init.coq_init {
-    Sertop_init.fb_handler   = pp_feed;
-    Sertop_init.ml_load      = None;
-    Sertop_init.debug        = ser_opts.debug;
-  } in
+  let _ = Sertop_init.(
+      coq_init
+        { fb_handler   = pp_feed
+        ; ml_load      = None
+        ; debug        = ser_opts.debug
+        })
+  in
 
   (* Follow the same approach than coqtop for now: allow Coq to be
    * interrupted by Ctrl-C. Not entirely safe or race free... but we

--- a/tests/genarg/dune
+++ b/tests/genarg/dune
@@ -1,105 +1,148 @@
+; Eventually we should use the "put binaries in scope feature of Dune"
 (alias
  (name runtest)
- (deps (:input add_field.v))
- (action (ignore-stdout (run sercomp --exn_on_opaque %{input}))))
+ (deps (:input add_field.v)
+   ../../sertop/sercomp.exe
+   ../../sertop/compser.exe)
+ (action (run ./test_roundtrip %{input})))
 
 (alias
  (name runtest)
- (deps (:input auto.v))
- (action (ignore-stdout (run sercomp --exn_on_opaque %{input}))))
+ (deps (:input auto.v)
+   ../../sertop/sercomp.exe
+   ../../sertop/compser.exe)
+ (action (run ./test_roundtrip %{input})))
 
 (alias
  (name runtest)
- (deps (:input clear.v))
- (action (ignore-stdout (run sercomp --exn_on_opaque %{input}))))
+ (deps (:input clear.v)
+   ../../sertop/sercomp.exe
+   ../../sertop/compser.exe)
+ (action (run ./test_roundtrip %{input})))
 
 (alias
  (name runtest)
- (deps (:input eauto.v))
- (action (ignore-stdout (run sercomp --exn_on_opaque %{input}))))
+ (deps (:input eauto.v)
+   ../../sertop/sercomp.exe
+   ../../sertop/compser.exe)
+ (action (run ./test_roundtrip %{input})))
 
 ; Broken
 ; (alias
 ;  (name runtest)
-;  (deps (:input elim.v))
-;  (action (ignore-stdout (run sercomp --exn_on_opaque --debug %{input}))))
+;  (deps (:input elim.v)
+;    ../../sertop/sercomp.exe
+;    ../../sertop/compser.exe)
+;  (action (run ./test_roundtrip %{input})))
 
 (alias
  (name runtest)
- (deps (:input exact.v))
+ (deps (:input exact.v)
+   ../../sertop/sercomp.exe
+   ../../sertop/compser.exe)
+ (action (run ./test_roundtrip %{input})))
+
+(alias
+ (name runtest)
+ (deps (:input exists.v)
+   ../../sertop/sercomp.exe
+   ../../sertop/compser.exe)
+ (action (run ./test_roundtrip %{input})))
+
+(alias
+ (name runtest)
+ (deps (:input firstorder.v)
+   ../../sertop/sercomp.exe
+   ../../sertop/compser.exe)
+ (action (run ./test_roundtrip %{input})))
+
+(alias
+ (name runtest)
+ (deps (:input fix.v)
+   ../../sertop/sercomp.exe
+   ../../sertop/compser.exe)
+ (action (run ./test_roundtrip %{input})))
+
+(alias
+ (name runtest)
+ (deps (:input functional_scheme.v)
+   ../../sertop/sercomp.exe
+   ../../sertop/compser.exe)
+ (action (run ./test_roundtrip %{input})))
+
+(alias
+ (name runtest)
+ (deps (:input hint_rewrite.v)
+   ../../sertop/sercomp.exe
+   ../../sertop/compser.exe)
  (action (ignore-stdout (run sercomp --exn_on_opaque %{input}))))
 
 (alias
  (name runtest)
- (deps (:input exists.v))
- (action (ignore-stdout (run sercomp --exn_on_opaque %{input}))))
+ (deps (:input intropattern.v)
+   ../../sertop/sercomp.exe
+   ../../sertop/compser.exe)
+ (action (run ./test_roundtrip %{input})))
 
 (alias
  (name runtest)
- (deps (:input firstorder.v))
- (action (ignore-stdout (run sercomp --exn_on_opaque %{input}))))
+ (deps (:input intros.v)
+   ../../sertop/sercomp.exe
+   ../../sertop/compser.exe)
+ (action (run ./test_roundtrip %{input})))
 
 (alias
  (name runtest)
- (deps (:input fix.v))
- (action (ignore-stdout (run sercomp --exn_on_opaque %{input}))))
+ (deps (:input libTactics.v)
+   ../../sertop/sercomp.exe
+   ../../sertop/compser.exe)
+ (action (run ./test_roundtrip %{input})))
 
 (alias
  (name runtest)
- (deps (:input functional_scheme.v))
- (action (ignore-stdout (run sercomp --exn_on_opaque %{input}))))
-
-(alias
-(name runtest)
-(deps (:input hint_rewrite.v))
-(action (ignore-stdout (run sercomp --exn_on_opaque %{input}))))
+ (deps (:input rename.v)
+   ../../sertop/sercomp.exe
+   ../../sertop/compser.exe)
+ (action (run ./test_roundtrip %{input})))
 
 (alias
  (name runtest)
- (deps (:input intropattern.v))
- (action (ignore-stdout (run sercomp --exn_on_opaque %{input}))))
+ (deps (:input replace.v)
+   ../../sertop/sercomp.exe
+   ../../sertop/compser.exe)
+ (action (run ./test_roundtrip %{input})))
 
 (alias
  (name runtest)
- (deps (:input intros.v))
- (action (ignore-stdout (run sercomp --exn_on_opaque %{input}))))
+ (deps (:input revert.v)
+   ../../sertop/sercomp.exe
+   ../../sertop/compser.exe)
+ (action (run ./test_roundtrip %{input})))
 
 (alias
  (name runtest)
- (deps (:input libTactics.v))
- (action (ignore-stdout (run sercomp --exn_on_opaque %{input}))))
+ (deps (:input specialize.v)
+   ../../sertop/sercomp.exe
+   ../../sertop/compser.exe)
+ (action (run ./test_roundtrip %{input})))
 
 (alias
  (name runtest)
- (deps (:input rename.v))
- (action (ignore-stdout (run sercomp --exn_on_opaque %{input}))))
+ (deps (:input subst.v)
+   ../../sertop/sercomp.exe
+   ../../sertop/compser.exe)
+ (action (run ./test_roundtrip %{input})))
 
 (alias
  (name runtest)
- (deps (:input replace.v))
- (action (ignore-stdout (run sercomp --exn_on_opaque %{input}))))
+ (deps (:input symmetry.v)
+   ../../sertop/sercomp.exe
+   ../../sertop/compser.exe)
+ (action (run ./test_roundtrip %{input})))
 
 (alias
  (name runtest)
- (deps (:input revert.v))
- (action (ignore-stdout (run sercomp --exn_on_opaque %{input}))))
-
-(alias
- (name runtest)
- (deps (:input specialize.v))
- (action (ignore-stdout (run sercomp --exn_on_opaque %{input}))))
-
-(alias
- (name runtest)
- (deps (:input subst.v))
- (action (ignore-stdout (run sercomp --exn_on_opaque %{input}))))
-
-(alias
- (name runtest)
- (deps (:input symmetry.v))
- (action (ignore-stdout (run sercomp --exn_on_opaque %{input}))))
-
-(alias
- (name runtest)
- (deps (:input tactic_notation.v))
- (action (ignore-stdout (run sercomp --exn_on_opaque %{input}))))
+ (deps (:input tactic_notation.v)
+   ../../sertop/sercomp.exe
+   ../../sertop/compser.exe)
+ (action (run ./test_roundtrip %{input})))

--- a/tests/genarg/test_roundtrip
+++ b/tests/genarg/test_roundtrip
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+COMPSER=../../sertop/compser.exe
+SERCOMP=../../sertop/sercomp.exe
+FILE_IN="$1"
+FILE_OUT="${FILE_IN%.v}.sexp"
+
+$SERCOMP --mode=sexp --exn_on_opaque "$FILE_IN" > "$FILE_OUT"
+$COMPSER "$FILE_OUT"


### PR DESCRIPTION
Following #69, which fixed the round trip for the batch compiler cases, we modify the test cases so we test the full serialization / deserialization roundtrip.