### PR TITLE
[sertop] Add `--mode=vo` option that will output a `.vo` file.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,8 @@ _Version 0.6.0_:
  * [serapi]  Allow custom document creation using the `NewDoc` call.
              Use the `--no_init` option to avoid automatic creation
              on init. (@ejgallego)
+ * [sercomp] Allow compilers to output `.vo` (@ejgallego , suggested by
+             @palmskog)
 
 _Version 0.5.7_:
 

--- a/sertop/complib.mli
+++ b/sertop/complib.mli
@@ -33,7 +33,11 @@ val process_vernac
   -> Vernacexpr.vernac_control CAst.t
   -> Stm.doc * Stateid.t
 
-val close_document : mode:comp_mode -> unit
+val close_document
+  :  mode:comp_mode
+  -> doc:Stm.doc
+  -> out_vo:string
+  -> unit
 
 type compfun
   =  comp_mode

--- a/sertop/compser.ml
+++ b/sertop/compser.ml
@@ -34,7 +34,7 @@ let compser mode debug printer async coq_path ml_path lp1 lp2 in_file omit_loc o
   let pp_sexp = Sertop_ser.select_printer printer        in
 
   let stt = ref (doc, sid) in
-  try
+  let () = try
     while true; do
       let line = input_line in_chan in
       if String.trim line <> "" then begin
@@ -44,9 +44,11 @@ let compser mode debug printer async coq_path ml_path lp1 lp2 in_file omit_loc o
         stt := Complib.process_vernac ~mode ~pp:pp_sexp ~doc:(fst !stt) ~st:(snd !stt) ast
       end
     done
-  with End_of_file ->
-    let _ = Stm.finish ~doc:(fst !stt) in
-    close_in in_chan
+  with End_of_file -> ()
+  in
+  let doc = fst !stt in
+  let out_vo = Filename.(remove_extension in_file) ^ ".vo" in
+  Complib.close_document ~doc ~mode ~out_vo
 
 let _ =
   Complib.maincomp ~ext:".sexp" ~name:"compser"

--- a/sertop/sercomp.ml
+++ b/sertop/sercomp.ml
@@ -21,13 +21,14 @@ let parse_document ~mode pp ~doc sid in_pa =
   try while true do
       let east = Stm.parse_sentence ~doc:(fst !stt) (snd !stt) in_pa in
       stt := Complib.process_vernac ~mode ~pp ~doc:(fst !stt) ~st:(snd !stt) east
-    done
+    done;
+    fst !stt
   with any ->
     let (e, _info) = CErrors.push any in
     match e with
-    | Stm.End_of_input -> ()
+    | Stm.End_of_input ->
+      fst !stt
     | any          ->
-      let (e, info) = CErrors.push any in
       Format.eprintf "Error: %a@\n%!" Pp.pp_with (CErrors.iprint (e, info));
       exit 1
     (* Format.eprintf "Error in parsing@\n%!" (\* XXX: add loc *\) *)
@@ -61,9 +62,10 @@ let sercomp mode debug printer async coq_path ml_path lp1 lp2 in_file omit_loc o
   let in_pa   = Pcoq.Parsable.make ~file:(Loc.InFile in_file) in_strm in
   let pp_sexp = Sertop_ser.select_printer printer        in
 
-  parse_document ~mode pp_sexp ~doc sid in_pa;
+  let doc = parse_document ~mode pp_sexp ~doc sid in_pa in
   close_in in_chan;
-  Complib.close_document ~mode
+  let out_vo = Filename.(remove_extension in_file) ^ ".vo" in
+  Complib.close_document ~doc ~mode ~out_vo
 
 let _ =
   Complib.maincomp ~ext:".v" ~name:"sercomp"

--- a/sertop/sertop_arg.ml
+++ b/sertop/sertop_arg.ml
@@ -118,18 +118,20 @@ let exn_on_opaque : bool Term.t =
   Arg.(value & flag & info ["exn_on_opaque"] ~doc)
 
 (* sertop options *)
-type comp_mode = | C_parse | C_stats | C_sexp
+type comp_mode = | C_parse | C_stats | C_sexp | C_vo
 
 let comp_mode_args =
   Arg.(enum
          [ "parse", C_parse
          ; "stats", C_stats
-         ; "sexp",  C_sexp])
+         ; "sexp",  C_sexp
+         ; "vo",    C_vo])
 
 let comp_mode_doc = Arg.doc_alts
   [ "parse: parse the file and remain silent (except for Coq output)"
   ; "stats: output stats on the input file"
   ;  "sexp: output serialized version of the input file"
+  ;    "vo: output .vo version of the input file"
   ]
 
 let comp_mode =

--- a/sertop/sertop_arg.mli
+++ b/sertop/sertop_arg.mli
@@ -33,7 +33,7 @@ val ml_include_path : Mltop.coq_path list Term.t
 val no_init         : bool Term.t
 
 (* sertop options *)
-type comp_mode = | C_parse | C_stats | C_sexp
+type comp_mode = | C_parse | C_stats | C_sexp | C_vo
 val comp_mode : comp_mode Term.t
 
 (* debug options *)

--- a/tests/genarg/dune
+++ b/tests/genarg/dune
@@ -4,7 +4,13 @@
  (deps (:input test_roundtrip.in)
    ../../sertop/sercomp.exe
    ../../sertop/compser.exe)
- (action (copy test_roundtrip.in test_roundtrip)))
+ (action
+  (progn
+   (copy test_roundtrip.in test_roundtrip)
+   ; We insert the digest of the binaries to force a rebuild of the
+   ; test cases if the binaries have been modified.
+   (bash "echo \"# $(md5sum ../../sertop/compser.exe)\" >> test_roundtrip")
+   (bash "echo \"# $(md5sum ../../sertop/sercomp.exe)\" >> test_roundtrip"))))
 
 (alias
  (name runtest)


### PR DESCRIPTION
This way we can do `.sexp -> .vo`.
