### PR TITLE
[test] Add test for instantiate tactic

### DIFF
--- a/tests/genarg/dune
+++ b/tests/genarg/dune
@@ -62,6 +62,12 @@
  (deps (:input hint_rewrite.v))
  (action (run ./test_roundtrip %{input})))
 
+; Broken
+; (alias
+;  (name runtest)
+;  (deps (:input instantiate.v))
+;  (action (run ./test_roundtrip %{input})))
+
 (alias
  (name runtest)
  (deps (:input intropattern.v))

--- a/tests/genarg/instantiate.v
+++ b/tests/genarg/instantiate.v
@@ -1,0 +1,20 @@
+Set Implicit Arguments.
+
+Require Import List.
+
+Section Filter.
+
+Variable A : Type.
+
+Lemma In_filter_In :
+  forall (f : A -> bool) x l l',
+    filter f l = l' ->
+    In x l' -> In x l.
+Proof.
+  intros. subst.
+  eapply filter_In.
+  instantiate (1 := f).
+  assumption.
+Qed.
+
+End Filter.


### PR DESCRIPTION
Yet another missing tactic argument witness bug, it seems. This time for the `instantiate` tactic.

Another thing I noticed while investigating this is that `sercomp` does not propagate exceptions to the shell level unless one uses `--mode=sexp`. For example, the following does not raise any exception:
```shell
$ sercomp.exe --exn_on_opaque tests/genarg/instantiate.v
$ echo $?
0
```
On the other hand:
```shell
$ sercomp.exe --mode=sexp --exn_on_opaque tests/genarg/instantiate.v
...
Error: Serlib Error: [raw: (ExtraArg lglob): ABSTRACT]
$ echo $?
1
```