### PR TITLE
[test] Add test for setoid_rewrite tactic

### DIFF
--- a/tests/genarg/dune
+++ b/tests/genarg/dune
@@ -108,6 +108,12 @@
  (deps (:input revert.v))
  (action (run ./test_roundtrip %{input})))
 
+; Broken
+; (alias
+;  (name runtest)
+;  (deps (:input setoid_rewrite.v))
+;  (action (run ./test_roundtrip %{input})))
+
 (alias
  (name runtest)
  (deps (:input specialize.v))

--- a/tests/genarg/setoid_rewrite.v
+++ b/tests/genarg/setoid_rewrite.v
@@ -1,0 +1,20 @@
+Require Setoid.
+Require Import PeanoNat Le Gt Minus Bool Lt List.
+Require Import Omega.
+
+Section ReDun.
+
+  Variable A : Type.
+
+  Variable decA : forall (a b : A), {a = b}+{a <> b}.
+
+  Theorem NoDup_count_occ' l:
+    NoDup l <-> (forall x:A, In x l -> count_occ decA l x = 1).
+  Proof.
+    rewrite (NoDup_count_occ decA).
+    setoid_rewrite (count_occ_In decA) at 1.
+    unfold gt, lt in *.
+    split; intros H x; specialize (H x);
+    set (n := count_occ decA l x) in *; clearbody n; omega.
+  Qed.
+End ReDun.


### PR DESCRIPTION
We found another non-ssreflect tactic that causes parsing errors: `setoid_rewrite`. Here is a minimal test case that reproduces the problem (note that the `at 1` is the trigger).