### PR TITLE
[test] Add test case showing discrepancy between coqc and sercomp/compser

### DIFF
--- a/tests/genarg/assoc.v
+++ b/tests/genarg/assoc.v
@@ -1,0 +1,94 @@
+Require Import List.
+Import ListNotations.
+
+Set Implicit Arguments.
+
+Ltac break_match_hyp :=
+  match goal with
+    | [ H : context [ match ?X with _ => _ end ] |- _] =>
+      match type of X with
+        | sumbool _ _ => destruct X
+        | _ => destruct X eqn:?
+      end
+  end.
+
+Ltac break_match_goal :=
+  match goal with
+    | [ |- context [ match ?X with _ => _ end ] ] =>
+      match type of X with
+        | sumbool _ _ => destruct X
+        | _ => destruct X eqn:?
+      end
+  end.
+
+Ltac break_match := break_match_goal || break_match_hyp.
+
+Section assoc.
+  Variable K V : Type.
+  Variable K_eq_dec : forall k k' : K, {k = k'} + {k <> k'}.
+
+  Fixpoint assoc (l : list (K * V)) (k : K) : option V :=
+    match l with
+      | [] => None
+      | (k', v) :: l' =>
+        if K_eq_dec k k' then
+          Some v
+        else
+          assoc l' k
+    end.
+
+  Definition assoc_default (l : list (K * V)) (k : K) (default : V) : V :=
+    match (assoc l k) with
+      | Some x => x
+      | None => default
+    end.
+
+  Fixpoint assoc_set (l : list (K * V)) (k : K) (v : V) : list (K * V) :=
+    match l with
+      | [] => [(k, v)]
+      | (k', v') :: l' =>
+        if K_eq_dec k k' then
+          (k, v) :: l'
+        else
+          (k', v') :: (assoc_set l' k v)
+    end.
+
+  Fixpoint assoc_del (l : list (K * V)) (k : K) : list (K * V) :=
+    match l with
+      | [] => []
+      | (k', v') :: l' =>
+        if K_eq_dec k k' then
+          assoc_del l' k
+        else
+          (assoc_del l' k)
+    end.
+
+  Lemma get_set_diff :
+    forall k k' v l,
+      k <> k' ->
+      assoc (assoc_set l k v) k' = assoc l k'.
+  Proof using.
+    induction l; intros; simpl; repeat (break_match; simpl); subst; try congruence; auto.
+  Qed.
+
+  Lemma get_del_same :
+    forall k l,
+      assoc (assoc_del l k) k = None.
+  Proof using.
+    induction l; intros; simpl in *.
+    - auto.
+    - repeat break_match; subst; simpl in *; auto.
+      break_if; try congruence.
+  Qed.
+
+  Lemma get_set_diff_default :
+    forall (k k' : K) (v : V) l d,
+      k <> k' ->
+      assoc_default (assoc_set l k v) k' d = assoc_default l k' d.
+  Proof using.
+    unfold assoc_default.
+    intros.
+    repeat break_match; auto;
+    rewrite get_set_diff in * by auto; congruence.
+  Qed.
+End assoc.

--- a/tests/genarg/dune
+++ b/tests/genarg/dune
@@ -17,6 +17,12 @@
  (deps (:input add_field.v))
  (action (run ./test_roundtrip %{input})))
 
+; Broken
+; (alias
+;  (name runtest)
+;  (deps (:input assoc.v))
+;  (action (run ./test_roundtrip %{input})))
+
 (alias
  (name runtest)
  (deps (:input auto.v))


### PR DESCRIPTION
Here is an example file where, strangely, `coqc` and `sercomp`/`compser` differ in whether a proof fails. With `coqc`, I get:
```shell
File "./assoc.v", line 81, characters 6-31:
Error: No such goal.
```
That is, the proof of the lemma `get_del_same` fails.

However, `sercomp` and `compser` produce a `.sexp` file and then a `.vo` file without complaints. But now something really strange happens. If I remove the last lemma (`get_set_diff_default`) suddenly `get_del_same` starts to fail with `sercomp` at the right place.

I have no idea what's going on here. Any tips on debugging more would be welcome.