### PR TITLE
[sercomp] Add check mode for compser

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -28,6 +28,8 @@ _Version 0.6.0_:
  * [sercomp] Disable error resilience mode in compilers; semantics are
              a bit dubious see coq/coq#9204 also #94.
              (@ejgallego, report by @palmskog)
+ * [sercomp] Add `check` mode to compilers to check all proofs without
+             outputting `.vo`. (@palmskog)
 
 _Version 0.5.7_:
 

--- a/sertop/sercomp_lib.ml
+++ b/sertop/sercomp_lib.ml
@@ -70,6 +70,7 @@ let process_vernac ~mode ~pp ~doc ~sid ast =
   let open Sertop_arg in
   let () = match mode with
     | C_vo    -> ()
+    | C_check -> ()
     | C_parse -> ()
     | C_stats ->
       Sercomp_stats.do_stats ast
@@ -94,6 +95,9 @@ let close_document ~mode ~doc ~in_file =
   | C_sexp  -> ()
   | C_stats ->
     Sercomp_stats.print_stats ()
+  | C_check ->
+    let _doc = Stm.join ~doc in
+    check_pending_proofs ()
   | C_vo ->
     let _doc = Stm.join ~doc in
     check_pending_proofs ();

--- a/sertop/sertop_arg.ml
+++ b/sertop/sertop_arg.ml
@@ -118,20 +118,22 @@ let exn_on_opaque : bool Term.t =
   Arg.(value & flag & info ["exn_on_opaque"] ~doc)
 
 (* sertop options *)
-type comp_mode = | C_parse | C_stats | C_sexp | C_vo
+type comp_mode = | C_parse | C_stats | C_sexp | C_check | C_vo
 
 let comp_mode_args =
   Arg.(enum
          [ "parse", C_parse
          ; "stats", C_stats
          ; "sexp",  C_sexp
+         ; "check", C_check
          ; "vo",    C_vo])
 
 let comp_mode_doc = Arg.doc_alts
   [ "parse: parse the file and remain silent (except for Coq output)"
   ; "stats: output stats on the input file"
   ;  "sexp: output serialized version of the input file"
-  ;    "vo: output .vo version of the input file"
+  ; "check: check proofs in the file and remain silent (except for Coq output)"
+  ;    "vo: check proofs and output .vo version of the input file"
   ]
 
 let comp_mode =

--- a/sertop/sertop_arg.mli
+++ b/sertop/sertop_arg.mli
@@ -33,7 +33,7 @@ val ml_include_path : Mltop.coq_path list Term.t
 val no_init         : bool Term.t
 
 (* sertop options *)
-type comp_mode = | C_parse | C_stats | C_sexp | C_vo
+type comp_mode = | C_parse | C_stats | C_sexp | C_check | C_vo
 val comp_mode : comp_mode Term.t
 
 (* debug options *)


### PR DESCRIPTION
We sometimes need to check sexprialized files but have no use for the `.vo` output (which can be quite large and costly to produce). This PR introduces a `check` mode that does what the `vo` mode does but without building/writing the `.vo` file. Seems complementary to any improvements in the `parse` mode.

