### PR TITLE
[sercomp] Add experimental `--quick` option to skip proofs.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -30,6 +30,8 @@ _Version 0.6.0_:
              (@ejgallego, report by @palmskog)
  * [sercomp] Add `check` mode to compilers to check all proofs without
              outputting `.vo`. (@palmskog)
+ * [sercomp] Add "hacky" `--quick` option to skip checking of opaque
+             proofs. (@ejgallego, request by @palmskog)
 
 _Version 0.5.7_:
 

--- a/sertop/sertop_arg.ml
+++ b/sertop/sertop_arg.ml
@@ -27,6 +27,10 @@ let async =
   let doc = "Enable async support using Coq binary $(docv) (experimental)." in
   Arg.(value & opt (some string) None & info ["async"] ~doc ~docv:"COQTOP")
 
+let quick =
+  let doc = "Skip checking opaque proofs (very experimental)." in
+  Arg.(value & flag & info ["quick"] ~doc)
+
 let async_full =
   let doc = "Enable Coq's async_full option." in
   Arg.(value & flag & info ["async-full"] ~doc)

--- a/sertop/sertop_arg.mli
+++ b/sertop/sertop_arg.mli
@@ -20,6 +20,7 @@ open Cmdliner
 
 val prelude         : string Term.t
 val async           : string option Term.t
+val quick           : bool Term.t
 val async_full      : bool Term.t
 val deep_edits      : bool Term.t
 val implicit_stdlib : bool Term.t

--- a/tests/quick/ab.v
+++ b/tests/quick/ab.v
@@ -1,0 +1,5 @@
+Section AB.
+Lemma a: True. Proof. idtac. fail. auto. Qed.
+
+Lemma b: True. Proof. pose proof a as H. auto. Qed.
+End AB.

--- a/tests/quick/assoc.v
+++ b/tests/quick/assoc.v
@@ -1,0 +1,94 @@
+Require Import List.
+Import ListNotations.
+
+Set Implicit Arguments.
+
+Ltac break_match_hyp :=
+  match goal with
+    | [ H : context [ match ?X with _ => _ end ] |- _] =>
+      match type of X with
+        | sumbool _ _ => destruct X
+        | _ => destruct X eqn:?
+      end
+  end.
+
+Ltac break_match_goal :=
+  match goal with
+    | [ |- context [ match ?X with _ => _ end ] ] =>
+      match type of X with
+        | sumbool _ _ => destruct X
+        | _ => destruct X eqn:?
+      end
+  end.
+
+Ltac break_match := break_match_goal || break_match_hyp.
+
+Section assoc.
+  Variable K V : Type.
+  Variable K_eq_dec : forall k k' : K, {k = k'} + {k <> k'}.
+
+  Fixpoint assoc (l : list (K * V)) (k : K) : option V :=
+    match l with
+      | [] => None
+      | (k', v) :: l' =>
+        if K_eq_dec k k' then
+          Some v
+        else
+          assoc l' k
+    end.
+
+  Definition assoc_default (l : list (K * V)) (k : K) (default : V) : V :=
+    match (assoc l k) with
+      | Some x => x
+      | None => default
+    end.
+
+  Fixpoint assoc_set (l : list (K * V)) (k : K) (v : V) : list (K * V) :=
+    match l with
+      | [] => [(k, v)]
+      | (k', v') :: l' =>
+        if K_eq_dec k k' then
+          (k, v) :: l'
+        else
+          (k', v') :: (assoc_set l' k v)
+    end.
+
+  Fixpoint assoc_del (l : list (K * V)) (k : K) : list (K * V) :=
+    match l with
+      | [] => []
+      | (k', v') :: l' =>
+        if K_eq_dec k k' then
+          assoc_del l' k
+        else
+          (assoc_del l' k)
+    end.
+
+  Lemma get_set_diff :
+    forall k k' v l,
+      k <> k' ->
+      assoc (assoc_set l k v) k' = assoc l k'.
+  Proof using.
+    induction l; intros; simpl; repeat (break_match; simpl); subst; try congruence; auto.
+  Qed.
+
+  Lemma get_del_same :
+    forall k l,
+      assoc (assoc_del l k) k = None.
+  Proof using.
+    induction l; intros; simpl in *.
+    - auto.
+    - repeat break_match; subst; simpl in *; auto.
+      break_if; try congruence.
+  Qed.
+
+  Lemma get_set_diff_default :
+    forall (k k' : K) (v : V) l d,
+      k <> k' ->
+      assoc_default (assoc_set l k v) k' d = assoc_default l k' d.
+  Proof using.
+    unfold assoc_default.
+    intros.
+    repeat break_match; auto;
+    rewrite get_set_diff in * by auto; congruence.
+  Qed.
+End assoc.

--- a/tests/quick/dune
+++ b/tests/quick/dune
@@ -1,0 +1,11 @@
+(alias
+ (name runtest)
+ (deps (:input ab.v))
+ (action (ignore-outputs
+           (bash "%{bin:sercomp} --quick %{input}"))))
+
+(alias
+ (name runtest)
+ (deps (:input assoc.v))
+ (action (ignore-outputs
+           (bash "%{bin:sercomp} --quick %{input}"))))


### PR DESCRIPTION
IMHO this is not an option we want to support in the long term as
proposed here, however @palmskog proposed it and indeed it may be very
useful in the short term.