### PR TITLE
[sercomp] Add --async-workers option to set max parallel jobs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -32,6 +32,8 @@ _Version 0.6.0_:
              outputting `.vo`. (@palmskog)
  * [sercomp] Add "hacky" `--quick` option to skip checking of opaque
              proofs. (@ejgallego, request by @palmskog)
+ * [sercomp] Add `--async_workers` option to set maximum number
+             of parallel async workers. (@palmskog)
 
 _Version 0.5.7_:
 

--- a/sertop/sertop.ml
+++ b/sertop/sertop.ml
@@ -19,7 +19,7 @@
 open Cmdliner
 
 let sertop_version = Ser_version.ser_git_version
-let sertop printer print0 debug lheader coq_path ml_path no_init lp1 lp2 std_impl async async_full deep_edits omit_loc omit_att exn_on_opaque =
+let sertop printer print0 debug lheader coq_path ml_path no_init lp1 lp2 std_impl async async_full deep_edits async_workers omit_loc omit_att exn_on_opaque =
 
   let open  Sertop_init         in
   let open! Sertop_sexp         in
@@ -45,6 +45,7 @@ let sertop printer print0 debug lheader coq_path ml_path no_init lp1 lp2 std_imp
          enable_async = async;
          async_full = async_full;
          deep_edits = deep_edits;
+         async_workers = async_workers;
        }
     }
 
@@ -70,7 +71,7 @@ let sertop_cmd =
   in
   Term.(const sertop
         $ printer $ print0 $ debug $ length $ prelude $ ml_include_path $ no_init $ load_path $ rload_path $ implicit_stdlib
-        $ async $ async_full $ deep_edits $ omit_loc $ omit_att $ exn_on_opaque ),
+        $ async $ async_full $ deep_edits $ async_workers $ omit_loc $ omit_att $ exn_on_opaque ),
   Term.info "sertop" ~version:sertop_version ~doc ~man
 
 let main () =

--- a/sertop/sertop_arg.ml
+++ b/sertop/sertop_arg.ml
@@ -39,6 +39,10 @@ let deep_edits =
   let doc = "Enable Coq's deep document edits option." in
   Arg.(value & flag & info ["deep-edits"] ~doc)
 
+let async_workers =
+  let doc = "Maximum number of async workers." in
+  Arg.(value & opt int 3 & info ["async-workers"] ~doc)
+
 let implicit_stdlib =
   let doc = "Allow loading unqualified stdlib libraries (deprecated)." in
   Arg.(value & flag & info ["implicit"] ~doc)

--- a/sertop/sertop_arg.mli
+++ b/sertop/sertop_arg.mli
@@ -23,6 +23,7 @@ val async           : string option Term.t
 val quick           : bool Term.t
 val async_full      : bool Term.t
 val deep_edits      : bool Term.t
+val async_workers   : int Term.t
 val implicit_stdlib : bool Term.t
 val printer         : Sertop_ser.ser_printer Term.t
 val debug           : bool Term.t

--- a/sertop/sertop_async.ml
+++ b/sertop/sertop_async.ml
@@ -44,9 +44,10 @@ let sertop_init ~(fb_out : Sexp.t -> unit) ~iload_path ~require_libs ~debug =
   };
 
   let stm_options = process_stm_flags
-    { enable_async = None;
-      async_full   = false;
-      deep_edits   = false;
+    { enable_async  = None;
+      async_full    = false;
+      deep_edits    = false;
+      async_workers = 0;
     } in
 
   let open Stm in

--- a/sertop/sertop_init.ml
+++ b/sertop/sertop_init.ml
@@ -17,9 +17,10 @@
 
 (* Init options for coq *)
 type async_flags = {
-  enable_async : string option;
-  async_full   : bool;
-  deep_edits   : bool;
+  enable_async  : string option;
+  async_full    : bool;
+  deep_edits    : bool;
+  async_workers : int;
 }
 
 type coq_opts = {
@@ -104,8 +105,8 @@ let process_stm_flags opts = Option.cata (fun coqtop ->
         (* Imitate CoqIDE *)
         async_proofs_full = opts.async_full;
         async_proofs_never_reopen_branch = not opts.deep_edits;
-        async_proofs_n_workers    = 3;
-        async_proofs_n_tacworkers = 3;
+        async_proofs_n_workers    = opts.async_workers;
+        async_proofs_n_tacworkers = opts.async_workers;
       } in
     (* async_proofs_worker_priority); *)
     AsyncTaskQueue.async_proofs_flags_for_workers := [dump_opt];

--- a/sertop/sertop_init.mli
+++ b/sertop/sertop_init.mli
@@ -17,9 +17,10 @@
 (************************************************************************)
 
 type async_flags =
-  { enable_async : string option
-  ; async_full   : bool
-  ; deep_edits   : bool
+  { enable_async  : string option
+  ; async_full    : bool
+  ; deep_edits    : bool
+  ; async_workers : int
   }
 (** SerAPI flags for asynchronous processing *)
 


### PR DESCRIPTION
We want to experiment with several forms of parallel checking, and this means that controlling the maximum number of parallel workers/threads/jobs (when using `--async=...`) is a must. I tried to only do edits to remove the hardcoding and preserve the default. I'd be fine with this living in a separate branch for now, though.