### PR TITLE
[doc] Add man pages with examples for sercomp and compser

### DIFF
--- a/sertop/compser.ml
+++ b/sertop/compser.ml
@@ -31,6 +31,13 @@ let compfun ~in_file:_ ~in_chan ~process ~doc ~sid =
   with End_of_file -> fst !stt
 
 let _ =
-  Sercomp_lib.maincomp ~ext:".sexp" ~name:"compser"
-    ~desc:"Experimental Coq Compiler with deserialization support."
-    ~compfun
+  let man = [
+    `S "DESCRIPTION";
+    `P "Experimental Coq compiler with deserialization support.";
+    `S "USAGE";
+    `P "To deserialize and check `fun.sexp` in directory `fs` with path `Funs`:";
+    `Pre "compser -Q fs,Funs --mode=check fs/fun.sexp";
+    `P "See the documentation on the project's webpage for more information"
+  ]
+  in
+  Sercomp_lib.maincomp ~ext:".sexp" ~name:"compser" ~man ~compfun

--- a/sertop/sercomp.ml
+++ b/sertop/sercomp.ml
@@ -31,6 +31,13 @@ let compfun ~in_file ~in_chan ~process ~doc ~sid =
   with Stm.End_of_input -> fst !stt
 
 let _ =
-  Sercomp_lib.maincomp ~ext:".v" ~name:"sercomp"
-    ~desc:"Experimental Coq Compiler with serialization support."
-    ~compfun
+  let man = [
+    `S "DESCRIPTION";
+    `P "Experimental Coq compiler with serialization support.";
+    `S "USAGE";
+    `P "To serialize `fun.v` in directory `fs` with path `Funs`:";
+    `Pre "sercomp -Q fs,Funs --mode=sexp fs/fun.v > fs/fun.sexp";
+    `P "See the documentation on the project's webpage for more information"
+  ]
+  in
+  Sercomp_lib.maincomp ~ext:".v" ~name:"sercomp" ~man ~compfun

--- a/sertop/sercomp_lib.ml
+++ b/sertop/sercomp_lib.ml
@@ -147,7 +147,7 @@ let driver fn mode debug printer async async_workers quick coq_path ml_path load
   let doc = fn ~in_file ~in_chan ~process ~doc ~sid in
   close_document ~mode ~doc ~in_file
 
-let maincomp ~ext ~name ~desc ~(compfun:compfun) =
+let maincomp ~ext ~name ~man ~(compfun:compfun) =
   let input_file =
     let doc = "Input " ^ ext ^ " file." in
     Arg.(required & pos 0 (some string) None & info [] ~docv:("FILE"^ext) ~doc)
@@ -155,11 +155,6 @@ let maincomp ~ext ~name ~desc ~(compfun:compfun) =
 
   let comp_cmd =
     let doc = name ^ " Coq Compiler" in
-    let man = [
-      `S "DESCRIPTION";
-      `P desc;
-    ]
-    in
     let open Sertop_arg in
     Term.(const (driver compfun)
           $ comp_mode $ debug $ printer $ async $ async_workers $ quick $ prelude

--- a/sertop/sercomp_lib.mli
+++ b/sertop/sercomp_lib.mli
@@ -48,6 +48,6 @@ type compfun
 val maincomp
   :  ext:string
   -> name:string
-  -> desc:string
+  -> man:Cmdliner.Manpage.block list
   -> compfun:compfun
   -> unit


### PR DESCRIPTION
Very basic description of the one key modes of use of `sercom` and `compser` to begin addressing #98.