### PR TITLE
[test] Add two failing tests for --quick

### DIFF
--- a/tests/quick/dune
+++ b/tests/quick/dune
@@ -9,3 +9,15 @@
  (deps (:input assoc.v))
  (action (ignore-outputs
            (bash "%{bin:sercomp} --quick %{input}"))))
+
+(alias
+ (name runtest)
+ (deps (:input ordered.v))
+ (action (ignore-outputs
+           (bash "%{bin:sercomp} --quick %{input}"))))
+
+(alias
+ (name runtest)
+ (deps (:input reserved.v))
+ (action (ignore-outputs
+           (bash "%{bin:sercomp} --quick %{input}"))))

--- a/tests/quick/ordered.v
+++ b/tests/quick/ordered.v
@@ -1,0 +1,34 @@
+Require Import List.
+Require Import NArith.
+
+Module Type OrderedTypeAlt.
+ Parameter t : Type.
+
+ Parameter compare : t -> t -> comparison.
+ Infix "?=" := compare (at level 70, no associativity).
+
+ Parameter compare_sym : forall x y, (y?=x) = CompOpp (x?=y).
+ Parameter compare_trans : forall c x y z, (x?=y) = c -> (y?=z) = c -> (x?=z) = c.
+ Parameter reflect : forall x y, x ?= y = Eq -> x = y.
+End OrderedTypeAlt.
+
+Module Nat_as_OTA <: OrderedTypeAlt.
+  Definition t := nat.
+  Fixpoint compare x y := 
+    match x,y with 
+      | O,O => Eq
+      | O,_ => Lt
+      | _,O => Gt
+      | S x, S y => compare x y
+    end.
+  Lemma compare_sym: forall x y, compare y x = CompOpp (compare x y). 
+  Proof using. induction x; intros y; destruct y; simpl; auto. Qed.
+  Lemma compare_trans: forall c x y z, compare x y = c -> compare y z = c -> compare x z = c. 
+  Proof using.
+    intros c x. revert c.
+    induction x; intros c y z; destruct y; simpl; intro H; auto; subst; try discriminate H;
+      destruct z; simpl; intro H'; eauto; try discriminate H'.
+  Qed.
+  Lemma reflect: forall x y, compare x y = Eq -> x = y.
+  Proof using. induction x; intros y; destruct y; simpl; intro H; auto; discriminate. Qed.
+End Nat_as_OTA.

--- a/tests/quick/reserved.v
+++ b/tests/quick/reserved.v
@@ -1,0 +1,23 @@
+Require Import List String Ascii.
+Import ListNotations.
+
+Local Open Scope char.
+
+Module chars.
+  Notation lparen := "("%char.
+  Notation rparen := ")"%char.
+  Notation space  := " "%char.
+  Notation newline  := "010"%char.
+
+  Definition reserved (a : ascii) : Prop  :=
+    In a [lparen; rparen; newline; space].
+
+  Definition reserved_dec (a : ascii) : {reserved a} + {~ reserved a}.
+    unfold reserved.
+    apply in_dec.
+    apply ascii_dec.
+  Defined.
+
+  Lemma lparen_reserved : reserved lparen.
+  Proof using. red. intuition. Qed.
+End chars.


### PR DESCRIPTION
Here are two tests that give the following error when given to `sercomp` with `--quick`:
```
Error: 
       Anomaly
       "True Future.t were created for opaque constants even if -async-proofs is off"
       Please report at http://coq.inria.fr/bugs/.
``` 
Note that `Proof.` or `Proof using.` makes no difference, but I used the latter for completeness.