### PR TITLE
[sercomp] Allow delayed constants for both quick and async

### DIFF
--- a/sertop/sercomp_lib.ml
+++ b/sertop/sercomp_lib.ml
@@ -55,12 +55,7 @@ let create_document ~in_file ~async ~async_workers ~quick ~iload_path ~debug =
 
   let stm_options =
     if quick
-    then begin
-      (* Workaround, see
-         https://github.com/ejgallego/coq-serapi/pull/101 *)
-      Safe_typing.allow_delayed_constants := true;
-      { stm_options with async_proofs_mode = APonLazy }
-    end
+    then { stm_options with async_proofs_mode = APonLazy }
     else stm_options
   in
 
@@ -71,6 +66,11 @@ let create_document ~in_file ~async ~async_workers ~quick ~iload_path ~debug =
              ; iload_path
              ; stm_options
              } in
+
+  (* Workaround, see
+     https://github.com/ejgallego/coq-serapi/pull/101 *)
+  if quick || async <> None
+  then Safe_typing.allow_delayed_constants := true;
 
   Stm.new_doc ndoc
 


### PR DESCRIPTION
We get the `True Future.t were created for opaque constants even if -async-proofs is off` anomaly when checking proofs using `compser --async=coqtop`. Here, I use the same workaround as for the `--quick` option. Any advice about a cleaner way to handle this appreciated.