### PR TITLE
[test] Add async test

### DIFF
--- a/tests/async/dune
+++ b/tests/async/dune
@@ -1,0 +1,6 @@
+; Broken
+; (alias
+;  (name runtest)
+;  (deps (:input quote.v))
+;  (action (ignore-outputs
+;            (bash "%{bin:sercomp} --async=coqtop --mode=check %{input}"))))

--- a/tests/async/quote.v
+++ b/tests/async/quote.v
@@ -1,0 +1,13 @@
+Require Import Arith.
+Require Import List.
+Import ListNotations.
+
+Set Implicit Arguments.
+
+Lemma leb_false_lt : forall m n, leb m n = false -> n < m.
+Proof.
+  induction m; intros.
+  - discriminate.
+  - simpl in *.
+    destruct n; subst; auto with arith.
+Qed.


### PR DESCRIPTION
After the switch to dynamic plugin loading, we are seeing errors like the following with the `--async` option:
```
Error:
      while loading quote_plugin.cmxs:
      cannot find file /home/test/src/project/quote_plugin.cmxs in search path
```
where `/home/test/src/project` is the directory we are running `sercomp` or `compser` from. 

Here is a test that replicates this error in a minimal example, at least for me locally. Note that running `dune install` or not makes no difference.

To speculate a bit, this may have do with async workers not getting the right `OCAMLPATH` variable.