### PR TITLE
[ci] [travis] Update Travis to use Coq's OPAM package.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,29 +28,26 @@ env:
   - COQ_VERSION="v8.9"
   - COQ_BRANCH="v8.9"
   - COQ_CONF="-local -native-compiler no -coqide no"
-  - COMPILER="4.06.1"
+  - COMPILER="4.07.1"
   - BASE_OPAM="camlp5 cmdliner ppx_deriving ppx_import ppx_sexp_conv sexplib dune"
   # Main test suites
   matrix:
-  # Don't test opam in 8.9 yet.
-  # - TEST_TARGET="all"                                                                               EXTRA_OPAM="coq"
-  - TEST_TARGET="build"   COMPILER="4.06.1"       SERAPI_COQ_HOME="$HOME/coq-$COQ_VERSION/"
-  - TEST_TARGET="build"   COMPILER="4.07.1"       SERAPI_COQ_HOME="$HOME/coq-$COQ_VERSION/"
-  - TEST_TARGET="test"    COMPILER="4.07.1"       SERAPI_COQ_HOME="$HOME/coq-$COQ_VERSION/"
-  - TEST_TARGET="js-dune" COMPILER="4.06.1+32bit" SERAPI_COQ_HOME="$HOME/coq-$COQ_VERSION/" EXTRA_OPAM="js_of_ocaml js_of_ocaml-lwt ppx_deriving_yojson" COQ_EXTRA_MAKE="byte"
+  - TEST_TARGET="build"   COMPILER="4.06.1"                                                 EXTRA_OPAM="coq"
+  - TEST_TARGET="build"   COMPILER="4.07.1"                                                 EXTRA_OPAM="coq"
+  - TEST_TARGET="test"    COMPILER="4.07.1"                                                 EXTRA_OPAM="coq"
+  - TEST_TARGET="js-dune" COMPILER="4.07.1+32bit" SERAPI_COQ_HOME="$HOME/coq-$COQ_VERSION/" EXTRA_OPAM="js_of_ocaml js_of_ocaml-lwt ppx_deriving_yojson" COQ_EXTRA_MAKE="byte"
   # Add COQ_EXTRA_CONF="-bytecode-compiler no" to 8.8
   # - TEST_TARGET="test2"
 
 install:
-- echo "yes" | sudo add-apt-repository ppa:ansible/bubblewrap
-- sudo apt-get update -qq
-- sudo apt-get install -qq bubblewrap
-- sudo curl -sL https://github.com/ocaml/opam/releases/download/2.0.2/opam-2.0.2-x86_64-linux -o /usr/bin/opam
+- sudo curl -sL https://github.com/ocaml/opam/releases/download/2.0.3/opam-2.0.3-x86_64-linux -o /usr/bin/opam
 - sudo chmod 755 /usr/bin/opam
-- opam init -c "$COMPILER"
+- opam init -c "$COMPILER" --disable-sandboxing
 - opam switch set "$COMPILER"
 - eval $(opam env)
-- opam install $BASE_OPAM $EXTRA_OPAM # yojson ppx_deriving_yojson
+# OPAM 2 is quite broken here
+- opam config set-global jobs $NJOBS
+- opam install $BASE_OPAM $EXTRA_OPAM
 - opam list
 - >
   if [[ -v SERAPI_COQ_HOME ]]; then


### PR DESCRIPTION
This allows Coq to be cached, and it is more faithful to what most
users do.