### PR TITLE
[serlib] add partial support for serializing Env

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,3 +1,4 @@
 Emilio Jesús Gallego Arias
 Karl Palmskog
 Clément Pit--Claudel
+Kaiyu Yang

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,8 @@
  * [serlib]  Serialize `Universe.t` (@ejgallego, request by @yangky11)
  * [sercomp] Merge `sercomp` and `compser`, add `--input` parameter to `sercomp`
              (@palmskog) (cc: @ejgallego)
+ * [serlib] Much improved support for serialization of `Environ.env`
+             (@yangky11 and @ejgallego c.f. #118)
 
 ## Version 0.6.0:
 

--- a/serlib/ser_cEphemeron.ml
+++ b/serlib/ser_cEphemeron.ml
@@ -8,15 +8,12 @@
 
 (************************************************************************)
 (* Coq serialization API/Plugin                                         *)
-(* Copyright 2016-2018 MINES ParisTech                                  *)
+(* Copyright 2016-2019 MINES ParisTech                                  *)
 (************************************************************************)
 (* Status: Experimental                                                 *)
 (************************************************************************)
 
-type opaque = [%import: Opaqueproof.opaque]
-let sexp_of_opaque = Serlib_base.sexp_of_opaque ~typ:"Opaqueproof.opaque"
-let opaque_of_sexp = Serlib_base.opaque_of_sexp ~typ:"Opaqueproof.opaque"
+type 'a key = 'a CEphemeron.key
 
-type opaquetab = [%import: Opaqueproof.opaquetab]
-let sexp_of_opaquetab = Serlib_base.sexp_of_opaque ~typ:"Opaqueproof.opaquetab"
-let opaquetab_of_sexp = Serlib_base.opaque_of_sexp ~typ:"Opaqueproof.opaquetab"
+let key_of_sexp f x = CEphemeron.create (f x)
+let sexp_of_key f v = f CEphemeron.(get v)

--- a/serlib/ser_cMap.ml
+++ b/serlib/ser_cMap.ml
@@ -1,0 +1,50 @@
+(************************************************************************)
+(*         *   The Coq Proof Assistant / The Coq Development Team       *)
+(*  v      *   INRIA, CNRS and contributors - Copyright 1999-2018       *)
+(* <O___,, *       (see CREDITS file for the list of authors)           *)
+(*   \VV/  **************************************************************)
+(*    //   *    This file is distributed under the terms of the         *)
+(*         *     GNU Lesser General Public License Version 2.1          *)
+(*         *     (see LICENSE file for the text of the license)         *)
+(************************************************************************)
+
+(************************************************************************)
+(* Coq serialization API/Plugin                                         *)
+(* Copyright 2016-2019 MINES ParisTech -- Dual License LGPL 2.1 / GPL3+ *)
+(* Written by: Emilio J. Gallego Arias                                  *)
+(************************************************************************)
+(* Status: Very Experimental                                            *)
+(************************************************************************)
+
+open Sexplib
+open Sexplib.Conv
+
+module type SerType = sig
+
+  type t
+  val t_of_sexp : Sexp.t -> t
+  val sexp_of_t : t -> Sexp.t
+
+end
+
+module type ExtS = sig
+
+  include CSig.MapS
+
+  val t_of_sexp : (Sexp.t -> 'a) -> Sexp.t -> 'a t
+  val sexp_of_t : ('a -> Sexp.t) -> 'a t -> Sexp.t
+
+end
+
+module Make (M : CSig.MapS) (S : SerType with type t := M.key) = struct
+
+  include M
+
+  let sexp_of_t f cst =
+    sexp_of_list (Sexplib.Conv.sexp_of_pair S.sexp_of_t f) M.(bindings cst)
+
+  let t_of_sexp f sexp =
+    List.fold_left (fun e (k,s) -> M.add k s e) M.empty
+      (list_of_sexp (pair_of_sexp S.t_of_sexp f) sexp)
+
+end

--- a/serlib/ser_cMap.mli
+++ b/serlib/ser_cMap.mli
@@ -1,0 +1,40 @@
+(************************************************************************)
+(*         *   The Coq Proof Assistant / The Coq Development Team       *)
+(*  v      *   INRIA, CNRS and contributors - Copyright 1999-2018       *)
+(* <O___,, *       (see CREDITS file for the list of authors)           *)
+(*   \VV/  **************************************************************)
+(*    //   *    This file is distributed under the terms of the         *)
+(*         *     GNU Lesser General Public License Version 2.1          *)
+(*         *     (see LICENSE file for the text of the license)         *)
+(************************************************************************)
+
+(************************************************************************)
+(* Coq serialization API/Plugin                                         *)
+(* Copyright 2016-2019 MINES ParisTech -- Dual License LGPL 2.1 / GPL3+ *)
+(* Written by: Emilio J. Gallego Arias                                  *)
+(************************************************************************)
+(* Status: Very Experimental                                            *)
+(************************************************************************)
+
+open Sexplib
+
+module type SerType = sig
+
+  type t
+  val t_of_sexp : Sexp.t -> t
+  val sexp_of_t : t -> Sexp.t
+
+end
+
+module type ExtS = sig
+
+  include CSig.MapS
+
+  val t_of_sexp : (Sexp.t -> 'a) -> Sexp.t -> 'a t
+  val sexp_of_t : ('a -> Sexp.t) -> 'a t -> Sexp.t
+
+end
+
+module Make (M : CSig.MapS) (S : SerType with type t := M.key)
+  : ExtS with type key = M.key
+

--- a/serlib/ser_cemitcodes.ml
+++ b/serlib/ser_cemitcodes.ml
@@ -1,0 +1,5 @@
+type to_patch_substituted =
+  [%import: Cemitcodes.to_patch_substituted]
+
+let sexp_of_to_patch_substituted = Serlib_base.sexp_of_opaque ~typ:"Cemitcodes.to_patch_substituted"
+let to_patch_substituted_of_sexp = Serlib_base.opaque_of_sexp ~typ:"Cemitcodes.to_patch_substituted"

--- a/serlib/ser_cemitcodes.mli
+++ b/serlib/ser_cemitcodes.mli
@@ -1,0 +1,6 @@
+open Sexplib
+
+type to_patch_substituted = Cemitcodes.to_patch_substituted
+
+val sexp_of_to_patch_substituted : to_patch_substituted -> Sexp.t
+val to_patch_substituted_of_sexp : Sexp.t -> to_patch_substituted

--- a/serlib/ser_declarations.ml
+++ b/serlib/ser_declarations.ml
@@ -16,15 +16,20 @@
 
 open Sexplib
 open Sexplib.Conv
+open Declarations
 
 module Names   = Ser_names
 module Context = Ser_context
 module Constr  = Ser_constr
 module Sorts   = Ser_sorts
 module Univ    = Ser_univ
-module Decl_kinds = Ser_decl_kinds
-module Vmvalues = Ser_vmvalues
+module Decl_kinds  = Ser_decl_kinds
+module Vmvalues    = Ser_vmvalues
 module Conv_oracle = Ser_conv_oracle
+module Mod_subst   = Ser_mod_subst
+module Opaqueproof = Ser_opaqueproof
+module Cemitcodes  = Ser_cemitcodes
+module Retroknowledge = Ser_retroknowledge
 
 type template_arity =
   [%import: Declarations.template_arity]
@@ -76,14 +81,32 @@ type engagement =
   [%import: Declarations.engagement]
   [@@deriving sexp]
 
+type inline =
+  [%import: Declarations.inline]
+  [@@deriving sexp]
+
+type constant_universes =
+  [%import: Declarations.constant_universes]
+  [@@deriving sexp]
+
+type constant_def =
+  [%import: Declarations.constant_def]
+  [@@deriving sexp]
+
 type typing_flags =
   [%import: Declarations.typing_flags]
   [@@deriving sexp]
 
-(* type record_body =
- *   [%import: Declarations.record_body
- *   [@with Context.section_context := Context.Named.t;]]
- *   [@@deriving sexp] *)
+type constant_body =
+  [%import: Declarations.constant_body]
+  [@@deriving sexp]
+
+(* XXX: At least one serializer can be done *)
+let sexp_of_module_retroknowledge _ =
+  Serlib_base.sexp_of_opaque ~typ:"Declarations.module_retroknowledge"
+
+let module_retroknowledge_of_sexp _ =
+  Serlib_base.opaque_of_sexp ~typ:"Declarations.module_retroknowledge"
 
 type abstract_inductive_universes =
   [%import: Declarations.abstract_inductive_universes]
@@ -102,3 +125,46 @@ type mutual_inductive_body =
   [@with Context.section_context := Context.Named.t;]]
   [@@deriving sexp]
 
+type ('ty,'a) functorize =
+  [%import: ('ty, 'a) Declarations.functorize]
+  [@@deriving sexp]
+
+type with_declaration =
+  [%import: Declarations.with_declaration]
+  [@@deriving sexp]
+
+type module_alg_expr =
+  [%import: Declarations.module_alg_expr]
+  [@@deriving sexp]
+
+type structure_field_body =
+  [%import: Declarations.structure_field_body]
+  [@@deriving sexp]
+
+and structure_body =
+  [%import: Declarations.structure_body]
+  [@@deriving sexp]
+
+and module_signature =
+  [%import: Declarations.module_signature]
+  [@@deriving sexp]
+
+and module_expression =
+  [%import: Declarations.module_expression]
+  [@@deriving sexp]
+
+and module_implementation =
+  [%import: Declarations.module_implementation]
+  [@@deriving sexp]
+
+and 'a generic_module_body =
+  [%import: 'a Declarations.generic_module_body]
+  [@@deriving sexp]
+
+and module_body =
+  [%import: Declarations.module_body]
+  [@@deriving sexp]
+
+and module_type_body =
+  [%import: Declarations.module_type_body]
+  [@@deriving sexp]

--- a/serlib/ser_declarations.mli
+++ b/serlib/ser_declarations.mli
@@ -64,6 +64,10 @@ type typing_flags = Declarations.typing_flags
 val typing_flags_of_sexp : Sexp.t -> typing_flags
 val sexp_of_typing_flags : typing_flags -> Sexp.t
 
+type constant_body = Declarations.constant_body
+val sexp_of_constant_body : constant_body -> Sexp.t
+val constant_body_of_sexp : Sexp.t -> constant_body
+
 (* type record_body = Declarations.record_body
  * val record_body_of_sexp : Sexp.t -> record_body
  * val sexp_of_record_body : record_body -> Sexp.t *)
@@ -75,3 +79,11 @@ val sexp_of_recursivity_kind : recursivity_kind -> Sexp.t
 type mutual_inductive_body = Declarations.mutual_inductive_body
 val mutual_inductive_body_of_sexp : Sexp.t -> mutual_inductive_body
 val sexp_of_mutual_inductive_body : mutual_inductive_body -> Sexp.t
+
+type module_body = Declarations.module_body
+val sexp_of_module_body : module_body -> Sexp.t
+val module_body_of_sexp : Sexp.t -> module_body
+
+type module_type_body = Declarations.module_type_body
+val sexp_of_module_type_body : module_type_body -> Sexp.t
+val module_type_body_of_sexp : Sexp.t -> module_type_body

--- a/serlib/ser_environ.ml
+++ b/serlib/ser_environ.ml
@@ -8,13 +8,14 @@
 
 (************************************************************************)
 (* Coq serialization API/Plugin                                         *)
-(* Copyright 2016-2018 MINES ParisTech                                  *)
+(* Copyright 2016-2019 MINES ParisTech                                  *)
 (************************************************************************)
 (* Status: Experimental                                                 *)
 (************************************************************************)
 
-open Sexplib.Std
+open Sexplib.Conv
 
+module CEphemeron = Ser_cEphemeron
 module Range  = Ser_range
 module Names  = Ser_names
 module Constr = Ser_constr
@@ -38,10 +39,45 @@ type named_context_val =
   [%import: Environ.named_context_val]
   [@@deriving sexp_of]
 
-type globals =
-  [%import: Environ.globals]
+type link_info =
+  [%import: Environ.link_info]
+  [@@deriving sexp]
 
-let sexp_of_globals = Serlib_base.sexp_of_opaque ~typ:"Environ.globals"
+(* For 4.06 *)
+module Pervasives = struct
+  type nonrec 'a ref = 'a ref
+    [@@deriving sexp]
+end
+
+(* For 4.07 *)
+module Stdlib = struct
+  type nonrec 'a ref = 'a ref
+    [@@deriving sexp]
+end
+
+type key = 
+  [%import: Environ.key]
+  [@@deriving sexp]
+
+type constant_key = 
+  [%import: Environ.constant_key]
+  [@@deriving sexp]
+
+type mind_key =   
+  [%import: Environ.mind_key]
+  [@@deriving sexp]
+
+type _globals = {
+  env_constants : constant_key Names.Cmap_env.t;
+  env_inductives : mind_key Names.Mindmap_env.t;
+  env_modules : Declarations.module_body Names.MPmap.t;
+  env_modtypes : Declarations.module_type_body Names.MPmap.t;
+} [@@deriving sexp]
+
+type globals = Environ.globals
+
+let sexp_of_globals g = sexp_of__globals Obj.(magic g)
+let _globals_of_sexp g = Obj.magic (_globals_of_sexp g)
 
 type env =
   [%import: Environ.env]

--- a/serlib/ser_mod_subst.ml
+++ b/serlib/ser_mod_subst.ml
@@ -8,15 +8,25 @@
 
 (************************************************************************)
 (* Coq serialization API/Plugin                                         *)
-(* Copyright 2016-2018 MINES ParisTech                                  *)
+(* Copyright 2016-2019 MINES ParisTech                                  *)
 (************************************************************************)
 (* Status: Experimental                                                 *)
 (************************************************************************)
 
-type opaque = [%import: Opaqueproof.opaque]
-let sexp_of_opaque = Serlib_base.sexp_of_opaque ~typ:"Opaqueproof.opaque"
-let opaque_of_sexp = Serlib_base.opaque_of_sexp ~typ:"Opaqueproof.opaque"
+type delta_resolver =
+  [%import: Mod_subst.delta_resolver]
 
-type opaquetab = [%import: Opaqueproof.opaquetab]
-let sexp_of_opaquetab = Serlib_base.sexp_of_opaque ~typ:"Opaqueproof.opaquetab"
-let opaquetab_of_sexp = Serlib_base.opaque_of_sexp ~typ:"Opaqueproof.opaquetab"
+let sexp_of_delta_resolver =
+  Serlib_base.sexp_of_opaque ~typ:"Mod_subst.delta_resolver"
+
+let delta_resolver_of_sexp =
+  Serlib_base.opaque_of_sexp ~typ:"Mod_subst.delta_resolver"
+
+type 'a substituted =
+  [%import: 'a Mod_subst.substituted]
+
+let sexp_of_substituted _ =
+  Serlib_base.sexp_of_opaque ~typ:"Mod_subst.substituted"
+
+let substituted_of_sexp _ =
+  Serlib_base.opaque_of_sexp ~typ:"Mod_subst.substituted"

--- a/serlib/ser_mod_subst.mli
+++ b/serlib/ser_mod_subst.mli
@@ -8,15 +8,17 @@
 
 (************************************************************************)
 (* Coq serialization API/Plugin                                         *)
-(* Copyright 2016-2018 MINES ParisTech                                  *)
+(* Copyright 2016-2019 MINES ParisTech                                  *)
 (************************************************************************)
 (* Status: Experimental                                                 *)
 (************************************************************************)
 
-type opaque = [%import: Opaqueproof.opaque]
-let sexp_of_opaque = Serlib_base.sexp_of_opaque ~typ:"Opaqueproof.opaque"
-let opaque_of_sexp = Serlib_base.opaque_of_sexp ~typ:"Opaqueproof.opaque"
+open Sexplib
 
-type opaquetab = [%import: Opaqueproof.opaquetab]
-let sexp_of_opaquetab = Serlib_base.sexp_of_opaque ~typ:"Opaqueproof.opaquetab"
-let opaquetab_of_sexp = Serlib_base.opaque_of_sexp ~typ:"Opaqueproof.opaquetab"
+type delta_resolver = Mod_subst.delta_resolver
+val sexp_of_delta_resolver : delta_resolver -> Sexp.t
+val delta_resolver_of_sexp : Sexp.t -> delta_resolver
+
+type 'a substituted = 'a Mod_subst.substituted
+val sexp_of_substituted : ('a -> Sexp.t) -> 'a substituted -> Sexp.t
+val substituted_of_sexp : (Sexp.t -> 'a) -> Sexp.t -> 'a substituted

--- a/serlib/ser_names.ml
+++ b/serlib/ser_names.ml
@@ -130,6 +130,8 @@ type t = [%import: Names.ModPath.t]
 
 end
 
+module MPmap = Ser_cMap.Make(MPmap)(ModPath)
+
 (* KerName: private *)
 module KerName = struct
 
@@ -164,6 +166,8 @@ let sexp_of_t dp   = sexp_of__constant (_constant_put dp)
 
 end
 
+module Cmap_env = Ser_cMap.Make(Cmap_env)(Constant)
+
 module MutInd = struct
 
 (* MutInd.t: private *)
@@ -180,6 +184,8 @@ let t_of_sexp sexp = _mutind_get (_mutind_of_sexp sexp)
 let sexp_of_t dp   = sexp_of__mutind (_mutind_put dp)
 
 end
+
+module Mindmap_env = Ser_cMap.Make(Mindmap_env)(MutInd)
 
 type 'a tableKey =
   [%import: 'a Names.tableKey]

--- a/serlib/ser_names.mli
+++ b/serlib/ser_names.mli
@@ -10,7 +10,7 @@
 
 (************************************************************************)
 (* Coq serialization API/Plugin                                         *)
-(* Copyright 2016-2018 MINES ParisTech -- Dual License LGPL 2.1 / GPL3+ *)
+(* Copyright 2016-2019 MINES ParisTech -- Dual License LGPL 2.1 / GPL3+ *)
 (* Written by: Emilio J. Gallego Arias                                  *)
 (************************************************************************)
 (* Status: Very Experimental                                            *)
@@ -84,6 +84,8 @@ module ModPath : sig
 
 end
 
+module MPmap : Ser_cMap.ExtS with type key = ModPath.t
+
 module KerName : sig
 
   type t = KerName.t
@@ -102,6 +104,8 @@ module Constant : sig
 
 end
 
+module Cmap_env : Ser_cMap.ExtS with type key = Constant.t
+
 module MutInd : sig
 
   type t = Names.MutInd.t
@@ -110,6 +114,8 @@ module MutInd : sig
   val sexp_of_t : t -> Sexp.t
 
 end
+
+module Mindmap_env : Ser_cMap.ExtS with type key = MutInd.t
 
 type 'a tableKey = 'a Names.tableKey
 

--- a/serlib/ser_opaqueproof.mli
+++ b/serlib/ser_opaqueproof.mli
@@ -15,7 +15,10 @@
 
 open Sexplib
 
-type opaquetab = Opaqueproof.opaquetab
+type opaque = Opaqueproof.opaque
+val sexp_of_opaque : opaque -> Sexp.t
+val opaque_of_sexp : Sexp.t -> opaque
 
+type opaquetab = Opaqueproof.opaquetab
 val sexp_of_opaquetab : opaquetab -> Sexp.t
 val opaquetab_of_sexp : Sexp.t -> opaquetab

--- a/serlib/ser_retroknowledge.ml
+++ b/serlib/ser_retroknowledge.ml
@@ -28,3 +28,12 @@ type retroknowledge =
 
 let sexp_of_retroknowledge = Serlib_base.sexp_of_opaque ~typ:"Retroknowledge.retroknowledge"
 let retroknowledge_of_sexp = Serlib_base.opaque_of_sexp ~typ:"Retroknowledge.retroknowledge"
+
+type entry = 
+  [%import: Retroknowledge.entry]
+
+type action = 
+  [%import: Retroknowledge.action]
+
+let sexp_of_action = Serlib_base.sexp_of_opaque ~typ:"Retroknowledge.action"
+let action_of_sexp = Serlib_base.opaque_of_sexp ~typ:"Retroknowledge.action"

--- a/serlib/ser_retroknowledge.mli
+++ b/serlib/ser_retroknowledge.mli
@@ -23,3 +23,8 @@ type retroknowledge = Retroknowledge.retroknowledge
 
 val sexp_of_retroknowledge : retroknowledge -> Sexp.t
 val retroknowledge_of_sexp : Sexp.t -> retroknowledge
+
+type action = Retroknowledge.action
+
+val sexp_of_action : action -> Sexp.t
+val action_of_sexp : Sexp.t -> action


### PR DESCRIPTION
Hi,

This is what I have for serializing the `Env`. It relies on exposing `type globals` in kernel/environ.mli. 
To reduce the output size, I simply omit the modules and module types in Env (see `sexp_of_globals` in ser_environ.ml),  but there may be a better way to do that.