### PR TITLE
[serlib] Fix serialization for global_declaration

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,7 +16,7 @@
              (@ejgallego c.f. #119)
  * [serlib ] Serialize more internal environment fields (@ejgallego c.f. #119)
  * [serlib ] Improvements in serialization org (@ejgallego)
- * [serlib ] Serialize kernel entries (@ejgallego)
+ * [serlib ] Serialize kernel entries (@ejgallego @palmskog)
 
 ## Version 0.6.0:
 

--- a/serlib/ser_cemitcodes.ml
+++ b/serlib/ser_cemitcodes.ml
@@ -1,5 +1,56 @@
+(************************************************************************)
+(*         *   The Coq Proof Assistant / The Coq Development Team       *)
+(*  v      *   INRIA, CNRS and contributors - Copyright 1999-2018       *)
+(* <O___,, *       (see CREDITS file for the list of authors)           *)
+(*   \VV/  **************************************************************)
+(*    //   *    This file is distributed under the terms of the         *)
+(*         *     GNU Lesser General Public License Version 2.1          *)
+(*         *     (see LICENSE file for the text of the license)         *)
+(************************************************************************)
+
+(************************************************************************)
+(* Coq serialization API/Plugin                                         *)
+(* Copyright 2016-2019 MINES ParisTech                                  *)
+(* Written byo: Emilio J. Gallego Arias                                  *)
+(************************************************************************)
+(* Status: Very Experimental                                            *)
+(************************************************************************)
+
+(* open Sexplib *)
+module Names = Ser_names
+module Mod_subst = Ser_mod_subst
+
+[@@@ocaml.warning "-37"]
+
+type emitcodes = String.t
+(* [@@deriving sexp] *)
+
+type reloc_info =
+  | Reloc_annot of Vmvalues.annot_switch
+  | Reloc_const of Vmvalues.structured_constant
+  | Reloc_getglobal of Names.Constant.t
+  | Reloc_proj_name of Names.Projection.Repr.t
+
+type patches = {
+  reloc_infos : (reloc_info * int array) array;
+}
+
+type to_patch = emitcodes * patches * Cbytecodes.fv
+(* [@@deriving sexp] *)
+
+type _to_patch_substituted =
+| PBCdefined of to_patch Mod_subst.substituted
+| PBCalias of Names.Constant.t Mod_subst.substituted
+| PBCconstant
+(* [@@deriving sexp] *)
+
 type to_patch_substituted =
   [%import: Cemitcodes.to_patch_substituted]
 
-let sexp_of_to_patch_substituted = Serlib_base.sexp_of_opaque ~typ:"Cemitcodes.to_patch_substituted"
-let to_patch_substituted_of_sexp = Serlib_base.opaque_of_sexp ~typ:"Cemitcodes.to_patch_substituted"
+let sexp_of_to_patch_substituted =
+  Serlib_base.sexp_of_opaque ~typ:"Cemitcodes.to_patch_substituted"
+
+(* XXX: Dummy value *)
+let to_patch_substituted_of_sexp _ =
+  Obj.magic PBCconstant
+  (* Serlib_base.opaque_of_sexp ~typ:"Cemitcodes.to_patch_substituted" *)

--- a/serlib/ser_cemitcodes.mli
+++ b/serlib/ser_cemitcodes.mli
@@ -1,4 +1,26 @@
+(************************************************************************)
+(*         *   The Coq Proof Assistant / The Coq Development Team       *)
+(*  v      *   INRIA, CNRS and contributors - Copyright 1999-2018       *)
+(* <O___,, *       (see CREDITS file for the list of authors)           *)
+(*   \VV/  **************************************************************)
+(*    //   *    This file is distributed under the terms of the         *)
+(*         *     GNU Lesser General Public License Version 2.1          *)
+(*         *     (see LICENSE file for the text of the license)         *)
+(************************************************************************)
+
+(************************************************************************)
+(* Coq serialization API/Plugin                                         *)
+(* Copyright 2016-2019 MINES ParisTech                                  *)
+(* Written by: Emilio J. Gallego Arias                                  *)
+(************************************************************************)
+(* Status: Very Experimental                                            *)
+(************************************************************************)
+
 open Sexplib
+
+(* type body_code = Cemitcodes.body_code
+ * val sexp_of_to_patch_substituted : to_patch_substituted -> Sexp.t
+ * val to_patch_substituted_of_sexp : Sexp.t -> to_patch_substituted *)
 
 type to_patch_substituted = Cemitcodes.to_patch_substituted
 

--- a/serlib/ser_declarations.mli
+++ b/serlib/ser_declarations.mli
@@ -80,6 +80,10 @@ type mutual_inductive_body = Declarations.mutual_inductive_body
 val mutual_inductive_body_of_sexp : Sexp.t -> mutual_inductive_body
 val sexp_of_mutual_inductive_body : mutual_inductive_body -> Sexp.t
 
+type structure_body = Declarations.structure_body
+val sexp_of_structure_body : structure_body -> Sexp.t
+val structure_body_of_sexp : Sexp.t -> structure_body
+
 type module_body = Declarations.module_body
 val sexp_of_module_body : module_body -> Sexp.t
 val module_body_of_sexp : Sexp.t -> module_body

--- a/serlib/ser_entries.ml
+++ b/serlib/ser_entries.ml
@@ -76,3 +76,15 @@ type parameter_entry =
 type 'a constant_entry =
   [%import: 'a Entries.constant_entry]
   [@@deriving sexp]
+
+type seff_env =
+  [%import: Entries.seff_env]
+  [@@deriving sexp]
+
+type side_effect_role =
+  [%import: Entries.side_effect_role]
+  [@@deriving sexp]
+
+type side_eff =
+  [%import: Entries.side_eff]
+  [@@deriving sexp]

--- a/serlib/ser_names.ml
+++ b/serlib/ser_names.ml
@@ -184,6 +184,14 @@ type constructor = [%import: Names.constructor] [@@deriving sexp]
 (* Projection: private *)
 module Projection = struct
 
+  module Repr = struct
+    type t =
+      { proj_ind : inductive;
+        proj_npars : int;
+        proj_arg : int;
+        proj_name : Label.t; }
+  end
+
   type t = [%import: Names.Projection.t]
 
   type _projection = Projection of Constant.t * bool

--- a/serlib/ser_names.mli
+++ b/serlib/ser_names.mli
@@ -54,7 +54,19 @@ type variable    = Names.variable
 type inductive   = Names.inductive
 type constructor = Names.constructor
 
-module Projection : SerType.S with type t = Projection.t
+module Projection : sig
+
+  include SerType.S with type t = Projection.t
+
+  module Repr : sig
+    type t =
+      { proj_ind : inductive;
+        proj_npars : int;
+        proj_arg : int;
+        proj_name : Label.t; }
+  end
+
+end
 
 type projection  = Names.Projection.t
 

--- a/serlib/ser_safe_typing.ml
+++ b/serlib/ser_safe_typing.ml
@@ -17,24 +17,50 @@
 (************************************************************************)
 
 open Sexplib
+open Sexplib.Std
 
+module CEphemeron = Ser_cEphemeron
+module Declarations = Ser_declarations
 module Entries = Ser_entries
 module Cooking = Ser_cooking
 
-(* This is easy to fix, it is just Term_typing.side_effects *)
+(* Side_effects *)
+type side_effect = {
+  from_env : Declarations.structure_body CEphemeron.key;
+  eff      : Entries.side_eff list;
+} [@@deriving sexp]
+
+module SeffOrd = struct
+type t = side_effect
+let compare e1 e2 =
+  let open Names in
+  let open Entries in
+  let cmp e1 e2 = Constant.CanOrd.compare e1.seff_constant e2.seff_constant in
+  Util.List.compare cmp e1.eff e2.eff
+let t_of_sexp = side_effect_of_sexp
+let sexp_of_t = sexp_of_side_effect
+end
+
+module SeffSet = Set.Make(SeffOrd)
+module SerSeffSet = Ser_cSet.Make(SeffSet)(SeffOrd)
+
+type _t = { seff : side_effect list; elts : SerSeffSet.t }
+ [@@deriving sexp]
+
+type _private_constants = _t
+ [@@deriving sexp]
+
 type private_constants = Safe_typing.private_constants
 
-let sexp_of_private_constants _ =
-  Serlib_base.sexp_of_opaque ~typ:"Safe_typing.private_constants"
-let private_constants_of_sexp _ =
-  Serlib_base.opaque_of_sexp ~typ:"Safe_typing.private_constants"
+let sexp_of_private_constants x = sexp_of__private_constants (Obj.magic x)
+let private_constants_of_sexp x = Obj.magic (_private_constants_of_sexp x)
 
 type 'a effect_entry =
   [%import: 'a Safe_typing.effect_entry]
   [@@deriving sexp_of]
 
 (* XXX: Typical GADT Problem *)
-let effect_entry_of_sexp (_f : Sexp.t -> 'a) (x : Sexp.t) : 'a effect_entry =
+let _effect_entry_of_sexp (_f : Sexp.t -> 'a) (x : Sexp.t) : 'a effect_entry =
   let open Sexp in
   match x with
   | Atom "PureEntry" ->
@@ -46,7 +72,22 @@ let effect_entry_of_sexp (_f : Sexp.t -> 'a) (x : Sexp.t) : 'a effect_entry =
 
 type global_declaration =
   [%import: Safe_typing.global_declaration]
-  [@@deriving sexp_of]
+  (* [@@deriving sexp_of] *)
+
+let sexp_of_global_declaration (x : global_declaration) : Sexp.t =
+  let open Sexp in
+  match x with
+  | ConstantEntry (d, ce) -> (
+      match d with
+      | PureEntry ->
+        let sce = Entries.sexp_of_constant_entry (fun _ -> List []) ce in
+        List [Atom "ConstantEntry"; Atom "PureEntry"; sce]
+      | EffectEntry ->
+        let sce = Entries.sexp_of_constant_entry sexp_of_private_constants ce in
+        List [Atom "ConstantEntry"; Atom "EffectEntry"; sce]
+    )
+  | GlobalRecipe recipe ->
+    List [Atom "GlobalRecipe"; Cooking.sexp_of_recipe recipe]
 
 (* XXX: Typical existential type problem *)
 let global_declaration_of_sexp (x : Sexp.t) =
@@ -55,9 +96,16 @@ let global_declaration_of_sexp (x : Sexp.t) =
   | List [Atom "ConstantEntry"; ef; ce] ->
     (* This not sound, we should match on ef and pass the right
        serializer for the private constants *)
-    ConstantEntry (effect_entry_of_sexp (fun x -> x) ef,
-                   Entries.constant_entry_of_sexp (fun x -> x) ce)
+    begin match ef with
+    | Atom "PureEntry" ->
+      ConstantEntry (PureEntry, Entries.constant_entry_of_sexp (fun _ -> ()) ce)
+    | Atom "EffectEntry" ->
+      ConstantEntry (EffectEntry, Entries.constant_entry_of_sexp private_constants_of_sexp ce)
+    | _ ->
+      Sexplib.Conv_error.no_variant_match ()
+    end
   | List [Atom "GlobalRecipe"; cr] ->
     GlobalRecipe (Cooking.recipe_of_sexp cr)
-  | _ ->
+  | exp ->
+    Format.eprintf "no for: %a@\n%!" Sexp.pp_hum exp;
     Sexplib.Conv_error.no_variant_match ()

--- a/serlib/ser_safe_typing.mli
+++ b/serlib/ser_safe_typing.mli
@@ -19,8 +19,8 @@
 open Sexplib
 
 type private_constants = Safe_typing.private_constants
-val private_constants_of_sexp : 'a -> Sexp.t -> private_constants
-val sexp_of_private_constants : 'a -> private_constants -> Sexp.t
+val private_constants_of_sexp : Sexp.t -> private_constants
+val sexp_of_private_constants : private_constants -> Sexp.t
 
 type global_declaration = Safe_typing.global_declaration
 val global_declaration_of_sexp : Sexp.t -> global_declaration


### PR DESCRIPTION
Side effects in the GADT where tricky to encode due to limitations of
the serializers.

Anyways, ppx_sexp_conv is doing something strange in the `sexp_of`
case for the `global_declaration` GADT; I had to manually code the
serializer, but it should work a bit better IMO.