### PR TITLE
[serapi] Output location on tokenization.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -21,6 +21,7 @@
              fix by @SkySkimmer.
  * [sertop]  Fix backtrace printing when using `--debug` (@ejgallego)
  * [serlib ] Don't serialize VM values (@ejgallego, bug report by @palmskog)
+ * [serapi ] Output location on tokenization (@ejgallego , idea by @palmskog)
 
 ## Version 0.6.0:
 

--- a/serapi/serapi_protocol.mli
+++ b/serapi/serapi_protocol.mli
@@ -56,7 +56,7 @@ type coq_object =
   | CoqPp        of Pp.t
   (* | CoqRichpp    of Richpp.richpp *)
   | CoqLoc       of Loc.t
-  | CoqTok       of Tok.t list
+  | CoqTok       of Tok.t CAst.t list
   | CoqAst       of Vernacexpr.vernac_control Loc.located
   | CoqOption    of Goptions.option_name * Goptions.option_state
   | CoqConstr    of Constr.constr

--- a/sertop/sertop_ser.ml
+++ b/sertop/sertop_ser.ml
@@ -83,6 +83,7 @@ let _ =
 (******************************************************************************)
 
 module Loc      = Ser_loc
+module CAst     = Ser_cAst
 module Pp       = Ser_pp
 module Names    = Ser_names
 module Environ  = Ser_environ


### PR DESCRIPTION
We now output the location of tokens in the input stream, and provide
sercomp with the ability to tokenize.

@palmskog I will add a sercomp tokenization mode soon.