### PR TITLE
[build] Drop support for OCaml 4.06.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,8 +33,7 @@ env:
   # Main test suites
   - SERAPI_COQ_HOME="$HOME/coq-$COQ_VERSION/"
   matrix:
-  - TEST_TARGET="build"   COMPILER="4.06.1"
-  - TEST_TARGET="build"   COMPILER="4.07.1"
+  - TEST_TARGET="build"   COMPILER="4.07.0"
   - TEST_TARGET="test"    COMPILER="4.07.1"
   - TEST_TARGET="js-dune" COMPILER="4.07.1+32bit" EXTRA_OPAM="js_of_ocaml js_of_ocaml-lwt ppx_deriving_yojson"
   # Don't test opam in 8.10 [yet]

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
              upstream changes. (@ejgallego)
  * [serlib]  Complete (hopefully) serialization for ssreflect ASTs.
              (#73 @ejgallego)
+ * [general] Drop support for OCaml < 4.07 (#140 @ejgallego)
 
 ## Version 0.6.1:
 

--- a/coq-serapi.opam
+++ b/coq-serapi.opam
@@ -11,7 +11,7 @@ license:      "GPL 3"
 doc:          "https://ejgallego.github.io/coq-serapi/"
 
 depends: [
-  "ocaml"         { >= "4.06.0"           }
+  "ocaml"         { >= "4.07.0"           }
   "coq"           { >= "8.9.0" & < "8.10" }
   "cmdliner"      { >= "1.0.0"            }
   "ocamlfind"     { >= "1.8.0"            }

--- a/serlib/ser_constrexpr.ml
+++ b/serlib/ser_constrexpr.ml
@@ -100,6 +100,7 @@ and branch_expr = [%import: Constrexpr.branch_expr]
 (* and binder_expr = [%import: Constrexpr.binder_expr] *)
 and fix_expr    = [%import: Constrexpr.fix_expr]
 and cofix_expr  = [%import: Constrexpr.cofix_expr]
+and recursion_order_expr_r = [%import: Constrexpr.recursion_order_expr_r]
 and recursion_order_expr = [%import: Constrexpr.recursion_order_expr]
 and local_binder_expr    = [%import: Constrexpr.local_binder_expr]
 and constr_notation_substitution = [%import: Constrexpr.constr_notation_substitution]

--- a/serlib/ser_environ.ml
+++ b/serlib/ser_environ.ml
@@ -15,6 +15,7 @@
 
 open Sexplib.Conv
 
+module Stdlib = Ser_stdlib
 module CEphemeron = Ser_cEphemeron
 module Range  = Ser_range
 module Names  = Ser_names
@@ -42,18 +43,6 @@ type named_context_val =
 type link_info =
   [%import: Environ.link_info]
   [@@deriving sexp]
-
-(* For 4.06 *)
-module Pervasives = struct
-  type nonrec 'a ref = 'a ref
-    [@@deriving sexp]
-end
-
-(* For 4.07 *)
-module Stdlib = struct
-  type nonrec 'a ref = 'a ref
-    [@@deriving sexp]
-end
 
 type key = 
   [%import: Environ.key]

--- a/serlib/ser_genintern.ml
+++ b/serlib/ser_genintern.ml
@@ -17,6 +17,7 @@
 
 open Sexplib.Conv
 
+module Stdlib     = Ser_stdlib
 module Names      = Ser_names
 module Environ    = Ser_environ
 module Glob_term  = Ser_glob_term
@@ -30,11 +31,6 @@ module Store = struct
   let t_of_sexp _ = CErrors.user_err Pp.(str "[GI Store: Cannot deserialize stores.")
   let sexp_of_t _ = Sexplib.Sexp.Atom "[GENINTERN STORE]"
 
-end
-
-module Stdlib = struct
-  type nonrec 'a ref = 'a ref
-  [@@deriving sexp]
 end
 
 type intern_variable_status =

--- a/serlib/ser_glob_term.ml
+++ b/serlib/ser_glob_term.ml
@@ -76,11 +76,17 @@ type cases_pattern =
   [%import: Glob_term.cases_pattern]
   [@@deriving sexp]
 
+type glob_recarg =
+  [%import: Glob_term.glob_recarg]
+  [@@deriving sexp]
+
+type glob_fix_kind =
+  [%import: Glob_term.glob_fix_kind]
+  [@@deriving sexp]
+
 type 'a glob_constr_r        = [%import: 'a Glob_term.glob_constr_r]
 and 'a glob_constr_g         = [%import: 'a Glob_term.glob_constr_g]
 and 'a glob_decl_g           = [%import: 'a Glob_term.glob_decl_g]
-and 'a fix_recursion_order_g = [%import: 'a Glob_term.fix_recursion_order_g]
-and 'a fix_kind_g            = [%import: 'a Glob_term.fix_kind_g]
 and 'a predicate_pattern_g   = [%import: 'a Glob_term.predicate_pattern_g]
 and 'a tomatch_tuple_g       = [%import: 'a Glob_term.tomatch_tuple_g]
 and 'a tomatch_tuples_g      = [%import: 'a Glob_term.tomatch_tuples_g]
@@ -94,13 +100,6 @@ type glob_constr =
 
 type glob_decl =
   [%import: Glob_term.glob_decl]
-  [@@deriving sexp]
-
-type fix_recursion_order =
-  [%import: Glob_term.fix_recursion_order]
-  [@@deriving sexp]
-
-type fix_kind            = [%import: Glob_term.fix_kind]
   [@@deriving sexp]
 
 type predicate_pattern   = [%import: Glob_term.predicate_pattern]

--- a/serlib/ser_glob_term.mli
+++ b/serlib/ser_glob_term.mli
@@ -37,8 +37,6 @@ type cases_pattern    = Glob_term.cases_pattern
 
 type glob_constr        = Glob_term.glob_constr
 and glob_decl           = Glob_term.glob_decl
-and fix_recursion_order = Glob_term.fix_recursion_order
-and fix_kind            = Glob_term.fix_kind
 and predicate_pattern   = Glob_term.predicate_pattern
 and tomatch_tuple       = Glob_term.tomatch_tuple
 and tomatch_tuples      = Glob_term.tomatch_tuples
@@ -56,12 +54,6 @@ val sexp_of_glob_constr : glob_constr -> Sexp.t
 
 val glob_decl_of_sexp : Sexp.t -> glob_decl
 val sexp_of_glob_decl : glob_decl -> Sexp.t
-
-val fix_recursion_order_of_sexp : Sexp.t -> fix_recursion_order
-val sexp_of_fix_recursion_order : fix_recursion_order -> Sexp.t
-
-val fix_kind_of_sexp : Sexp.t -> fix_kind
-val sexp_of_fix_kind : fix_kind -> Sexp.t
 
 val predicate_pattern_of_sexp : Sexp.t -> predicate_pattern
 val sexp_of_predicate_pattern : predicate_pattern -> Sexp.t

--- a/serlib/ser_stdlib.ml
+++ b/serlib/ser_stdlib.ml
@@ -1,0 +1,24 @@
+(************************************************************************)
+(*  v      *   The Coq Proof Assistant  /  The Coq Development Team     *)
+(* <O___,, *   INRIA - CNRS - LIX - LRI - PPS - Copyright 1999-2016     *)
+(*   \VV/  **************************************************************)
+(*    //   *      This file is distributed under the terms of the       *)
+(*         *       GNU Lesser General Public License Version 2.1        *)
+(************************************************************************)
+
+(************************************************************************)
+(* Coq serialization API/Plugin                                         *)
+(* Copyright 2016-2019 MINES ParisTech                                  *)
+(************************************************************************)
+(* Status: Experimental                                                 *)
+(************************************************************************)
+
+open Sexplib.Conv
+
+type nonrec 'a ref = 'a ref
+[@@deriving sexp]
+
+module Lazy = struct
+  type 'a t = 'a lazy_t
+  [@@deriving sexp]
+end

--- a/serlib/ser_univ.ml
+++ b/serlib/ser_univ.ml
@@ -16,6 +16,7 @@
 open Sexplib
 open Sexplib.Conv
 
+module Stdlib = Ser_stdlib
 module Names = Ser_names
 
 module RawLevel = struct
@@ -195,21 +196,6 @@ type explanation =
   [%import: Univ.explanation]
   [@@deriving sexp]
 
-(* This problem seems due to packing in OCaml 4.07.0 *)
-module Stdlib = struct
-module Lazy = struct
-
-  type 'a t = 'a Lazy.t
-  let t_of_sexp = lazy_t_of_sexp
-  let sexp_of_t = sexp_of_lazy_t
-
-end
-end
-
-(* For 4.06.0 *)
-module Lazy = Stdlib.Lazy
-
 type univ_inconsistency =
   [%import: Univ.univ_inconsistency]
   [@@deriving sexp]
-


### PR DESCRIPTION
After 4.05.0 we have to provide qualified serializers for core OCaml
types such as `ref` or `Lazy.t`; not worth supporting 4.06.0 anymore
on the 0.7.0 series.