### PR TITLE
[js] Update to newer jsCoq Coq JS package format.

### DIFF
--- a/jscoq/coq-js/dune
+++ b/jscoq/coq-js/dune
@@ -1,7 +1,6 @@
 (library
  (name jscoq_lib)
- (preprocess (pps ppx_deriving_yojson))
- (wrapped false)
+ (preprocess (staged_pps lwt_ppx js_of_ocaml.ppx ppx_import ppx_deriving_yojson))
  (optional)
  (flags :standard -w -39)
- (libraries yojson ppx_deriving_yojson.runtime js_of_ocaml-lwt))
+ (libraries yojson ppx_deriving_yojson.runtime js_of_ocaml-lwt coq.stm))

--- a/jscoq/coq-js/jslib.ml
+++ b/jscoq/coq-js/jslib.ml
@@ -12,34 +12,25 @@
  * this module separated from Coq
  *)
 
-type digest  = Digest.t
-type _digest = string
-[@@deriving yojson]
+type digest =
+  [%import: Digest.t]
+  [@@deriving yojson]
 
-type json = Yojson.Safe.json [@ocaml.warning "-3"]
+type coq_pkg =
+  { pkg_id    : string list
+  ; vo_files  : (string * digest) list
+  ; cma_files : (string * digest) list
+  } [@@deriving yojson]
 
-let digest_of_yojson j =
-  let open Result in
-  match _digest_of_yojson j with
-  | Ok s    -> Ok (Digest.from_hex s)
-  | Error e -> Error e
-
-let digest_to_yojson s = _digest_to_yojson (Digest.to_hex s)
-
-type coq_pkg = {
-  pkg_id    : string list;
-  vo_files  : (string * digest) list;
-  cma_files : (string * digest) list;
-}
-[@@deriving yojson]
-
-type coq_bundle = {
-  desc      : string;
-  deps      : string list;
-  pkgs      : coq_pkg list;
-}
-[@@deriving yojson]
-
-let to_dir   pkg = String.concat "/" (pkg.pkg_id)
-let to_desc  pkg = String.concat "." (pkg.pkg_id)
+let to_dir   pkg = String.concat "/" pkg.pkg_id
+let to_desc  pkg = String.concat "." pkg.pkg_id
 let no_files pkg = List.length pkg.vo_files + List.length pkg.cma_files
+
+type coq_bundle =
+  { desc      : string
+  ; deps      : string list
+  ; pkgs      : coq_pkg list
+  ; archive   : string option [@default None]
+  ; modDeps   : Yojson.Safe.t option [@default None]
+  } [@@deriving yojson]
+

--- a/jscoq/coq-js/jslib.mli
+++ b/jscoq/coq-js/jslib.mli
@@ -12,30 +12,27 @@
  * this module separated from Coq
  *)
 
+(* JSON handling *)
 type coq_pkg = {
   pkg_id    : string list;
   vo_files  : (string * Digest.t) list;
   cma_files : (string * Digest.t) list;
 }
 
+val coq_pkg_to_yojson : coq_pkg -> Yojson.Safe.t
+val coq_pkg_of_yojson : Yojson.Safe.t -> (coq_pkg, string) Result.result
+
+val to_dir  : coq_pkg -> string
+val to_desc : coq_pkg -> string
+val no_files : coq_pkg -> int
+
 type coq_bundle = {
   desc      : string;
   deps      : string list;
   pkgs      : coq_pkg list;
+  archive   : string option;
+  modDeps   : Yojson.Safe.t option;
 }
 
-val to_dir  : coq_pkg -> string
-val to_desc : coq_pkg -> string
-
-val no_files : coq_pkg -> int
-
-(* JSON handling *)
-(* XXX Use PPX *)
-type json = Yojson.Safe.json [@ocaml.warning "-3"]
-
-val coq_pkg_to_yojson : coq_pkg -> json
-val coq_pkg_of_yojson : json -> (coq_pkg, string) Result.result
-
-val coq_bundle_to_yojson : coq_bundle -> json
-val coq_bundle_of_yojson : json -> (coq_bundle, string) Result.result
-
+val coq_bundle_to_yojson : coq_bundle -> Yojson.Safe.t
+val coq_bundle_of_yojson : Yojson.Safe.t -> (coq_bundle, string) Result.result

--- a/jscoq/coq-js/jslibmng.ml
+++ b/jscoq/coq-js/jslibmng.ml
@@ -1,7 +1,7 @@
 (* JsCoq/SerAPI
  *
- * Copyright (C) 2016-2018 Emilio J. Gallego Arias
- * Copyright (C) 2016-2018 Mines ParisTech
+ * Copyright (C) 2016-2019 Emilio J. Gallego Arias
+ * Copyright (C) 2016-2019 Mines ParisTech
  *
  * LICENSE: GPLv3+
  *)
@@ -14,15 +14,18 @@
 open Jslib
 open Lwt
 open Js_of_ocaml
-open Js_of_ocaml_lwt
+module JL = Js_of_ocaml_lwt
 
 let verb = false
 
+external dummy : unit -> unit = "MlFakeDevice_monkeypatch"
+let _ = dummy ()
+
 (* Main file_cache, indexed by url *)
-type cache_entry = {
-  file_content : string  ; (* file_content is backed by a TypedArray, thanks to @hhugo *)
-  md5          : Digest.t;
-}
+type cache_entry =
+  { file_content : string   (* file_content is backed by a TypedArray, thanks to @hhugo *)
+  ; md5          : Digest.t
+  }
 
 (* Number of actual files in a full distribution ~ 2000 *)
 let file_cache : (string, cache_entry) Hashtbl.t = Hashtbl.create 503
@@ -30,31 +33,35 @@ let file_cache : (string, cache_entry) Hashtbl.t = Hashtbl.create 503
 (* The cma resolver cache maps a cma module to its actual path. *)
 let cma_cache : (string, string) Hashtbl.t = Hashtbl.create 103
 
-type progress_info = {
-  bundle : string;
-  pkg    : string;
-  loaded : int;
-  total  : int;
-}
+type progress_info =
+  { bundle : string
+  ; pkg    : string
+  ; loaded : int
+  ; total  : int
+  }
 
 type lib_event =
   | LibInfo     of string * coq_bundle  (* Information about the bundle, we could well put the json here *)
   | LibProgress of progress_info        (* Information about loading progress *)
-  | LibLoaded   of string               (* Bundle [pkg] is loaded *)
+  | LibLoaded   of string * coq_bundle  (* Bundle [pkg] is loaded *)
 
 type out_fn = lib_event -> unit
 
+exception DynLinkFailed of string
+
+let is_bytecode file = Filename.(check_suffix file "cma" || check_suffix file "cmo")
+
 let preload_file ?(refresh=false) base_path base_url (file, _hash) : unit Lwt.t =
-  let open XmlHttpRequest                           in
+  let open JL.XmlHttpRequest                        in
   if verb then Format.eprintf "preload_request: %s / %s\n%!" base_path base_url;
-  let js_file = if Filename.(check_suffix file "cma"
-                          || check_suffix file "cmo")
-                then (Hashtbl.add cma_cache file base_url;
-                      file ^ ".js")
-                else file                               in
-  let full_url    = base_url  ^ "/" ^ js_file           in
-  let request_url = base_path ^ full_url                in
-  let cached      = Hashtbl.mem file_cache full_url     in
+
+  (* Cache the directory to workaround deficient Coq code *)
+  if is_bytecode file then Hashtbl.add cma_cache file base_url;
+  (* Load a js file for bytecode requests                           *)
+  let req_file    = file ^ (if is_bytecode file then ".js" else "") in
+  let full_url    = base_url  ^ "/" ^ file                          in
+  let request_url = base_path ^ "/" ^ base_url ^ "/" ^ req_file     in
+  let cached      = Hashtbl.mem file_cache full_url                 in
 
   (* Only reload if not cached or a refresh is requested *)
   if not cached || refresh then begin
@@ -73,7 +80,7 @@ let preload_file ?(refresh=false) base_path base_url (file, _hash) : unit Lwt.t 
          if verb then Format.eprintf "cache_add_entry: %s\n%!" full_url;
          Hashtbl.add file_cache full_url cache_entry;
          (* Warm the file cache to workaround a deficient jsoo is_directory implementation *)
-         ignore(Sys.file_exists full_url)
+         ignore(Sys.file_exists full_url);
       );
   Lwt.return_unit
   end
@@ -93,92 +100,154 @@ let preload_pkg ?(verb=false) out_fn base_path bundle pkg : unit Lwt.t =
     out_fn (LibProgress { bundle; pkg = pkg_dir; loaded = i+nc+1; total = nfiles });
     Lwt.return_unit
   in
-  Lwt_list.iteri_p (preload_and_log 0   ) pkg.cma_files <&>
-  Lwt_list.iteri_p (preload_and_log ncma) pkg.vo_files  >>= fun () ->
+  Lwt_list.iteri_s (preload_and_log 0   ) pkg.cma_files <&>
+  Lwt_list.iteri_s (preload_and_log ncma) pkg.vo_files  >>= fun () ->
   (* We don't emit a package loaded event for now *)
   (* out_fn (LibLoadedPkg bundle pkg); *)
   Lwt.return_unit
 
 let parse_bundle base_path file : coq_bundle Lwt.t =
-  let open XmlHttpRequest in
+  let open JL.XmlHttpRequest in
   let file_url = base_path ^ file ^ ".json" in
-  get file_url >>= (fun res ->
-      match Jslib.coq_bundle_of_yojson
-              (Yojson.Safe.from_string res.content) with
-      | Result.Ok bundle -> return bundle
-      | Result.Error s   -> Format.eprintf "JSON error in preload_from_file\n%!";
-                            Lwt.fail (Failure s)
-    )
+  get file_url >>= fun res ->
+  match Jslib.coq_bundle_of_yojson (Yojson.Safe.from_string res.content) with
+  | Result.Ok bundle -> return bundle
+  | Result.Error s   ->
+    Format.eprintf "JSON parsing error in parse_bundle for file %s: %s\n%!" file s;
+    Lwt.fail (Failure s)
+  | exception Yojson.Json_error s ->
+    Format.eprintf "JSON conversion error in parse_bundle for file %s: %s\n%!" file s;
+    Lwt.fail (Failure s)
+
+let load_under_way = ref ([])
+
+let only_once lref s =
+  if List.mem s !lref then false
+  else begin
+    lref := !lref @ [s]; true
+  end
 
 (* Load a bundle *)
-let rec preload_from_file ?(verb=false) out_fn base_path file =
-  parse_bundle base_path file >>= (fun bundle ->
-  (* Load deps in paralell *)
-  Lwt_list.iter_p (preload_from_file ~verb:verb out_fn base_path) bundle.deps           <&>
-  Lwt_list.iter_p (preload_pkg ~verb:verb out_fn base_path file) bundle.pkgs  >>= fun () ->
-  return @@ out_fn (LibLoaded file))
+let rec preload_from_file ?(verb=false) out_fn base_path bundle_name =
+  if only_once load_under_way bundle_name then
+    try%lwt
+      parse_bundle base_path bundle_name >>= fun bundle ->
+      (* Load sub-packages in parallel *)
+      Lwt_list.iter_p (preload_pkg ~verb:verb out_fn base_path bundle_name) bundle.pkgs  >>= fun () ->
+      return @@ out_fn (LibLoaded (bundle_name, bundle))
+    with
+    | Failure _ ->
+    Lwt.return_unit
+  else
+    Lwt.return_unit
 
 let info_from_file out_fn base_path file =
-  parse_bundle base_path file >>= (fun bundle ->
-  return @@ out_fn (LibInfo (file, bundle)))
+  try%lwt
+    parse_bundle base_path file >>= fun bundle ->
+    return @@ out_fn (LibInfo (file, bundle))
+  with
+  | Failure _ ->
+    Lwt.return_unit
 
 let info_pkg out_fn base_path pkgs =
   Lwt_list.iter_p (info_from_file out_fn base_path) pkgs
 
 (* Hack *)
 let load_pkg out_fn base_path pkg_file =
-  preload_from_file out_fn base_path pkg_file >>= fun () ->
-  parse_bundle base_path pkg_file
+  preload_from_file out_fn base_path pkg_file (*>>= fun () ->
+  parse_bundle base_path pkg_file *)
 
 (* let _is_bad_url _ = false *)
 
 (* XXX: Wait until we have enough UI support for logging *)
 let coq_vo_req url =
-  if verb then Format.eprintf "url %s requested\n%!" url; (* with category info *)
   (* if not @@ is_bad_url url then *)
-  try let c_entry = Hashtbl.find file_cache url in
-    (* Jslog.printf Jslog.jscoq_log "coq_resource_req %s\n%!" (Js.to_string url); *)
+  try
+    let c_entry = Hashtbl.find file_cache url in
     Some c_entry.file_content
   with
-    (* coq_vo_reg is also invoked throught the Sys.file_exists call
-     * in mltop:file_of_name function, a good example on how to be
-     * too smart for your own good $:-)
-     *
-     * Sadly coq only uses this information to determine if it will
-     * load a cmo/cma file, not to guess the path...
-     *)
-  | Not_found ->
-    (* We check vs the true filesystem, even if unfortunately the
-       cache has to be used in coq_cma_req below :(
+  | Not_found -> None
 
-       Maybe we can fix this pitfall for 8.7 :/
-    *)
-    (* Format.eprintf "check path %s\n%!" url; *)
-    if Filename.(check_suffix url "cma" || check_suffix url "cmo") then
-      let js_file = Hashtbl.find cma_cache url ^ "/" ^ url ^ ".js" in
-      if verb then Format.eprintf "trying js %s\n%!" js_file;
-      try let c_entry = Hashtbl.find file_cache js_file in
-        Some c_entry.file_content
-      with Not_found -> None
-    else None
+(* coq_vo_reg is also invoked throught the Sys.file_exists call
+ * in mltop:file_of_name function, a good example on how to be
+ * too smart for your own good $:-)
+ *
+ * Sadly coq only uses this information to determine if it will
+ * load a cmo/cma file, not to guess the path...
+ *)
 
-let coq_cma_link cma =
+let coq_vo_req url =
+  if verb then Format.eprintf "url %s requested\n%!" url; (* with category info *)
+  match coq_vo_req url with
+  | Some file -> Some file
+  | None ->
+    if verb then Format.eprintf "url request for %s FAILED\n%!" url; (* with category info *)
+    None
+
+let coq_cma_link cmo_file =
   let open Format in
-  if verb then eprintf "bytecode file %s requested\n%!" cma;
-  try
-    let cma_path = Hashtbl.find cma_cache cma  in
-    (* Now, the js file should be in the file cache *)
-    let js_file = cma_path ^ "/" ^ cma ^ ".js" in
-    if verb then eprintf "requesting load of %s\n%!" js_file;
-    try
-      let js_code = (Hashtbl.find file_cache js_file).file_content in
-      (* When eval'ed, the js_code will return a closure waiting for the
-         jsoo global object to link the plugin.
-      *)
-      Js.Unsafe.((eval_string ("(" ^ js_code ^ ")") : < .. > Js.t -> unit) global)
+  if verb then eprintf "bytecode file %s requested\n%!" cmo_file;
+  let cmo_file =
+    try Hashtbl.find cma_cache cmo_file ^ "/" ^ cmo_file
     with
     | Not_found ->
-      eprintf "cache inconsistecy for %s !! \n%!" cma;
+      eprintf "!! cache inconsistency for file %s\n%!" cmo_file;
+      cmo_file
+  in
+  Feedback.feedback (Feedback.FileDependency(Some cmo_file, cmo_file));
+  try
+    (* let js_code = (Hashtbl.find file_cache cmo_file).file_content in *)
+    let js_code =
+      try (Hashtbl.find file_cache cmo_file).file_content
+      with Not_found -> Sys_js.read_file ~name:(cmo_file ^ ".js") in
+    (* When eval'ed, the js_code will return a closure waiting for the
+       jsoo global object to link the plugin.
+    *)
+    Js.Unsafe.((eval_string ("(" ^ js_code ^ ")") : < .. > Js.t -> unit) global);
+    Feedback.feedback (Feedback.FileLoaded(cmo_file, cmo_file));
   with
-  | Not_found ->
-    eprintf "!! bytecode file %s not found in path\n%!" cma
+  | Sys_error _ ->
+    eprintf "!! bytecode file %s not found in path. DYNLINK FAILED\n%!" cmo_file;
+    raise @@ DynLinkFailed cmo_file
+
+let register_cma ~file_path =
+  let filename = Filename.basename file_path in
+  let dir = Filename.dirname file_path in
+  Hashtbl.add cma_cache filename dir
+
+let rec last = function
+    | [] -> None
+    | [x] -> Some x
+    | _ :: t -> last t
+
+let path_to_coqpath ?(implicit=false) ?(unix_prefix=[]) lib_path =
+  let phys_path =  (* HACK to allow manual override of dir path *)
+    if last unix_prefix = Some "." then unix_prefix
+                                   else unix_prefix @ lib_path
+  in
+  Mltop.{
+    path_spec = VoPath {
+        unix_path = String.concat "/" phys_path;
+        coq_path = Names.(DirPath.make @@ List.rev_map Id.of_string lib_path);
+        has_ml = AddTopML;
+        implicit = implicit;
+      };
+    recursive = false;
+  }
+
+let coqpath_of_bundle ?(implicit=false) bundle =
+  List.map (fun pkg ->
+    path_to_coqpath ~implicit pkg.pkg_id
+  ) bundle.pkgs
+
+let path_of_dirpath dirpath =
+  Names.(List.rev_map Id.to_string (DirPath.repr dirpath))
+
+let module_name_of_qualid qualid =
+  let (dirpath, id) = Libnames.repr_qualid qualid in
+  (path_of_dirpath dirpath) @ [Names.Id.to_string id]
+
+(* let module_name_of_reference ref =
+ *   match ref with
+ *   | Libnames.Ident id -> [Names.Id.to_string id]
+ *   | Libnames.Qualid qid -> module_name_of_qualid qid *)

--- a/jscoq/coq-js/jslibmng.mli
+++ b/jscoq/coq-js/jslibmng.mli
@@ -1,5 +1,5 @@
 (* JsCoq
- * Copyright (C) 2016 Emilio Gallego / Mines ParisTech
+ * Copyright (C) 2016-2019 Emilio Gallego / Mines ParisTech
  *
  * LICENSE: GPLv3+
  *)
@@ -10,17 +10,17 @@
  * loading in the browser.
 *)
 
-type progress_info = {
-  bundle : string;
-  pkg    : string;
-  loaded : int;
-  total  : int;
-}
+type progress_info =
+  { bundle : string
+  ; pkg    : string
+  ; loaded : int
+  ; total  : int
+  }
 
 type lib_event =
   | LibInfo     of string * Jslib.coq_bundle (* Information about the bundle, we could well put the json here *)
   | LibProgress of progress_info             (* Information about loading progress *)
-  | LibLoaded   of string                    (* Bundle [pkg] is loaded *)
+  | LibLoaded   of string * Jslib.coq_bundle (* Bundle [pkg] is loaded *)
 
 type out_fn = lib_event -> unit
 
@@ -29,7 +29,7 @@ type out_fn = lib_event -> unit
 val info_pkg : out_fn -> string -> string list -> unit Lwt.t
 
 (** [load_pkg base_path pkg_file] loads package [pkg_file] *)
-val load_pkg : out_fn -> string -> string -> Jslib.coq_bundle Lwt.t
+val load_pkg : out_fn -> string -> string -> unit Lwt.t
 (** [info_pkg lib_path available_pkg ] gather package list
     [available_pkg] from directory [lib_path] *)
 
@@ -38,3 +38,14 @@ val coq_vo_req  : string -> string option
 
 (** [coq_cma_link cma] dynlinks the bytecode plugin [cma] *)
 val coq_cma_link : string -> unit
+
+val is_bytecode : string -> bool
+val register_cma : file_path:string -> unit
+
+(* auxiliary functions to create and process paths *)
+val path_to_coqpath : ?implicit:bool -> ?unix_prefix:string list -> string list -> Mltop.coq_path
+val coqpath_of_bundle : ?implicit:bool -> Jslib.coq_bundle -> Mltop.coq_path list
+
+val path_of_dirpath : Names.DirPath.t -> string list
+val module_name_of_qualid : Libnames.qualid -> string list
+(* val module_name_of_reference : Libnames.reference_r -> string list *)

--- a/jscoq/coq-libjs/coq_vm.js
+++ b/jscoq/coq-libjs/coq_vm.js
@@ -1,124 +1,204 @@
-//Provides: init_coq_vm
+// Provides: vm_ll
+function vm_ll(s, args) { 
+  if (vm_ll.log) joo_global_object.console.warn(s, args); 
+  if (vm_ll.trap) throw new Error("vm trap: '"+ s + "' not implemented");
+}
+
+vm_ll.log = false;     // whether to log calls
+vm_ll.trap = false;    // whether to halt on calls
+
+// Provides: init_coq_vm
+// Requires: vm_ll
 function init_coq_vm() {
+  vm_ll('init_coq_vm', arguments);
   return;
 }
 
 // EG: Coq VM's code is evil and performs static initialization... the
 // best option would be to disable the VM code entirely as before.
 
-//Provides: accumulate_code
+// Provides: coq_vm_trap
+// Requires: vm_ll
+function coq_vm_trap() {    // will cause future calls to vm code to fault
+  vm_ll.log = vm_ll.trap = true;  // (called after initialization)
+}
+
+// Provides: accumulate_code
+// Requires: vm_ll
 function accumulate_code() {
   // EG: Where the hell is that called from
+  vm_ll('accumulate_code', arguments);
   return [];
 }
 
-//Provides: coq_pushpop
+// Provides: coq_pushpop
+// Requires: vm_ll
 function coq_pushpop() {
+  vm_ll('coq_pushpop', arguments);
   return [];
 }
 
 // Provides: coq_closure_arity
+// Requires: vm_ll
 function coq_closure_arity() {
+  vm_ll('coq_closure_arity', arguments);
   return [];
 }
 
 // Provides: coq_eval_tcode
+// Requires: vm_ll
 function coq_eval_tcode() {
+  vm_ll('coq_eval_tcode', arguments);
   return [];
 }
 
 // Provides: coq_int_tcode
+// Requires: vm_ll
 function coq_int_tcode() {
+  vm_ll('coq_int_tcode', arguments);
   return [];
 }
 
 // Provides: coq_interprete_ml
+// Requires: vm_ll
 function coq_interprete_ml() {
+  vm_ll('coq_interprete_ml', arguments);
   return [];
 }
 
 // Provides: coq_is_accumulate_code
+// Requires: vm_ll
 function coq_is_accumulate_code() {
+  vm_ll('coq_is_accumulate_code', arguments);
   return [];
 }
 
 // Provides: coq_kind_of_closure
+// Requires: vm_ll
 function coq_kind_of_closure() {
+  vm_ll('coq_kind_of_closure', arguments);
   return [];
 }
 
 // Provides: coq_makeaccu
+// Requires: vm_ll
 function coq_makeaccu() {
+  vm_ll('coq_makeaccu', arguments);
   return [];
 }
 
 // Provides: coq_offset
+// Requires: vm_ll
 function coq_offset() {
+  vm_ll('coq_offset', arguments);
   return [];
 }
 
 // Provides: coq_offset_closure
+// Requires: vm_ll
 function coq_offset_closure() {
+  vm_ll('coq_offset_closure', arguments);
   return [];
 }
 
 // Provides: coq_offset_tcode
+// Requires: vm_ll
 function coq_offset_tcode() {
+  vm_ll('coq_offset_tcode', arguments);
   return [];
 }
 
 // Provides: coq_push_arguments
+// Requires: vm_ll
 function coq_push_arguments() {
+  vm_ll('coq_push_arguments', arguments);
   return [];
 }
 
 // Provides: coq_push_ra
+// Requires: vm_ll
 function coq_push_ra() {
+  vm_ll('coq_push_ra', arguments);
   return [];
 }
 
 // Provides: coq_push_val
+// Requires: vm_ll
 function coq_push_val() {
+  vm_ll('coq_push_val', arguments);
   return [];
 }
 
 // Provides: coq_push_vstack
+// Requires: vm_ll
 function coq_push_vstack() {
+  vm_ll('coq_push_vstack', arguments);
   return [];
 }
 
 // Provides: coq_set_transp_value
+// Requires: vm_ll
 function coq_set_transp_value() {
+  vm_ll('coq_set_transp_value', arguments);
   return [];
 }
 
+// Provides: coq_set_bytecode_field
+// Requires: vm_ll
+function coq_set_bytecode_field() {
+  vm_ll('coq_set_bytecode_field', arguments);
+  return [0];
+}
+
 // Provides: coq_tcode_of_code
+// Requires: vm_ll
 function coq_tcode_of_code() {
+  vm_ll('coq_tcode_of_code', arguments);
   return [];
 }
 
 // Provides: get_coq_atom_tbl
+// Requires: vm_ll
 function get_coq_atom_tbl() {
   // First element of the array is the length!
+  vm_ll('get_coq_atom_tbl', arguments);
   return [0];
 }
 
 // Provides: get_coq_global_data
+// Requires: vm_ll
 function get_coq_global_data() {
+  vm_ll('get_coq_global_data', arguments);
   return [];
 }
 
 // Provides: get_coq_transp_value
+// Requires: vm_ll
 function get_coq_transp_value() {
+  vm_ll('get_coq_transp_value', arguments);
   return [];
 }
 
 // Provides: realloc_coq_atom_tbl
+// Requires: vm_ll
 function realloc_coq_atom_tbl() {
+  vm_ll('realloc_coq_atom_tbl', arguments);
   return;
 }
 
 // Provides: realloc_coq_global_data
+// Requires: vm_ll
 function realloc_coq_global_data() {
+  vm_ll('realloc_coq_global_data', arguments);
   return;
 }
+
+// Provides: coq_interprete_byte
+// Requires: vm_ll
+function coq_interprete_byte()    { vm_ll('coq_interprete_byte', arguments); }
+// Provides: coq_set_drawinstr
+// Requires: vm_ll
+function coq_set_drawinstr()      { vm_ll('coq_set_drawinstr', arguments); }
+// Provides: coq_tcode_array
+// Requires: vm_ll
+function coq_tcode_array()        { vm_ll('coq_tcode_array', arguments); }

--- a/jscoq/coq-libjs/marshal.js
+++ b/jscoq/coq-libjs/marshal.js
@@ -1,0 +1,191 @@
+/**
+ * A few overrides for Marshal and channel primitives which seem to be buggy
+ * or inefficient in js_of_ocaml.
+ * (we will report them and hopefully they will get fixed upstream.)
+ */
+
+//Provides: caml_output_val
+//Requires: caml_int64_to_bytes, caml_failwith
+//Requires: caml_int64_bits_of_float
+//Requires: MlBytes, caml_ml_string_length, caml_string_unsafe_get
+/**
+ * This is a modified version of caml_output_val that correctly reflects
+ * sharing, and as a result, avoids duplication and saves a lot of space.
+ */
+var caml_output_val = function (){
+  function Writer () { this.chunk = []; }
+  Writer.prototype = {
+    chunk_idx:20, block_len:0, obj_counter:0, size_32:0, size_64:0,
+    write:function (size, value) {
+      for (var i = size - 8;i >= 0;i -= 8)
+        this.chunk[this.chunk_idx++] = (value >> i) & 0xFF;
+    },
+    write_code:function (size, code, value) {
+      this.chunk[this.chunk_idx++] = code;
+      for (var i = size - 8;i >= 0;i -= 8)
+        this.chunk[this.chunk_idx++] = (value >> i) & 0xFF;
+    },
+    write_shared:function (offset) {
+      if (offset < (1 << 8)) this.write_code(8, 0x04 /*cst.CODE_SHARED8*/, offset);
+      else if (offset < (1 << 16)) this.write_code(16, 0x05 /*cst.CODE_SHARED16*/, offset);
+      else this.write_code(32, 0x06 /*cst.CODE_SHARED32*/, offset);
+    },
+    finalize:function () {
+      this.block_len = this.chunk_idx - 20;
+      this.chunk_idx = 0;
+      this.write (32, 0x8495A6BE);
+      this.write (32, this.block_len);
+      this.write (32, this.obj_counter);
+      this.write (32, this.size_32);
+      this.write (32, this.size_64);
+      return this.chunk;
+    }
+  }
+  return function (v) {
+    var writer = new Writer ();
+    var stack = [];
+    var intern_obj_table = [];
+    
+    function store(v) { intern_obj_table.push(v); writer.obj_counter = intern_obj_table.length; }
+    function recall(v) {
+        for (var i = 0; i < intern_obj_table.length; i++) {
+            if (intern_obj_table[i] === v) return intern_obj_table.length - i;
+        }
+    }
+
+    function memo(v) {
+        var existing_offset = recall(v);
+        if (existing_offset) { writer.write_shared(existing_offset); return existing_offset; }
+        else store(v);
+    }
+
+    function extern_rec (v) {
+      if (v instanceof Array && v[0] === (v[0]|0)) {
+        if (v[0] == 255) {
+          // Int64
+          if (memo(v)) return;
+          writer.write (8, 0x12 /*cst.CODE_CUSTOM*/);
+          for (var i = 0; i < 3; i++) writer.write (8, "_j\0".charCodeAt(i));
+          var b = caml_int64_to_bytes (v);
+          for (var i = 0; i < 8; i++) writer.write (8, b[i]);
+          writer.size_32 += 4;
+          writer.size_64 += 3;
+          return;
+        }
+        if (v[0] == 251) {
+          caml_failwith("output_value: abstract value (Abstract)");
+        }
+        if (v.length > 1 && memo(v)) return;
+        if (v[0] < 16 && v.length - 1 < 8)
+          writer.write (8, 0x80 /*cst.PREFIX_SMALL_BLOCK*/ + v[0] + ((v.length - 1)<<4));
+        else
+          writer.write_code(32, 0x08 /*cst.CODE_BLOCK32*/, ((v.length-1) << 10) | v[0]);
+        writer.size_32 += v.length;
+        writer.size_64 += v.length;
+        if (v.length > 1) stack.push (v, 1);
+      } else if (v instanceof MlBytes) {
+        if (memo(v)) return;
+        var len = caml_ml_string_length(v);
+        if (len < 0x20)
+          writer.write (8, 0x20 /*cst.PREFIX_SMALL_STRING*/ + len);
+        else if (len < 0x100)
+          writer.write_code (8, 0x09/*cst.CODE_STRING8*/, len);
+        else
+          writer.write_code (32, 0x0A /*cst.CODE_STRING32*/, len);
+        for (var i = 0;i < len;i++)
+          writer.write (8, caml_string_unsafe_get(v,i));
+        writer.size_32 += 1 + (((len + 4) / 4)|0);
+        writer.size_64 += 1 + (((len + 8) / 8)|0);
+      } else {
+        if (v != (v|0)){
+          var type_of_v = typeof v;
+//
+// If a float happens to be an integer it is serialized as an integer
+// (Js_of_ocaml cannot tell whether the type of an integer number is
+// float or integer.) This can result in unexpected crashes when
+// unmarshalling using the standard runtime. It seems better to
+// systematically fail on marshalling.
+//
+//          if(type_of_v != "number")
+          caml_failwith("output_value: abstract value ("+type_of_v+")");
+//          var t = caml_int64_to_bytes(caml_int64_bits_of_float(v));
+//          writer.write (8, 0x0B /*cst.CODE_DOUBLE_BIG*/);
+//          for(var i = 0; i<8; i++){writer.write(8,t[i])}
+        }
+        else if (v >= 0 && v < 0x40) {
+          writer.write (8, 0X40 /*cst.PREFIX_SMALL_INT*/ + v);
+        } else {
+          if (v >= -(1 << 7) && v < (1 << 7))
+            writer.write_code(8, 0x00 /*cst.CODE_INT8*/, v);
+          else if (v >= -(1 << 15) && v < (1 << 15))
+            writer.write_code(16, 0x01 /*cst.CODE_INT16*/, v);
+          else
+            writer.write_code(32, 0x02 /*cst.CODE_INT32*/, v);
+        }
+      }
+    }
+    extern_rec (v);
+    while (stack.length > 0) {
+      var i = stack.pop ();
+      var v = stack.pop ();
+      if (i + 1 < v.length) stack.push (v, i + 1);
+      extern_rec (v[i]);
+    }
+    writer.finalize ();
+    return writer.chunk;
+  }
+} ();
+
+
+//Provides: caml_ml_pos_out
+//Requires: caml_ml_channels, caml_ml_flush
+function caml_ml_pos_out(chanid) {
+  caml_ml_flush(chanid);    /* [offset] is not reliable in output streams until buffer is flushed */
+  return caml_ml_channels[chanid].offset;
+}
+
+/*
+   The following seem to suffer from the same problem, but we are not using
+   them so it is hard to test.
+
+//Provides: caml_ml_pos_out_64
+//Requires: caml_int64_of_float, caml_ml_channels, caml_ml_flush
+function caml_ml_pos_out_64(chanid) {
+  caml_ml_flush(chanid);   
+  return caml_int64_of_float (caml_ml_channels[chanid].offset);
+}
+
+//Provides: caml_ml_seek_out
+//Requires: caml_ml_channels, caml_ml_flush
+function caml_ml_seek_out(chanid,pos){
+  caml_ml_channels[chanid].offset = pos;
+  return 0;
+}
+
+//Provides: caml_ml_seek_out_64
+//Requires: caml_int64_to_float, caml_ml_channels, caml_ml_flush
+function caml_ml_seek_out_64(chanid,pos){
+  caml_ml_flush(chanid);   
+  caml_ml_channels[chanid].offset = caml_int64_to_float(pos);
+  return 0;
+}
+
+*/
+
+/**
+ * This monkey-patch is an optimization for loading .vo files using UInt8Array.
+ * The original implementation has a bug where it converts the result to a string.
+ * 
+ * A patch has been submitted upstream. Remove this (and the call in icoq.ml)
+ * once it has been published.
+ */
+
+//Provides: MlFakeDevice_monkeypatch
+//Requires: MlFakeDevice, MlFakeFile, caml_new_string
+MlFakeDevice.prototype.lookup = function(name) {
+  if(!this.content[name] && this.lookupFun) {
+    var res = this.lookupFun(caml_new_string(this.root), caml_new_string(name));
+    if(res/* != 0 */) this.content[name]=new MlFakeFile(res[1]);   // <------------------------
+  }
+}
+function MlFakeDevice_monkeypatch() { }

--- a/jscoq/coq-libjs/str.js
+++ b/jscoq/coq-libjs/str.js
@@ -1,13 +1,188 @@
+//Provides: str_ll
+function str_ll(s, args) { if (str_ll.log) joo_global_object.console.warn(s, args); }
+str_ll.log = false;
+
 //Provides: re_string_match
-function re_string_match() {
-  // external re_string_match : regexp -> string -> int -> bool
-  console.log("re_string_match called from Str, danger");
-  return false;
+//Requires: str_ll, re_match
+function re_string_match(re, s, pos) {
+  // external re_string_match : regexp -> string -> int -> int array
+  str_ll('re_string_match', arguments);
+  var res = re_match(re, s, pos, 0);
+  return (res === 0) ? [0] : res;
 }
 
 //Provides: re_search_forward
-function re_search_forward() {
+//Requires: str_ll, re_search_forward_naive
+function re_search_forward(re, s, pos) {
   // external re_search_forward: regexp -> string -> int -> int array
-  console.log("re_search_forward called from Str, danger");
-  return [];
+  str_ll('re_search_forward', arguments);
+  return re_search_forward_naive(re, s, pos);
+}
+
+//Provides: re_partial_match
+//Requires: str_ll
+// external re_partial_match: regexp -> string -> int -> int array
+function re_partial_match()          { str_ll('re_partial_match', arguments);     return [0]; }
+//Provides: re_replacement_text
+//Requires: str_ll
+// external re_replacement_text: string -> int array -> string -> string
+function re_replacement_text(r,a,s)  { str_ll('re_replacement_text', arguments);  return s; }
+//Provides: re_search_backward
+//Requires: str_ll
+// external re_search_backward: regexp -> string -> int -> int array
+function re_search_backward()        { str_ll('re_search_backward', arguments);   return [0]; }
+
+//Provides: re_match
+// Based on
+// https://github.com/ocaml/ocaml/blob/4.07/otherlibs/str/strstubs.c
+
+var re_match = function(){
+
+  var opcodes = {
+      CHAR: 0, CHARNORM: 1, STRING: 2, STRINGNORM: 3, CHARCLASS: 4,
+      BOL: 5, EOL: 6, WORDBOUNDARY: 7,
+      BEGGROUP: 8, ENDGROUP: 9, REFGROUP: 10,
+      ACCEPT: 11,
+      SIMPLEOPT: 12, SIMPLESTAR: 13, SIMPLEPLUS: 14,
+      GOTO: 15, PUSHBACK: 16, SETMARK: 17,
+      CHECKPROGRESS: 18
+  };
+
+  function in_bitset(s,i) {
+      return (s.c.charCodeAt(i >> 3) >> (i & 7)) & 1;
+  }
+
+  function re_match_impl(re, s, pos, partial) {
+
+      var prog          = re[1].slice(1),
+          cpool         = re[2].slice(1),
+          numgroups     = re[4],
+          numregisters  = re[5],
+          startchars    = re[6];
+
+      var pc = 0, quit = false, txt = s.c,
+          stack = [],
+          groups = new Array(numgroups).fill(0).map(function () { return {}; }),
+          re_register = new Array(numregisters);
+
+      groups[0].start = pos;
+
+      var backtrack = function () {
+          while (stack.length) {
+              var item = stack.pop(), obj, prop;
+              if (item.undo) {
+                  [obj, prop] = item.undo.loc;
+                  obj[prop] = item.undo.value;
+              }
+              else {
+                  [pc, pos] = [item.pos.pc, item.pos.txt];
+                  return;
+              }
+          }
+          quit = true;
+      };
+      var push = function(item) { stack.push(item); };
+
+
+      var accept = function () { return Array.prototype.concat.apply([0],
+          groups.map(function (g) { return g.start >= 0 && g.end >= 0 ? [g.start, g.end] : [-1, -1]; })) };
+
+      /* Main DFA interpreter loop */
+      while (!quit) {
+          var op = prog[pc] & 0xff,
+              sarg = prog[pc] >> 8,
+              uarg = sarg & 0xff,
+              c = txt.charCodeAt(pos),
+              group;
+
+          pc++;
+
+          switch (op) {
+              case opcodes.CHAR:
+              case opcodes.CHARNORM:
+                  if (c === uarg) pos++;
+                  else backtrack();
+                  break;
+              case opcodes.STRING:
+              case opcodes.STRINGNORM:
+                  for (var w = cpool[uarg].c, i = 0; i < w.length; i++) {
+                      if (c === w.charCodeAt(i))
+                          c = txt.charCodeAt(++pos);
+                      else { backtrack(); break; }
+                  }
+                  break;
+              case opcodes.CHARCLASS:
+                  if (!isNaN(c) && in_bitset(cpool[uarg], c)) pos++;
+                  else backtrack();
+                  break;
+
+              case opcodes.BEGGROUP:
+                  group = groups[uarg];
+                  push({undo: {loc: [group, 'start'],
+                               value: group.start}});
+                  group.start = pos;
+                  break;
+              case opcodes.ENDGROUP:
+                  group = groups[uarg];
+                  push({undo: {loc: [group, 'end'],
+                               value: group.end}});
+                  group.end = pos;
+                  break;
+
+              case opcodes.SIMPLEOPT:
+                  if (!isNaN(c) && in_bitset(cpool[uarg], c)) pos++;
+                  break;
+              case opcodes.SIMPLESTAR:
+                  while (!isNaN(c) && in_bitset(cpool[uarg], c))
+                      c = txt.charCodeAt(++pos);
+                  break;
+              case opcodes.SIMPLEPLUS:
+                  if (!isNaN(c) && in_bitset(cpool[uarg], c)) {
+                      do {
+                          c = txt.charCodeAt(++pos);
+                      } while (!isNaN(c) && in_bitset(cpool[uarg], c));
+                  }
+                  else backtrack();
+                  break;
+
+              case opcodes.ACCEPT:
+                  groups[0].end = pos;
+                  return accept();
+
+              case opcodes.GOTO:
+                  pc = pc + sarg;
+                  break;
+              case opcodes.PUSHBACK:
+                  push({pos: {pc: pc + sarg, txt: pos}});
+                  break;
+              case opcodes.SETMARK:
+                  push({undo: {loc: [re_register, uarg], value: re_register[uarg]}});
+                  re_register[uarg] = pos;
+                  break;
+              case opcodes.CHECKPROGRESS:
+                  if (re_register[uarg] === pos) backtrack();
+                  break;
+
+              default:
+                  throw new Error("unimplemented regexp opcode " + op + "(" + sarg + ")");
+          }
+      }
+
+      return 0;
+  }
+
+  return re_match_impl;
+}();
+
+
+//Provides: re_search_forward_naive
+//Requires: re_match
+function re_search_forward_naive(re, s, pos) {
+    while (pos < s.l) {
+        var res = re_match(re, s, pos);
+        if (res) return res;
+        pos++;
+    }
+
+    return [0];  /* [||] : int array */
 }

--- a/jscoq/coq-libjs/unix.js
+++ b/jscoq/coq-libjs/unix.js
@@ -1,7 +1,13 @@
-// Whether to log.
-var v_log = false;
-function ll(s) { if (v_log) console.log(s); }
+//Provides: unix_ll
+function unix_ll(s, args) { 
+  if (unix_ll.log) joo_global_object.console.warn(s, args); 
+  if (unix_ll.trap) throw new Error("unix trap: '"+ s + "' not implemented");
+}
+unix_ll.log = true;       // whether to log calls
+unix_ll.trap = false;     // whether to halt on calls
 
+//Provides: caml_raise_unix_error
+//Requires: caml_named_value, caml_raise_with_arg, caml_new_string
 function caml_raise_unix_error(msg) {
   var tag = caml_named_value("Unix.Unix_error");
   // var util = require('util');
@@ -10,216 +16,532 @@ function caml_raise_unix_error(msg) {
 }
 
 //Provides: unix_access
+//Requires: unix_ll
 function unix_access() {
-  // ll("unix_access");
+  unix_ll("unix_access", arguments);
   return 0;
 }
 
 //Provides: unix_alarm
+//Requires: unix_ll
 function unix_alarm() {
-  // ll("unix_alarm");
+  unix_ll("unix_alarm", arguments);
   return 0;
 }
 
 //Provides: unix_bind
+//Requires: unix_ll
 function unix_bind() {
-  // ll("unix_bind");
+  unix_ll("unix_bind", arguments);
   return 0;
 }
 
 //Provides: unix_close
+//Requires: unix_ll
 function unix_close() {
-  // ll("unix_close");
+  unix_ll("unix_close", arguments);
   return 0;
 }
 
 //Provides: unix_connect
+//Requires: unix_ll
 function unix_connect() {
-  // ll("unix_connect");
+  unix_ll("unix_connect", arguments);
   return 0;
 }
 
 //Provides: unix_dup
+//Requires: unix_ll
 function unix_dup() {
-  // ll("unix_dup");
+  unix_ll("unix_dup", arguments);
   return 0;
 }
 
 //Provides: unix_dup2
+//Requires: unix_ll
 function unix_dup2() {
-  // ll("unix_dup2");
+  unix_ll("unix_dup2", arguments);
   return 0;
 }
 
 //Provides: unix_environment
+//Requires: unix_ll
 function unix_environment() {
-  // ll("unix_environment");
+  unix_ll("unix_environment", arguments);
   return 0;
 }
 
 //Provides: unix_error_message
+//Requires: unix_ll
 function unix_error_message() {
-  // ll("unix_error_message");
+  unix_ll("unix_error_message", arguments);
   return 0;
 }
 
 //Provides: unix_execve
+//Requires: unix_ll
 function unix_execve() {
-  // ll("unix_execve");
+  unix_ll("unix_execve", arguments);
   return 0;
 }
 
 //Provides: unix_execvp
+//Requires: unix_ll
 function unix_execvp() {
-  // ll("unix_execvp");
+  unix_ll("unix_execvp", arguments);
   return 0;
 }
 
 //Provides: unix_execvpe
+//Requires: unix_ll
 function unix_execvpe() {
-  // ll("unix_execvpe");
+  unix_ll("unix_execvpe", arguments);
   return 0;
 }
 
 //Provides: unix_getcwd
+//Requires: unix_ll
 function unix_getcwd() {
-  // ll("unix_getcwd");
+  unix_ll("unix_getcwd", arguments);
   return 0;
 }
 
 //Provides: unix_fork
+//Requires: unix_ll
 function unix_fork() {
-  // ll("unix_fork");
+  unix_ll("unix_fork", arguments);
   return 0;
 }
 
 //Provides: unix_getpid
+//Requires: unix_ll
 function unix_getpid() {
-  // ll("unix_getpid");
+  unix_ll("unix_getpid", arguments);
   return 0;
 }
 
 //Provides: unix_getpwnam
+//Requires: unix_ll
 function unix_getpwnam() {
-  // ll("unix_getpwnam");
+  unix_ll("unix_getpwnam", arguments);
   return 0;
 }
 
 //Provides: unix_getsockname
+//Requires: unix_ll
 function unix_getsockname() {
-  // ll("unix_getsockname");
+  unix_ll("unix_getsockname", arguments);
   return 0;
 }
 
 //Provides: unix_isatty
+//Requires: unix_ll
 function unix_isatty() {
-  // ll("unix_isatty");
+  unix_ll("unix_isatty", arguments);
   return 0;
 }
 
 //Provides: unix_kill
+//Requires: unix_ll
 function unix_kill() {
-  // ll("unix_kill");
+  unix_ll("unix_kill", arguments);
   return 0;
 }
 
 //Provides: unix_listen
+//Requires: unix_ll
 function unix_listen() {
-  // ll("unix_listen");
+  unix_ll("unix_listen", arguments);
   return 0;
 }
 
 //Provides: unix_mkdir
+//Requires: unix_ll
 function unix_mkdir() {
-  // ll("unix_mkdir");
+  unix_ll("unix_mkdir", arguments);
   return 0;
 }
 //Provides: unix_pipe
+//Requires: unix_ll
 function unix_pipe() {
-  // ll("unix_pipe");
+  unix_ll("unix_pipe", arguments);
   return 0;
 }
 
 //Provides: unix_read
+//Requires: unix_ll
 function unix_read() {
-  // ll("unix_read");
+  unix_ll("unix_read", arguments);
   return 0;
 }
 
 //Provides: unix_opendir
+//Requires: unix_ll
 function unix_opendir(dir) {
-  // ll("unix_opendir");
+  unix_ll("unix_opendir", arguments);
 
-  // caml_raise_unix_error("opendir");
+  // caml_raise_unix_error("opendir", arguments);
   return [];
 }
 
 //Provides: unix_readdir
-//Requires: caml_raise_constant, caml_global_data
+//Requires: unix_ll, caml_raise_constant, caml_global_data
 function unix_readdir(dir) {
-  // ll("unix_readdir");
+  unix_ll("unix_readdir", arguments);
 
-  // caml_raise_unix_error("readdir");
+  // caml_raise_unix_error("readdir", arguments);
   caml_raise_constant(caml_global_data.End_of_file);
   return [];
 }
 
 //Provides: unix_closedir
+//Requires: unix_ll
 function unix_closedir() {
-  // ll("unix_closedir");
+  unix_ll("unix_closedir", arguments);
   return [];
 }
 
 //Provides: unix_select
+//Requires: unix_ll
 function unix_select() {
-  // ll("unix_select");
+  unix_ll("unix_select", arguments);
   return 0;
 }
 
 //Provides: unix_set_close_on_exec
+//Requires: unix_ll
 function unix_set_close_on_exec() {
-  // ll("unix_set_close_on_exec");
+  unix_ll("unix_set_close_on_exec", arguments);
   return 0;
 }
 
 //Provides: unix_set_nonblock
+//Requires: unix_ll
 function unix_set_nonblock() {
-  // ll("unix_set_nonblock");
+  unix_ll("unix_set_nonblock", arguments);
   return 0;
 }
 
 //Provides: unix_sleep
+//Requires: unix_ll
 function unix_sleep() {
-  // ll("unix_sleep");
+  unix_ll("unix_sleep", arguments);
   return 0;
 }
 
 //Provides: unix_socket
+//Requires: unix_ll
 function unix_socket() {
-  // ll("unix_socket");
+  unix_ll("unix_socket", arguments);
   return 0;
 }
 
 //Provides: unix_string_of_inet_addr
+//Requires: unix_ll
 function unix_string_of_inet_addr() {
-  // ll("unix_string_of_inet_addr");
+  unix_ll("unix_string_of_inet_addr", arguments);
   return 0;
 }
 
 //Provides: unix_times
+//Requires: unix_ll
 function unix_times() {
-  // ll("unix_times");
+  unix_ll("unix_times", arguments);
   return 0;
 }
 
 //Provides: unix_wait
+//Requires: unix_ll
 function unix_wait() {
-  // ll("unix_wait");
+  unix_ll("unix_wait", arguments);
   return 0;
 }
 
 //Provides: unix_waitpid
+//Requires: unix_ll
 function unix_waitpid() {
-  // ll("unix_waitpid");
+  unix_ll("unix_waitpid", arguments);
   return 0;
 }
+
+//Provides: unix_stat
+//Requires: unix_ll
+function unix_stat() {
+  unix_ll("unix_stat", arguments);
+  return 0;
+}
+
+
+// Provides: unix_accept
+// Requires: unix_ll
+function unix_accept()                 { unix_ll("unix_accept", arguments); }
+// Provides: unix_chdir
+// Requires: unix_ll
+function unix_chdir()                  { unix_ll("unix_chdir", arguments); }
+// Provides: unix_chmod
+// Requires: unix_ll
+function unix_chmod()                  { unix_ll("unix_chmod", arguments); }
+// Provides: unix_chown
+// Requires: unix_ll
+function unix_chown()                  { unix_ll("unix_chown", arguments); }
+// Provides: unix_chroot
+// Requires: unix_ll
+function unix_chroot()                 { unix_ll("unix_chroot", arguments); }
+// Provides: unix_clear_close_on_exec
+// Requires: unix_ll
+function unix_clear_close_on_exec()    { unix_ll("unix_clear_close_on_exec", arguments); }
+// Provides: unix_clear_nonblock
+// Requires: unix_ll
+function unix_clear_nonblock()         { unix_ll("unix_clear_nonblock", arguments); }
+// Provides: unix_environment_unsafe
+// Requires: unix_ll
+function unix_environment_unsafe()     { unix_ll("unix_environment_unsafe", arguments); }
+// Provides: unix_execv
+// Requires: unix_ll
+function unix_execv()                  { unix_ll("unix_execv", arguments); }
+// Provides: unix_fchmod
+// Requires: unix_ll
+function unix_fchmod()                 { unix_ll("unix_fchmod", arguments); }
+// Provides: unix_fchown
+// Requires: unix_ll
+function unix_fchown()                 { unix_ll("unix_fchown", arguments); }
+// Provides: unix_fstat
+// Requires: unix_ll
+function unix_fstat()                 { unix_ll("unix_fstat", arguments); }
+// Provides: unix_fstat_64
+// Requires: unix_ll
+function unix_fstat_64()              { unix_ll("unix_fstat_64", arguments); }
+// Provides: unix_ftruncate
+// Requires: unix_ll
+function unix_ftruncate()             { unix_ll("unix_ftruncate", arguments); }
+// Provides: unix_ftruncate_64
+// Requires: unix_ll
+function unix_ftruncate_64()          { unix_ll("unix_ftruncate_64", arguments); }
+// Provides: unix_getaddrinfo
+// Requires: unix_ll
+function unix_getaddrinfo()           { unix_ll("unix_getaddrinfo", arguments); }
+// Provides: unix_getegid
+// Requires: unix_ll
+function unix_getegid()               { unix_ll("unix_getegid", arguments); }
+// Provides: unix_geteuid
+// Requires: unix_ll
+function unix_geteuid()               { unix_ll("unix_geteuid", arguments); }
+// Provides: unix_getgid
+// Requires: unix_ll
+function unix_getgid()                { unix_ll("unix_getgid", arguments); }
+// Provides: unix_getgrgid
+// Requires: unix_ll
+function unix_getgrgid()              { unix_ll("unix_getgrgid", arguments); }
+// Provides: unix_getgrnam
+// Requires: unix_ll
+function unix_getgrnam()              { unix_ll("unix_getgrnam", arguments); }
+// Provides: unix_getgroups
+// Requires: unix_ll
+function unix_getgroups()             { unix_ll("unix_getgroups", arguments); }
+// Provides: unix_gethostbyaddr
+// Requires: unix_ll
+function unix_gethostbyaddr()         { unix_ll("unix_gethostbyaddr", arguments); }
+// Provides: unix_gethostbyname
+// Requires: unix_ll
+function unix_gethostbyname()         { unix_ll("unix_gethostbyname", arguments); }
+// Provides: unix_gethostname
+// Requires: unix_ll
+function unix_gethostname()           { unix_ll("unix_gethostname", arguments); }
+// Provides: unix_getitimer
+// Requires: unix_ll
+function unix_getitimer()             { unix_ll("unix_getitimer", arguments); }
+// Provides: unix_getlogin
+// Requires: unix_ll
+function unix_getlogin()              { unix_ll("unix_getlogin", arguments); }
+// Provides: unix_getnameinfo
+// Requires: unix_ll
+function unix_getnameinfo()           { unix_ll("unix_getnameinfo", arguments); }
+// Provides: unix_getpeername
+// Requires: unix_ll
+function unix_getpeername()           { unix_ll("unix_getpeername", arguments); }
+// Provides: unix_getppid
+// Requires: unix_ll
+function unix_getppid()               { unix_ll("unix_getppid", arguments); }
+// Provides: unix_getprotobyname
+// Requires: unix_ll
+function unix_getprotobyname()        { unix_ll("unix_getprotobyname", arguments); }
+// Provides: unix_getprotobynumber
+// Requires: unix_ll
+function unix_getprotobynumber()      { unix_ll("unix_getprotobynumber", arguments); }
+// Provides: unix_getpwuid
+// Requires: unix_ll
+function unix_getpwuid()              { unix_ll("unix_getpwuid", arguments); }
+// Provides: unix_getservbyname
+// Requires: unix_ll
+function unix_getservbyname()         { unix_ll("unix_getservbyname", arguments); }
+// Provides: unix_getservbyport
+// Requires: unix_ll
+function unix_getservbyport()         { unix_ll("unix_getservbyport", arguments); }
+// Provides: unix_getsockopt
+// Requires: unix_ll
+function unix_getsockopt()            { unix_ll("unix_getsockopt", arguments); }
+// Provides: unix_getuid
+// Requires: unix_ll
+function unix_getuid()                { unix_ll("unix_getuid", arguments); }
+// Provides: unix_has_symlink
+// Requires: unix_ll
+function unix_has_symlink()           { unix_ll("unix_has_symlink", arguments); }
+// Provides: unix_initgroups
+// Requires: unix_ll
+function unix_initgroups()            { unix_ll("unix_initgroups", arguments); }
+// Provides: unix_link
+// Requires: unix_ll
+function unix_link()                  { unix_ll("unix_link", arguments); }
+// Provides: unix_lockf
+// Requires: unix_ll
+function unix_lockf()                 { unix_ll("unix_lockf", arguments); }
+// Provides: unix_lseek
+// Requires: unix_ll
+function unix_lseek()                 { unix_ll("unix_lseek", arguments); }
+// Provides: unix_lseek_64
+// Requires: unix_ll
+function unix_lseek_64()              { unix_ll("unix_lseek_64", arguments); }
+// Provides: unix_lstat
+// Requires: unix_ll
+function unix_lstat()                 { unix_ll("unix_lstat", arguments); }
+// Provides: unix_lstat_64
+// Requires: unix_ll
+function unix_lstat_64()              { unix_ll("unix_lstat_64", arguments); }
+// Provides: unix_mkfifo
+// Requires: unix_ll
+function unix_mkfifo()                { unix_ll("unix_mkfifo", arguments); }
+// Provides: unix_nice
+// Requires: unix_ll
+function unix_nice()                  { unix_ll("unix_nice", arguments); }
+// Provides: unix_open
+// Requires: unix_ll
+function unix_open()                  { unix_ll("unix_open", arguments); }
+// Provides: unix_putenv
+// Requires: unix_ll
+function unix_putenv()                { unix_ll("unix_putenv", arguments); }
+// Provides: unix_readlink
+// Requires: unix_ll
+function unix_readlink()              { unix_ll("unix_readlink", arguments); }
+// Provides: unix_recv
+// Requires: unix_ll
+function unix_recv()                  { unix_ll("unix_recv", arguments); }
+// Provides: unix_recvfrom
+// Requires: unix_ll
+function unix_recvfrom()              { unix_ll("unix_recvfrom", arguments); }
+// Provides: unix_rename
+// Requires: unix_ll
+function unix_rename()                { unix_ll("unix_rename", arguments); }
+// Provides: unix_rewinddir
+// Requires: unix_ll
+function unix_rewinddir()             { unix_ll("unix_rewinddir", arguments); }
+// Provides: unix_rmdir
+// Requires: unix_ll
+function unix_rmdir()                 { unix_ll("unix_rmdir", arguments); }
+// Provides: unix_send
+// Requires: unix_ll
+function unix_send()                  { unix_ll("unix_send", arguments); }
+// Provides: unix_sendto
+// Requires: unix_ll
+function unix_sendto()                { unix_ll("unix_sendto", arguments); }
+// Provides: unix_setgid
+// Requires: unix_ll
+function unix_setgid()                { unix_ll("unix_setgid", arguments); }
+// Provides: unix_setgroups
+// Requires: unix_ll
+function unix_setgroups()             { unix_ll("unix_setgroups", arguments); }
+// Provides: unix_setitimer
+// Requires: unix_ll
+function unix_setitimer()             { unix_ll("unix_setitimer", arguments); }
+// Provides: unix_setsid
+// Requires: unix_ll
+function unix_setsid()                { unix_ll("unix_setsid", arguments); }
+// Provides: unix_setsockopt
+// Requires: unix_ll
+function unix_setsockopt()            { unix_ll("unix_setsockopt", arguments); }
+// Provides: unix_setuid
+// Requires: unix_ll
+function unix_setuid()                { unix_ll("unix_setuid", arguments); }
+// Provides: unix_shutdown
+// Requires: unix_ll
+function unix_shutdown()              { unix_ll("unix_shutdown", arguments); }
+// Provides: unix_sigpending
+// Requires: unix_ll
+function unix_sigpending()            { unix_ll("unix_sigpending", arguments); }
+// Provides: unix_sigprocmask
+// Requires: unix_ll
+function unix_sigprocmask()           { unix_ll("unix_sigprocmask", arguments); }
+// Provides: unix_sigsuspend
+// Requires: unix_ll
+function unix_sigsuspend()            { unix_ll("unix_sigsuspend", arguments); }
+// Provides: unix_single_write
+// Requires: unix_ll
+function unix_single_write()          { unix_ll("unix_single_write", arguments); }
+// Provides: unix_socketpair
+// Requires: unix_ll
+function unix_socketpair()            { unix_ll("unix_socketpair", arguments); }
+// Provides: unix_stat_64
+// Requires: unix_ll
+function unix_stat_64()               { unix_ll("unix_stat_64", arguments); }
+// Provides: unix_symlink
+// Requires: unix_ll
+function unix_symlink()               { unix_ll("unix_symlink", arguments); }
+// Provides: unix_tcdrain
+// Requires: unix_ll
+function unix_tcdrain()               { unix_ll("unix_tcdrain", arguments); }
+// Provides: unix_tcflow
+// Requires: unix_ll
+function unix_tcflow()                { unix_ll("unix_tcflow", arguments); }
+// Provides: unix_tcflush
+// Requires: unix_ll
+function unix_tcflush()               { unix_ll("unix_tcflush", arguments); }
+// Provides: unix_tcgetattr
+// Requires: unix_ll
+function unix_tcgetattr()             { unix_ll("unix_tcgetattr", arguments); }
+// Provides: unix_tcsendbreak
+// Requires: unix_ll
+function unix_tcsendbreak()           { unix_ll("unix_tcsendbreak", arguments); }
+// Provides: unix_tcsetattr
+// Requires: unix_ll
+function unix_tcsetattr()             { unix_ll("unix_tcsetattr", arguments); }
+// Provides: unix_truncate
+// Requires: unix_ll
+function unix_truncate()              { unix_ll("unix_truncate", arguments); }
+// Provides: unix_truncate_64
+// Requires: unix_ll
+function unix_truncate_64()           { unix_ll("unix_truncate_64", arguments); }
+// Provides: unix_umask
+// Requires: unix_ll
+function unix_umask()                 { unix_ll("unix_umask", arguments); }
+// Provides: unix_unlink
+// Requires: unix_ll
+function unix_unlink()                { unix_ll("unix_unlink", arguments); }
+// Provides: unix_utimes
+// Requires: unix_ll
+function unix_utimes()                { unix_ll("unix_utimes", arguments); }
+// Provides: unix_write
+// Requires: unix_ll
+function unix_write()                 { unix_ll("unix_write", arguments); }
+// Provides: caml_channel_descriptor
+// Requires: unix_ll
+function caml_channel_descriptor()   { unix_ll("caml_channel_descriptor", arguments); }
+// Provides: caml_mutex_try_lock
+// Requires: unix_ll
+function caml_mutex_try_lock()       { unix_ll("caml_mutex_try_lock", arguments); }
+// Provides: caml_obj_add_offset
+// Requires: unix_ll
+function caml_obj_add_offset()       { unix_ll("caml_obj_add_offset", arguments); }
+// Provides: caml_sys_unsafe_getenv
+// Requires: unix_ll
+function caml_sys_unsafe_getenv()    { unix_ll("caml_sys_unsafe_getenv", arguments); }
+// Provides: caml_thread_join
+// Requires: unix_ll
+function caml_thread_join()          { unix_ll("caml_thread_join", arguments); }
+// Provides: caml_thread_sigmask
+// Requires: unix_ll
+function caml_thread_sigmask()       { unix_ll("caml_thread_sigmask", arguments); }
+// Provides: caml_unix_map_file_bytecode
+// Requires: unix_ll
+function caml_unix_map_file_bytecode() { unix_ll("caml_unix_map_file_bytecode", arguments); }
+// Provides: caml_wait_signal
+// Requires: unix_ll
+function caml_wait_signal()          { unix_ll("caml_wait_signal", arguments); }

--- a/sertop/dune
+++ b/sertop/dune
@@ -21,6 +21,7 @@
     ../jscoq/coq-libjs/mutex.js
     ../jscoq/coq-libjs/unix.js
     ../jscoq/coq-libjs/str.js
+    ../jscoq/coq-libjs/marshal.js
     ../jscoq/coq-libjs/coq_vm.js)
   (flags :standard --dynlink +nat.js +dynlink.js +toplevel.js))
 ; (flags :standard --dynlink +nat.js +dynlink.js +toplevel.js --pretty --noinline --disable shortvar --debug-info)


### PR DESCRIPTION
We update JS library manager to newer jsCoq code.

This almost works, however, there are some API deficiencies in jsCoq
that must be solved before we can make this function properly.