### PR TITLE
[coq_init] Set `indices_matter` to false, as default in Coq.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,8 @@
              cc #151 (@ejgallego , suggested by @cpitclaudel)
  * [serlib ] JSON support for vernac_expr (@ejgallego)
  * [sertop ] (!) Do as Coq upstream and load Coq's stdlib with `-R` (closes #56)
+ * [sertop ] Follow Coq upstream and unset `indices_matter` (closes #157,
+             thanks to @palmskog for the report)
 
 ## Version 0.6.1:
 

--- a/sertop/sertop_init.ml
+++ b/sertop/sertop_init.ml
@@ -62,7 +62,10 @@ let coq_init opts =
 
   (* Core Coq initialization *)
   Lib.init();
+
+  (* This should be configurable somehow. *)
   Global.set_engagement Declarations.PredicativeSet;
+  Global.set_indices_matter false;
 
   (**************************************************************************)
   (* Feedback setup                                                         *)


### PR DESCRIPTION
Indices matter is `false` by default in coqc/coqtop, however if unset
the kernel defaults to a more restrictive default of `true`.

For compatibility we follow `coqc` and set it to `false` too.

Note that this seems like the only discrepancy.

Closes #157