### PR TITLE
[serapi] Pretty-print exceptions inside `CoqExn` answer.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,8 @@
  * [sertop ] (!) Do as Coq upstream and load Coq's stdlib with `-R` (closes #56)
  * [sertop ] Follow Coq upstream and unset `indices_matter` (closes #157,
              thanks to @palmskog for the report)
+ * [serapi ] (!) Improve CoqExn answer to have pretty-printed message (improves #162,
+             thanks to @cpitclaudel for the request)
 
 ## Version 0.6.1:
 

--- a/serapi/serapi_protocol.mli
+++ b/serapi/serapi_protocol.mli
@@ -437,6 +437,16 @@ type cmd =
 
 exception NoSuchState of Stateid.t
 
+module ExnInfo : sig
+  type t =
+    { loc : Loc.t option
+    ; stm_ids : (Stateid.t * Stateid.t) option
+    ; backtrace : Printexc.raw_backtrace
+    ; exn : exn
+    ; pp : Pp.t
+    }
+end
+
 type answer_kind =
   | Ack
   (** The command was received, Coq is processing it. *)
@@ -448,7 +458,7 @@ type answer_kind =
   (** A set of sentences are not valid anymore. *)
   | ObjList   of coq_object list
   (** Set of objects, usually the answer to a query *)
-  | CoqExn    of Loc.t option * (Stateid.t * Stateid.t) option * Printexc.raw_backtrace * exn
+  | CoqExn    of ExnInfo.t
   (** The command produced an error, optionally at a document location *)
 
 (** {3 Entry points to the DSL evaluator} *)

--- a/sertop/sertop_ser.ml
+++ b/sertop/sertop_ser.ml
@@ -218,12 +218,20 @@ let sexp_of_raw_backtrace (bt : Printexc.raw_backtrace) : Sexp.t =
   let bt = sexp_of_option (sexp_of_array (fun x -> x)) bt in
   Sexp.(List [Atom "Backtrace"; bt])
 
+module ExnInfo = struct
+  type t =
+    [%import: Serapi_protocol.ExnInfo.t
+    [@with
+       Stm.focus := Ser_stm.focus;
+       Printexc.raw_backtrace := raw_backtrace;
+       Stdlib.Printexc.raw_backtrace := raw_backtrace;
+    ]]
+    [@@deriving sexp]
+end
+
 type answer_kind =
   [%import: Serapi_protocol.answer_kind
-  [@with
-     Stm.focus := Ser_stm.focus;
-     Printexc.raw_backtrace := raw_backtrace;
-     Stdlib.Printexc.raw_backtrace := raw_backtrace;
+  [@with Exninfo.t := Exninfo.t;
   ]]
   [@@deriving sexp]
 


### PR DESCRIPTION
This should improve #162 ; note that unfortunately some error wrapping
is still happening upstream so the usefulness of fine-grained `CoqExn`
is not the best yet (cc: coq/coq#9686)