### PR TITLE
Install the serapi and sertop sub-libraries

### DIFF
--- a/serapi/dune
+++ b/serapi/dune
@@ -1,6 +1,6 @@
 (library
  (name serapi)
- ; (public_name coq-serapi.serapi)
+ (public_name coq-serapi.serapi_v8_10)
  (wrapped false)
  (synopsis "Serialization Protocol for Coq")
  (libraries coq.stm coq.plugins.ltac sexplib))

--- a/sertop/dune
+++ b/sertop/dune
@@ -1,5 +1,6 @@
 (library
  (name sertoplib)
+ (public_name coq-serapi.sertop_v8_10)
  (modules :standard \ sertop sercomp sertop_js sertop_async)
  (wrapped false)
  (preprocess (staged_pps ppx_import ppx_sexp_conv))


### PR DESCRIPTION
This PR proposes to install the currently private serapi and sertop sub-libraries, to facilitate the development of out-of-tree programs similar to sertop/sercomp.

As suggested by @ejgallego , the public library names are timestamped with the version, to indicate that the API is unstable.

If this gets merged I plan on submitting a similar PR for the 8.9 branch, that I'm currently using.