### PR TITLE
Install the serapi and sertop sub-libraries

### DIFF
--- a/serapi/dune
+++ b/serapi/dune
@@ -1,6 +1,6 @@
 (library
  (name serapi)
- ; (public_name coq-serapi.serapi)
+ (public_name coq-serapi.serapi_v8_9)
  (wrapped false)
  (synopsis "Serialization Protocol for Coq")
  (libraries coq.stm coq.plugins.ltac sexplib))

--- a/sertop/dune
+++ b/sertop/dune
@@ -1,5 +1,6 @@
 (library
  (name sertoplib)
+ (public_name coq-serapi.sertop_v8_9)
  (modules :standard \ sertop sercomp sertop_js sertop_async)
  (wrapped false)
  (preprocess (staged_pps ppx_import ppx_sexp_conv))


### PR DESCRIPTION
This is the equivalent of #165 but for the 8.9 branch.