### PR TITLE
[sercomp] add goals mode to print some proof goal info

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+## Version 0.7.1:
+
+ * [sercomp] Add `--mode=goals` output format (@palmskog, @ejgallego) #174
+
 ## Version 0.7.0:
 
  * [general] (!) support Coq 8.10,

--- a/sertop/sercomp.ml
+++ b/sertop/sercomp.ml
@@ -124,6 +124,14 @@ let process_vernac ~mode ~pp ~doc ~sid ast =
     | C_sexp ->
       printf "@[%a@]@\n%!" pp
         Serlib.(Ser_cAst.sexp_of_t Ser_vernacexpr.sexp_of_vernac_control ast)
+    | C_goals ->
+       ignore (Stm.observe ~doc:doc n_st);
+       let sg_pre = Serapi_goals.get_goals ~doc:doc n_st in
+       match sg_pre with
+       | Some g ->
+	  let Serapi_goals.{ goals; stack; _ } = g in
+	  printf "%d %d\n%!" (List.length goals) (List.length stack)
+       | None -> printf "- -\n%!"
   in
   doc, n_st
 
@@ -143,6 +151,7 @@ let close_document ~pp ~mode ~doc ~in_file ~pstate =
   | C_parse -> ()
   | C_sexp  -> ()
   | C_print -> ()
+  | C_goals -> ()
   | C_stats ->
     Sercomp_stats.print_stats ()
   | C_check ->

--- a/sertop/sercomp.ml
+++ b/sertop/sercomp.ml
@@ -57,7 +57,7 @@ let create_document ~in_file ~async ~async_workers ~quick ~iload_path ~debug =
 
   let require_libs = ["Coq.Init.Prelude", None, Some false] in
 
-  let ndoc = { Stm.doc_type = Stm.VoDoc in_file
+  let ndoc = { Stm.doc_type = Stm.VioDoc in_file
              ; require_libs
              ; iload_path
              ; stm_options
@@ -125,12 +125,12 @@ let process_vernac ~mode ~pp ~doc ~sid ast =
       printf "@[%a@]@\n%!" pp
         Serlib.(Ser_cAst.sexp_of_t Ser_vernacexpr.sexp_of_vernac_control ast)
     | C_goals ->
-       ignore (Stm.observe ~doc:doc n_st);
+       let doc = Stm.observe ~doc:doc n_st in
        let sg_pre = Serapi_goals.get_goals ~doc:doc n_st in
        match sg_pre with
        | Some g ->
-	  let Serapi_goals.{ goals; stack; _ } = g in
-	  printf "%d %d\n%!" (List.length goals) (List.length stack)
+          let Serapi_goals.{ goals; stack; _ } = g in
+          printf "%d %d\n%!" (List.length goals) (List.length stack)
        | None -> printf "- -\n%!"
   in
   doc, n_st

--- a/sertop/sertop_arg.ml
+++ b/sertop/sertop_arg.ml
@@ -130,7 +130,7 @@ let exn_on_opaque : bool Term.t =
   Arg.(value & flag & info ["exn_on_opaque"] ~doc)
 
 (* sertop options *)
-type comp_mode = | C_parse | C_stats | C_print | C_sexp | C_check | C_vo | C_env
+type comp_mode = | C_parse | C_stats | C_print | C_sexp | C_check | C_vo | C_env | C_goals
 
 let comp_mode_args =
   Arg.(enum
@@ -141,6 +141,7 @@ let comp_mode_args =
          ; "check", C_check
          ; "vo",    C_vo
          ; "kenv",  C_env
+         ; "goals", C_goals
          ])
 
 let comp_mode_doc = Arg.doc_alts
@@ -151,6 +152,7 @@ let comp_mode_doc = Arg.doc_alts
   ; "check: check proofs in the file and remain silent (except for Coq output)"
   ;    "vo: check proofs and output .vo version of the input file"
   ;  "kenv: check proofs and output the final kernel enviroment"
+  ; "goals: check proofs and output proof goal information"
   ]
 
 let comp_mode =

--- a/sertop/sertop_arg.mli
+++ b/sertop/sertop_arg.mli
@@ -36,7 +36,7 @@ val no_init         : bool Term.t
 val no_prelude      : bool Term.t
 
 (* sertop options *)
-type comp_mode = | C_parse | C_stats | C_print | C_sexp | C_check | C_vo | C_env
+type comp_mode = | C_parse | C_stats | C_print | C_sexp | C_check | C_vo | C_env | C_goals
 val comp_mode : comp_mode Term.t
 
 type comp_input = | I_vernac | I_sexp


### PR DESCRIPTION
I'm trying to set up code for serialization via `sercomp` of some proof goal information, but am running into issues. 

Consider the following example (`pi.v`):
```coq
From mathcomp Require Import all_ssreflect.
Lemma filter_pi_of n m : n < m -> filter \pi(n) (index_iota 0 m) = primes n.
move=> lt_n_m; have ltnT := ltn_trans; apply: (eq_sorted_irr ltnT ltnn).
- by rewrite sorted_filter // iota_ltn_sorted.
- exact: sorted_primes.
move=> p; rewrite mem_filter mem_index_iota /= mem_primes; case: and3P => //.
by case=> _ n_gt0 dv_p_n; apply: leq_ltn_trans lt_n_m; apply: dvdn_leq.
Qed.
```
Here, the second sentence results in one proof goal, while the third sentence results in three goals. So I would have expected that `sercomp --mode=goals pi.v` would print something like:
```
0
1
3
...
```
But instead I get:
```
0
1
0
...
```
Is there anything obvious I'm doing wrong?