### PR TITLE
[serlib] Fix ppx_import w.r.t. old-style pack plugin compilation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,13 +30,12 @@ env:
   - COQ_CONF="-local -native-compiler no -coqide no"
   - COMPILER="4.07.1"
   # Main test suites
-  - SERAPI_COQ_HOME="$HOME/coq-$COQ_VERSION/"
   matrix:
-  - TEST_TARGET="build"   COMPILER="4.07.0"
-  - TEST_TARGET="test"    COMPILER="4.07.1"
-  - TEST_TARGET="js-dune" COMPILER="4.07.1+32bit" EXTRA_OPAM="js_of_ocaml js_of_ocaml-lwt"
+  - TEST_TARGET="build"   COMPILER="4.07.1"       EXTRA_OPAM="coq"
+  - TEST_TARGET="test"    COMPILER="4.07.1"       EXTRA_OPAM="coq coq-mathcomp-ssreflect"
+  - TEST_TARGET="js-dune" COMPILER="4.07.1+32bit" EXTRA_OPAM="coq js_of_ocaml js_of_ocaml-lwt"
   # Don't test opam in 8.10 [yet]
-  # - TEST_TARGET="test"                                                                               EXTRA_OPAM="coq"
+  - TEST_TARGET="test"    SERAPI_COQ_HOME="$HOME/coq-$COQ_VERSION/_build/install/default/lib/"
 
 install:
 - sudo curl -sL https://github.com/ocaml/opam/releases/download/2.0.4/opam-2.0.4-x86_64-linux -o /usr/bin/opam
@@ -45,6 +44,7 @@ install:
 - opam switch set "$COMPILER"
 - eval $(opam env)
 # OPAM 2 seems quite broken here
+- opam repos add coq-released http://coq.inria.fr/opam/released
 - opam config set-global jobs $NJOBS
 - opam pin add -y -n --kind=path coq-serapi .
 - opam install -y --deps-only -j $NJOBS coq-serapi
@@ -67,7 +67,7 @@ install:
 script:
 - set -e
 - echo 'Building SerAPI...' && echo -en 'travis_fold:start:serapi.build\\r'
-- make -j "$NJOBS" SERAPI_COQ_HOME="$SERAPI_COQ_HOME/_build/install/default/lib/" "$TEST_TARGET"
+- make -j "$NJOBS" SERAPI_COQ_HOME="$SERAPI_COQ_HOME" "$TEST_TARGET"
 - ls -lR _build/install/default/ || true
 - ls -lR _build/default/sertop/*.js || true
 - echo -en 'travis_fold:end:serapi.build\\r'

--- a/coq-serapi.opam
+++ b/coq-serapi.opam
@@ -16,10 +16,10 @@ depends: [
   "cmdliner"            {           >= "1.0.0"             }
   "ocamlfind"           {           >= "1.8.0"             }
   "sexplib"             {           >= "v0.11.0"           }
-  "dune"                { build   & >= "1.2.0"             }
+  "dune"                {           >= "1.2.0"             }
   "ppx_import"          { build   & >= "1.5-3"             }
-  "ppx_deriving"        { build   & >= "4.2.1"             }
-  "ppx_sexp_conv"       { build   & >= "v0.11.0"           }
+  "ppx_deriving"        {           >= "4.2.1"             }
+  "ppx_sexp_conv"       {           >= "v0.11.0"           }
   "yojson"              {           >= "1.7.0"             }
   "ppx_deriving_yojson" {           >= "3.4"               }
 ]

--- a/serlib/plugins/ltac/ser_tacentries.ml
+++ b/serlib/plugins/ltac/ser_tacentries.ml
@@ -19,6 +19,8 @@ open Serlib
 module Loc   = Ser_loc
 module Names = Ser_names
 
+open Ltac_plugin [@@ocaml.warning "-33"]
+
 type 'a grammar_tactic_prod_item_expr =
   [%import: 'a Ltac_plugin.Tacentries.grammar_tactic_prod_item_expr]
   [@@deriving sexp]

--- a/serlib/plugins/ltac/ser_tacenv.ml
+++ b/serlib/plugins/ltac/ser_tacenv.ml
@@ -26,6 +26,8 @@ module Ltac_plugin = struct
   module Tacenv  = Ltac_plugin.Tacenv
 end
 
+open Ltac_plugin [@@ocaml.warning "-33"]
+
 type ltac_entry =
   [%import: Ltac_plugin.Tacenv.ltac_entry]
   [@@deriving sexp]

--- a/serlib/plugins/ssr/ser_ssrast.ml
+++ b/serlib/plugins/ssr/ser_ssrast.ml
@@ -41,174 +41,174 @@ module Proofview = struct
 end
 
 type ssrhyp =
-  [%import: Ssreflect_plugin.Ssrast.ssrhyp]
+  [%import: Wrap_ssrast.ssrhyp]
   [@@deriving sexp]
 
 type ssrhyp_or_id =
-  [%import: Ssreflect_plugin.Ssrast.ssrhyp_or_id]
+  [%import: Wrap_ssrast.ssrhyp_or_id]
   [@@deriving sexp]
 
 type ssrhyps =
-  [%import: Ssreflect_plugin.Ssrast.ssrhyps]
+  [%import: Wrap_ssrast.ssrhyps]
   [@@deriving sexp]
 
 type ssrdir =
-  [%import: Ssreflect_plugin.Ssrast.ssrdir]
+  [%import: Wrap_ssrast.ssrdir]
   [@@deriving sexp]
 
 type ssrsimpl =
-  [%import: Ssreflect_plugin.Ssrast.ssrsimpl]
+  [%import: Wrap_ssrast.ssrsimpl]
   [@@deriving sexp]
 
 type ssrmmod =
-  [%import: Ssreflect_plugin.Ssrast.ssrmmod]
+  [%import: Wrap_ssrast.ssrmmod]
   [@@deriving sexp]
 
 type ssrmult =
-  [%import: Ssreflect_plugin.Ssrast.ssrmult]
+  [%import: Wrap_ssrast.ssrmult]
   [@@deriving sexp]
 
 type ssrocc =
-  [%import: Ssreflect_plugin.Ssrast.ssrocc]
+  [%import: Wrap_ssrast.ssrocc]
   [@@deriving sexp]
 
 type ssrindex =
-  [%import: Ssreflect_plugin.Ssrast.ssrindex]
+  [%import: Wrap_ssrast.ssrindex]
   [@@deriving sexp]
 
 type ssrclear =
-  [%import: Ssreflect_plugin.Ssrast.ssrclear]
+  [%import: Wrap_ssrast.ssrclear]
   [@@deriving sexp]
 
 type ssrdocc =
-  [%import: Ssreflect_plugin.Ssrast.ssrdocc]
+  [%import: Wrap_ssrast.ssrdocc]
   [@@deriving sexp]
 
 type ssrtermkind =
-  [%import: Ssreflect_plugin.Ssrast.ssrtermkind]
+  [%import: Wrap_ssrast.ssrtermkind]
   [@@deriving sexp]
 
 type ssrterm =
-  [%import: Ssreflect_plugin.Ssrast.ssrterm]
+  [%import: Wrap_ssrast.ssrterm]
   [@@deriving sexp]
 
 type ast_closure_term =
-  [%import: Ssreflect_plugin.Ssrast.ast_closure_term]
+  [%import: Wrap_ssrast.ast_closure_term]
   [@@deriving sexp]
 
 type ssrview =
-  [%import: Ssreflect_plugin.Ssrast.ssrview]
+  [%import: Wrap_ssrast.ssrview]
   [@@deriving sexp]
 
 type anon_kind =
-  [%import: Ssreflect_plugin.Ssrast.anon_kind]
+  [%import: Wrap_ssrast.anon_kind]
   [@@deriving sexp]
 
 (* type anon_iter =
- *   [%import: Ssreflect_plugin.Ssrast.anon_iter]
+ *   [%import: Wrap_ssrast.anon_iter]
  *   [@@deriving sexp] *)
 
 type id_block =
-  [%import: Ssreflect_plugin.Ssrast.id_block]
+  [%import: Wrap_ssrast.id_block]
   [@@deriving sexp]
 
 type ssripat =
-  [%import: Ssreflect_plugin.Ssrast.ssripat]
+  [%import: Wrap_ssrast.ssripat]
   [@@deriving sexp]
 and ssripats =
-  [%import: Ssreflect_plugin.Ssrast.ssripats]
+  [%import: Wrap_ssrast.ssripats]
   [@@deriving sexp]
 and ssripatss =
-  [%import: Ssreflect_plugin.Ssrast.ssripatss]
+  [%import: Wrap_ssrast.ssripatss]
   [@@deriving sexp]
 and ssripatss_or_block =
-  [%import: Ssreflect_plugin.Ssrast.ssripatss_or_block]
+  [%import: Wrap_ssrast.ssripatss_or_block]
   [@@deriving sexp]
 
 type ssrhpats =
-  [%import: Ssreflect_plugin.Ssrast.ssrhpats]
+  [%import: Wrap_ssrast.ssrhpats]
   [@@deriving sexp]
 
 type ssrhpats_wtransp =
-  [%import: Ssreflect_plugin.Ssrast.ssrhpats_wtransp]
+  [%import: Wrap_ssrast.ssrhpats_wtransp]
   [@@deriving sexp]
 
 type ssrintrosarg =
-  [%import: Ssreflect_plugin.Ssrast.ssrintrosarg]
+  [%import: Wrap_ssrast.ssrintrosarg]
   [@@deriving sexp]
 
 type ssrfwdid =
-  [%import: Ssreflect_plugin.Ssrast.ssrfwdid]
+  [%import: Wrap_ssrast.ssrfwdid]
   [@@deriving sexp]
 
 type 'term ssrbind =
-  [%import: 'term Ssreflect_plugin.Ssrast.ssrbind]
+  [%import: 'term Wrap_ssrast.ssrbind]
   [@@deriving sexp]
 
 type ssrbindfmt =
-  [%import: Ssreflect_plugin.Ssrast.ssrbindfmt]
+  [%import: Wrap_ssrast.ssrbindfmt]
   [@@deriving sexp]
 
 type 'term ssrbindval =
-  [%import: 'term Ssreflect_plugin.Ssrast.ssrbindval]
+  [%import: 'term Wrap_ssrast.ssrbindval]
   [@@deriving sexp]
 
 type ssrfwdkind =
-  [%import: Ssreflect_plugin.Ssrast.ssrfwdkind]
+  [%import: Wrap_ssrast.ssrfwdkind]
   [@@deriving sexp]
 
 type ssrfwdfmt =
-  [%import: Ssreflect_plugin.Ssrast.ssrfwdfmt]
+  [%import: Wrap_ssrast.ssrfwdfmt]
   [@@deriving sexp]
 
 type ssrclseq =
-  [%import: Ssreflect_plugin.Ssrast.ssrclseq]
+  [%import: Wrap_ssrast.ssrclseq]
   [@@deriving sexp]
 
 type 'tac ssrhint =
-  [%import: 'tac Ssreflect_plugin.Ssrast.ssrhint]
+  [%import: 'tac Wrap_ssrast.ssrhint]
   [@@deriving sexp]
 
 type 'tac fwdbinders =
-  [%import: 'tac Ssreflect_plugin.Ssrast.fwdbinders]
+  [%import: 'tac Wrap_ssrast.fwdbinders]
   [@@deriving sexp]
 
 type 'tac ffwbinders =
-  [%import: 'tac Ssreflect_plugin.Ssrast.ffwbinders]
+  [%import: 'tac Wrap_ssrast.ffwbinders]
   [@@deriving sexp]
 
 type clause =
-  [%import: Ssreflect_plugin.Ssrast.clause]
+  [%import: Wrap_ssrast.clause]
   [@@deriving sexp]
 
 type clauses =
-  [%import: Ssreflect_plugin.Ssrast.clauses]
+  [%import: Wrap_ssrast.clauses]
   [@@deriving sexp]
 
 type wgen =
-  [%import: Ssreflect_plugin.Ssrast.wgen]
+  [%import: Wrap_ssrast.wgen]
   [@@deriving sexp]
 
 type 'a ssrdoarg =
-  [%import: 'a Ssreflect_plugin.Ssrast.ssrdoarg]
+  [%import: 'a Wrap_ssrast.ssrdoarg]
   [@@deriving sexp]
 
 type 'a ssrseqarg =
-  [%import: 'a Ssreflect_plugin.Ssrast.ssrseqarg]
+  [%import: 'a Wrap_ssrast.ssrseqarg]
   [@@deriving sexp]
 
 type 'a ssragens =
-  [%import: 'a Ssreflect_plugin.Ssrast.ssragens]
+  [%import: 'a Wrap_ssrast.ssragens]
   [@@deriving sexp]
 
 type ssrapplyarg =
-  [%import: Ssreflect_plugin.Ssrast.ssrapplyarg]
+  [%import: Wrap_ssrast.ssrapplyarg]
   [@@deriving sexp]
 
 type 'a ssrcasearg =
-  [%import: 'a Ssreflect_plugin.Ssrast.ssrcasearg]
+  [%import: 'a Wrap_ssrast.ssrcasearg]
   [@@deriving sexp]
 
 type 'a ssrmovearg =
-  [%import: 'a Ssreflect_plugin.Ssrast.ssrmovearg]
+  [%import: 'a Wrap_ssrast.ssrmovearg]
   [@@deriving sexp]

--- a/serlib/plugins/ssr/ser_ssrequality.ml
+++ b/serlib/plugins/ssr/ser_ssrequality.ml
@@ -24,6 +24,8 @@ module Ssreflect_plugin = struct
   module Ssrequality = Ssreflect_plugin.Ssrequality
 end
 
+open Ssreflect_plugin [@@ocaml.warning "-33"]
+
 type ssrwkind =
   [%import: Ssreflect_plugin.Ssrequality.ssrwkind]
   [@@deriving sexp]

--- a/serlib/plugins/ssr/wrap_ssrast.ml
+++ b/serlib/plugins/ssr/wrap_ssrast.ml
@@ -1,0 +1,23 @@
+(************************************************************************)
+(*         *   The Coq Proof Assistant / The Coq Development Team       *)
+(*  v      *   INRIA, CNRS and contributors - Copyright 1999-2018       *)
+(* <O___,, *       (see CREDITS file for the list of authors)           *)
+(*   \VV/  **************************************************************)
+(*    //   *    This file is distributed under the terms of the         *)
+(*         *     GNU Lesser General Public License Version 2.1          *)
+(*         *     (see LICENSE file for the text of the license)         *)
+(************************************************************************)
+
+(* This file is (C) Copyright 2006-2015 Microsoft Corporation and Inria. *)
+
+open Ssreflect_plugin [@@ocaml.warning "-33"]
+
+module Ssreflect_plugin = struct
+  module Ssrast = Ssrast
+end
+
+module rec Wrap : sig
+  include module type of Ssreflect_plugin.Ssrast
+end = Wrap
+
+include Wrap


### PR DESCRIPTION
This is necessary when Coq is compiled with the standard Makefile.

In order to have a solution that both works with `-pack` and Dune
mode, we need to wrap the mli-only file that Coq is shipping upstream
due to differences in linking.

Fixes #143

We also update the Travis setup so we test both OPAM and the Dune build.

Proper working did require patching Coq's upstream META file so the plugin loader works correctly, c.f. https://github.com/coq/coq/pull/10943 https://github.com/ocaml/opam-repository/pull/15103