### PR TITLE
[serapi] Add string formatted messages to `CoqExn` and `Message`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -25,6 +25,8 @@
  * [serlib ] (!) Add index to `MBId` serialization` (fixes #150, @ejgallego)
  * [serapi ] (!) Add `sid` parameter to `Print` (helps #150, @ejgallego, reported by @cpitclaudel)
  * [sertop ] Add `sertok` program for batch serialization of tokens and their source locations (@palmskog)
+ * [serapi ] (!) Add string-formatted messages to `CoqExn` and `Message`
+             (@ejgallego closes #184 , closes #162)
 
 ## Version 0.6.1:
 

--- a/serapi/serapi_protocol.mli
+++ b/serapi/serapi_protocol.mli
@@ -451,6 +451,7 @@ module ExnInfo : sig
     ; backtrace : Printexc.raw_backtrace
     ; exn : exn
     ; pp : Pp.t
+    ; str : string
     }
 end
 
@@ -477,10 +478,32 @@ val exec_cmd : cmd -> answer_kind list
 type cmd_tag = string
 type tagged_cmd = cmd_tag * cmd
 
+(** We introduce our own feedback type to overcome some limitations of
+   Coq's Feedback, for now we only modify the Message data *)
+
+type feedback_content =
+  | Processed
+  | Incomplete
+  | Complete
+  | ProcessingIn of string
+  | InProgress of int
+  | WorkerStatus of string * string
+  | AddedAxiom
+  | FileDependency of string option * string
+  | FileLoaded of string * string
+  | Message of { level: Feedback.level ; loc : Loc.t option ; pp : Pp.t ; str: string }
+
+type feedback =
+  { doc_id   : Feedback.doc_id
+  ; span_id  : Stateid.t
+  ; route    : Feedback.route_id
+  ; contents : feedback_content
+  }
+
 (** General answers of the protocol can be responses to commands, or
    Coq messages *)
 type answer =
   | Answer    of cmd_tag * answer_kind
   (** The answer is comming from a user-issued command *)
-  | Feedback  of Feedback.feedback
+  | Feedback  of feedback
   (** Output produced by Coq (asynchronously) *)

--- a/serlib/ser_feedback.mli
+++ b/serlib/ser_feedback.mli
@@ -15,6 +15,13 @@
 
 open Sexplib
 
+type doc_id = Feedback.doc_id
+
+val doc_id_of_sexp : Sexp.t -> doc_id
+val sexp_of_doc_id : doc_id -> Sexp.t
+val doc_id_of_yojson : Yojson.Safe.t -> (doc_id, string) Result.result
+val doc_id_to_yojson : doc_id -> Yojson.Safe.t
+
 type level = Feedback.level
 
 val level_of_sexp : Sexp.t -> level

--- a/sertop/sertop_async.ml
+++ b/sertop/sertop_async.ml
@@ -35,7 +35,7 @@ let read_cmd cmd_sexp : [`Error of Sexp.t | `Ok of string * cmd ] =
 let sertop_init ~(fb_out : Sexp.t -> unit) ~iload_path ~require_libs ~debug =
   let open! Sertop_init in
 
-  let fb_handler fb = Sertop_ser.sexp_of_answer (Feedback fb) |> fb_out in
+  let fb_handler fb = Sertop_ser.sexp_of_answer (Feedback (Sertop_util.feedback_tr fb)) |> fb_out in
 
   coq_init {
     fb_handler;

--- a/sertop/sertop_ser.ml
+++ b/sertop/sertop_ser.ml
@@ -239,6 +239,14 @@ type answer_kind =
   ]]
   [@@deriving sexp]
 
+type feedback_content =
+  [%import: Serapi_protocol.feedback_content]
+  [@@deriving sexp]
+
+type feedback =
+  [%import: Serapi_protocol.feedback]
+  [@@deriving sexp]
+
 type answer =
   [%import: Serapi_protocol.answer]
   [@@deriving sexp]

--- a/sertop/sertop_sexp.ml
+++ b/sertop/sertop_sexp.ml
@@ -113,7 +113,7 @@ let ser_loop ser_opts =
   let pp_err       = ser_lock (out_sexp ser_opts out_fmt)              in
   let pp_ack cid   = pp_answer (SP.Answer (cid, SP.Ack))               in
   let pp_opt  fb   = Sertop_util.feedback_opt_filter fb                in
-  let pp_feed fb   = Option.iter (fun fb -> pp_answer (SP.Feedback fb)) (pp_opt fb) in
+  let pp_feed fb   = Option.iter (fun fb -> pp_answer (SP.Feedback (Sertop_util.feedback_tr fb))) (pp_opt fb) in
 
   (* Init Coq *)
   let () = Sertop_init.(

--- a/sertop/sertop_util.mli
+++ b/sertop/sertop_util.mli
@@ -31,3 +31,5 @@ type fb_filter_opts = {
 val default_fb_filter_opts : fb_filter_opts
 
 val feedback_opt_filter : ?opts:fb_filter_opts -> Feedback.feedback -> Feedback.feedback option
+
+val feedback_tr : Feedback.feedback -> Serapi_protocol.feedback


### PR DESCRIPTION
This way clients don't need to do a round-trip to convert the `Pp.t`
to a string.

Closes #184 , closes #162.