### PR TITLE
[serapi] [general] Bump version numbers for 8.11 and wrap libraries

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,9 @@
  * [general] (!) support Coq 8.11, a few datatypes have changed, in
              particular `CoqAst` handles locations as an AST node, and
              the kernel type includes primitive floats.
+ * [general] (!) Now the `sertop` and `serapi` OCaml libraries are
+             built packed, we've also bumped their compat version number
+             (#192 @ejgallego)
 
 ## Version 0.7.0:
 

--- a/FAQ.md
+++ b/FAQ.md
@@ -13,8 +13,8 @@ changelog with `(!)`.
 
 ## Which Coq versions does SerAPI support?
 
-At the moment, Coq 8.10 is the current supported version for the
-current protocol. Older versions (8.6---8.9) work, however the
+At the moment, Coq 8.11 is the current supported version for the
+current protocol. Older versions (8.6---8.10) work, however the
 protocol and feature sets do differ.
 
 ## How can I install SerAPI?

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## SerAPI: Machine-Friendly, Data-Centric Serialization for Coq
 
-[![Build Status](https://travis-ci.org/ejgallego/coq-serapi.svg?branch=v8.10)](https://travis-ci.org/ejgallego/coq-serapi) [![Gitter](https://badges.gitter.im/coq-serapi/Lobby.svg)](https://gitter.im/coq-serapi/Lobby)
+[![Build Status](https://travis-ci.org/ejgallego/coq-serapi.svg?branch=v8.11)](https://travis-ci.org/ejgallego/coq-serapi) [![Gitter](https://badges.gitter.im/coq-serapi/Lobby.svg)](https://gitter.im/coq-serapi/Lobby)
 
 ```
 $ opam install coq-serapi
@@ -103,7 +103,7 @@ There are three categories of [commands](serapi/serapi_protocol.mli#L147):
 
 ### Roadmap:
 
-SerAPI 0.7.x is based on Coq 8.10. These days, most work related to
+SerAPI 0.11.x is based on Coq 8.11. These days, most work related to
 SerAPI is directly happening over [Coq's upstream](https://github.com/coq/coq)
 itself. The main objective is to improve the proof-document model; building
 a rich query language will be next.

--- a/notes/build.md
+++ b/notes/build.md
@@ -2,7 +2,7 @@
 
 SerAPI is available for different Coq versions, with each of its
 branches targeting the corresponding Coq branch. The current
-development branch is `v8.10` targeting Coq's `v8.10` branch.
+development branch is `v8.11` targeting Coq's `v8.11` branch.
 
 Basic build instructions are below; the `.travis.yml` files should
 contain up-to-date information in any case. We recommend using OPAM to
@@ -10,14 +10,14 @@ setup the build environment, however Théo Zimmermann has reported
 success in [NixOS](https://nixos.org).
 
 0. The currently supported OCaml version is 4.07.1:
-   ``$ opam switch 4.07.1 && eval $(opam env)``. We also assume `COQVER=v8.10`.
+   ``$ opam switch 4.07.1 && eval $(opam env)``. We also assume `COQVER=v8.11`.
 1. Install the needed packages:
    `$ opam install cmdliner sexplib dune ppx_import ppx_deriving ppx_sexp_conv yojson ppx_deriving_yojson`.
 2. Download and compile Coq. We recommend:
    `$ git clone -b ${COQVER} https://github.com/coq/coq.git ~/external/coq-${COQVER} && cd ~/external/coq-${COQVER} && ./configure -local -native-compiler no && make -j $NJOBS`.
 3. Type `make SERAPI_COQ_HOME=~/external/coq-${COQVER}` to build `sertop`.
 
-Alternatively, you can install Coq `>= 8.10` using OPAM and build against it using just `make`.
+Alternatively, you can install Coq `>= 8.11` using OPAM and build against it using just `make`.
 
 The above instructions assume that you use `~/external/coq-${COQVER}`
 directory to place the Coq build that SerAPI needs; you can modify
@@ -39,6 +39,7 @@ If that is not properly done, the usual symptom is the error message:
 (CoqExn "Cannot link ml-object ground_plugin.cmxs to Coq code (Fl_package_base.No_such_package(\"coq-serapi.serlib.ground_plugin\", \"\"))."))
 ```
 When executing binaries via `dune exec`, be sure to pass any arguments after `--`, e.g., `dune exec sercomp -- --help`.
+
 ## Advanced Developer Setup
 
 SerAPI builds using Dune which supports modular builds. Starting with

--- a/serapi/dune
+++ b/serapi/dune
@@ -1,6 +1,5 @@
 (library
  (name serapi)
- (public_name coq-serapi.serapi_v8_10)
- (wrapped false)
+ (public_name coq-serapi.serapi_v8_11)
  (synopsis "Serialization Protocol for Coq")
  (libraries coq.stm coq.plugins.ltac sexplib))

--- a/serlib/plugins/extraction/dune
+++ b/serlib/plugins/extraction/dune
@@ -1,7 +1,6 @@
 (library
  (name serlib_extraction)
  (public_name coq-serapi.serlib.extraction_plugin)
- (wrapped false)
  (synopsis "Serialization Library for Coq Fundind Plugin")
  (preprocess (staged_pps ppx_import ppx_sexp_conv))
  (libraries coq.plugins.extraction serlib))

--- a/serlib/plugins/firstorder/dune
+++ b/serlib/plugins/firstorder/dune
@@ -1,7 +1,6 @@
 (library
  (name serlib_firstorder)
  (public_name coq-serapi.serlib.ground_plugin)
- (wrapped false)
  (synopsis "Serialization Library for Coq Firstorder Plugin")
  (preprocess (staged_pps ppx_import ppx_sexp_conv))
  (libraries coq.plugins.firstorder serlib sexplib))

--- a/serlib/plugins/funind/dune
+++ b/serlib/plugins/funind/dune
@@ -1,7 +1,6 @@
 (library
  (name serlib_funind)
  (public_name coq-serapi.serlib.recdef_plugin)
- (wrapped false)
  (synopsis "Serialization Library for Coq Fundind Plugin")
  (preprocess (staged_pps ppx_import ppx_sexp_conv))
  (libraries coq.plugins.funind serlib serlib_ltac sexplib))

--- a/serlib/plugins/funind/ser_g_indfun.ml
+++ b/serlib/plugins/funind/ser_g_indfun.ml
@@ -6,7 +6,7 @@ module Constrexpr = Ser_constrexpr
 module Tactypes   = Ser_tactypes
 module Genintern  = Ser_genintern
 module EConstr    = Ser_eConstr
-module Tacexpr    = Ser_tacexpr
+module Tacexpr    = Serlib_ltac.Ser_tacexpr
 
 module A1 = struct
 

--- a/serlib/plugins/ltac/dune
+++ b/serlib/plugins/ltac/dune
@@ -1,7 +1,6 @@
 (library
  (name serlib_ltac)
  (public_name coq-serapi.serlib.ltac)
- (wrapped false)
  (synopsis "Serialization Library for Coq [LTAC plugin]")
  (preprocess (staged_pps ppx_import ppx_sexp_conv))
  (libraries coq.plugins.ltac serlib sexplib))

--- a/serlib/plugins/setoid_ring/dune
+++ b/serlib/plugins/setoid_ring/dune
@@ -1,7 +1,6 @@
 (library
  (name serlib_setoid_ring)
  (public_name coq-serapi.serlib.newring_plugin)
- (wrapped false)
  (synopsis "Serialization Library for Coq Setoid Newring Plugin")
  (preprocess (staged_pps ppx_import ppx_sexp_conv))
  (libraries coq.plugins.setoid_ring serlib serlib_ltac sexplib))

--- a/serlib/plugins/setoid_ring/ser_g_newring.ml
+++ b/serlib/plugins/setoid_ring/ser_g_newring.ml
@@ -7,10 +7,10 @@ module Constrexpr = Ser_constrexpr
 module Tactypes   = Ser_tactypes
 module Genintern  = Ser_genintern
 module EConstr    = Ser_eConstr
-module Tacexpr    = Ser_tacexpr
+module Tacexpr    = Serlib_ltac.Ser_tacexpr
 
 module Ltac_plugin = struct
-  module Tacexpr = Ser_tacexpr
+  module Tacexpr = Serlib_ltac.Ser_tacexpr
 end
 
 type 'constr coeff_spec =

--- a/serlib/plugins/ssr/dune
+++ b/serlib/plugins/ssr/dune
@@ -1,7 +1,6 @@
 (library
  (name serlib_ssr)
  (public_name coq-serapi.serlib.ssreflect_plugin)
- (wrapped false)
  (synopsis "Serialization Library for Coq [SSR plugin]")
  (preprocess (staged_pps ppx_import ppx_sexp_conv))
  (libraries coq.plugins.ssreflect serlib serlib_ltac serlib_ssrmatching sexplib))

--- a/serlib/plugins/ssr/ser_ssrast.ml
+++ b/serlib/plugins/ssr/ser_ssrast.ml
@@ -26,11 +26,11 @@ module Genintern  = Ser_genintern
 module Geninterp  = Ser_geninterp
 
 module Ssrmatching_plugin = struct
-  module Ssrmatching = Ser_ssrmatching
+  module Ssrmatching = Serlib_ssrmatching.Ser_ssrmatching
 end
 
 module Ltac_plugin = struct
-  module Tacexpr = Ser_tacexpr
+  module Tacexpr = Serlib_ltac.Ser_tacexpr
 end
 
 (* What a hack is ssreflect using... *)

--- a/serlib/plugins/ssr/ser_ssrequality.ml
+++ b/serlib/plugins/ssr/ser_ssrequality.ml
@@ -16,7 +16,7 @@
 open Sexplib.Conv
 
 module Ssrmatching_plugin = struct
-  module Ssrmatching = Ser_ssrmatching
+  module Ssrmatching = Serlib_ssrmatching.Ser_ssrmatching
 end
 
 module Ssreflect_plugin = struct

--- a/serlib/plugins/ssr/ser_ssrparser.ml
+++ b/serlib/plugins/ssr/ser_ssrparser.ml
@@ -18,11 +18,11 @@
 open Sexplib.Conv
 open Serlib
 
-module Ssrmatching = Ser_ssrmatching
+module Ssrmatching = Serlib_ssrmatching.Ser_ssrmatching
 open Ssrmatching
 
 module Ltac_plugin = struct
-  module Tacexpr = Ser_tacexpr
+  module Tacexpr = Serlib_ltac.Ser_tacexpr
 end
 
 module Ssrast = Ser_ssrast
@@ -108,9 +108,9 @@ let ser_wit_ssrhintarg =
   }
 
 module A1 = struct
-  type h1 = Ser_tacexpr.raw_tactic_expr ssrseqarg
+  type h1 = Serlib_ltac.Ser_tacexpr.raw_tactic_expr ssrseqarg
   [@@deriving sexp]
-  type h2 = Ser_tacexpr.glob_tactic_expr ssrseqarg
+  type h2 = Serlib_ltac.Ser_tacexpr.glob_tactic_expr ssrseqarg
   [@@deriving sexp]
   type h3 = Geninterp.Val.t ssrseqarg
   [@@deriving sexp]
@@ -128,9 +128,9 @@ let ser_wit_ssrseqarg = let open A1 in Ser_genarg.
   }
 
 module A2 = struct
-  type h1 = Ser_tacexpr.raw_tactic_expr * ssripats
+  type h1 = Serlib_ltac.Ser_tacexpr.raw_tactic_expr * ssripats
   [@@deriving sexp]
-  type h2 = Ser_tacexpr.glob_tactic_expr * ssripats
+  type h2 = Serlib_ltac.Ser_tacexpr.glob_tactic_expr * ssripats
   [@@deriving sexp]
   type h3 = Geninterp.Val.t * ssripats
   [@@deriving sexp]
@@ -148,9 +148,9 @@ let ser_wit_ssrintrosarg = let open A2 in Ser_genarg.
   }
 
 module A3 = struct
-  type h1 = Ser_tacexpr.raw_tactic_expr ffwbinders
+  type h1 = Serlib_ltac.Ser_tacexpr.raw_tactic_expr ffwbinders
   [@@deriving sexp]
-  type h2 = Ser_tacexpr.glob_tactic_expr ffwbinders
+  type h2 = Serlib_ltac.Ser_tacexpr.glob_tactic_expr ffwbinders
   [@@deriving sexp]
   type h3 = Geninterp.Val.t ffwbinders
   [@@deriving sexp]
@@ -169,9 +169,9 @@ end
 let ser_wit_ssrcongrarg = let open A4 in Ser_genarg.mk_uniform sexp_of_h1 h1_of_sexp
 
 module A5 = struct
-  type h1 = Ser_tacexpr.raw_tactic_expr ssrdoarg
+  type h1 = Serlib_ltac.Ser_tacexpr.raw_tactic_expr ssrdoarg
   [@@deriving sexp]
-  type h2 = Ser_tacexpr.glob_tactic_expr ssrdoarg
+  type h2 = Serlib_ltac.Ser_tacexpr.glob_tactic_expr ssrdoarg
   [@@deriving sexp]
   type h3 = Geninterp.Val.t ssrdoarg
   [@@deriving sexp]
@@ -191,9 +191,9 @@ end
 let ser_wit_ssrsetfwd = let open A6 in Ser_genarg.mk_uniform sexp_of_h1 h1_of_sexp
 
 module A7 = struct
-  type h1 = Ser_tacexpr.raw_tactic_expr ssrhint
+  type h1 = Serlib_ltac.Ser_tacexpr.raw_tactic_expr ssrhint
   [@@deriving sexp]
-  type h2 = Ser_tacexpr.glob_tactic_expr ssrhint
+  type h2 = Serlib_ltac.Ser_tacexpr.glob_tactic_expr ssrhint
   [@@deriving sexp]
   type h3 = Geninterp.Val.t ssrhint
   [@@deriving sexp]
@@ -345,8 +345,8 @@ let register () =
   Ssreflect_plugin.Ssrparser.wit_ssrstruct
 *)
   register_genser wit_ssrsufffwd ser_wit_ssrsufffwd;
-  register_genser wit_ssrtacarg Ser_tacarg.ser_wit_tactic;
-  register_genser wit_ssrtclarg Ser_tacarg.ser_wit_tactic;
+  register_genser wit_ssrtacarg Serlib_ltac.Ser_tacarg.ser_wit_tactic;
+  register_genser wit_ssrtclarg Serlib_ltac.Ser_tacarg.ser_wit_tactic;
 
   register_genser wit_ssrterm       (mk_uniform sexp_of_ssrterm ssrterm_of_sexp);
   register_genser wit_ssrunlockarg  ser_wit_ssrunlockarg;

--- a/serlib/plugins/ssrmatching/dune
+++ b/serlib/plugins/ssrmatching/dune
@@ -1,7 +1,6 @@
 (library
  (name serlib_ssrmatching)
  (public_name coq-serapi.serlib.ssrmatching_plugin)
- (wrapped false)
  (synopsis "Serialization Library for Coq [SSR Matching plugin]")
  (preprocess (staged_pps ppx_import ppx_sexp_conv))
  (libraries coq.plugins.ssrmatching serlib serlib_ltac sexplib))

--- a/sertop/dune
+++ b/sertop/dune
@@ -1,17 +1,17 @@
 (library
- (name sertoplib)
- (public_name coq-serapi.sertop_v8_10)
- (modules :standard \ sertop sercomp sertok sertop_js sertop_async)
- (wrapped false)
+ (name sertop)
+ (public_name coq-serapi.sertop_v8_11)
+ (modules :standard \ sertop_bin sercomp sertok sertop_js sertop_async)
  (preprocess (staged_pps ppx_import ppx_sexp_conv))
  (libraries findlib.dynload cmdliner serapi serlib serlib_ltac))
 
 (executables
  (public_names sertop sercomp sertok)
- (modules sertop sercomp sertok)
+ (names sertop_bin sercomp sertok)
+ (modules sertop_bin sercomp sertok)
  (preprocess (staged_pps ppx_import ppx_sexp_conv))
  (link_flags -linkall)
- (libraries sertoplib num))
+ (libraries sertop num))
 
 (executable
  (name sertop_js)
@@ -27,7 +27,7 @@
   (flags :standard --dynlink +nat.js +dynlink.js +toplevel.js))
 ; (flags :standard --dynlink +nat.js +dynlink.js +toplevel.js --pretty --noinline --disable shortvar --debug-info)
  (link_flags -linkall -noautolink -no-check-prims)
- (libraries sertoplib ppx_deriving_yojson.runtime jscoq_lib))
+ (libraries sertop ppx_deriving_yojson.runtime jscoq_lib))
 
 (rule
  (targets ser_version.ml)

--- a/sertop/sercomp.ml
+++ b/sertop/sercomp.ml
@@ -25,7 +25,7 @@ let fatal_exn exn info =
 
 let create_document ~in_file ~async ~async_workers ~quick ~iload_path ~debug =
 
-  let open Sertop_init in
+  let open Sertop.Sertop_init in
 
   (* coq initialization *)
   coq_init
@@ -75,7 +75,7 @@ let create_document ~in_file ~async ~async_workers ~quick ~iload_path ~debug =
 exception End_of_input
 let input_doc ~input ~in_file ~in_chan ~process ~doc ~sid =
   let stt = ref (doc, sid) in
-  let open Sertop_arg in
+  let open Sertop.Sertop_arg in
   match input with
   | I_vernac ->
      begin
@@ -111,14 +111,14 @@ let process_vernac ~mode ~pp ~doc ~sid ast =
   let doc, n_st, tip = Stm.add ~doc ~ontop:sid false ast in
   if tip <> `NewTip then
     CErrors.user_err ?loc:ast.loc Pp.(str "fatal, got no `NewTip`");
-  let open Sertop_arg in
+  let open Sertop.Sertop_arg in
   let () = match mode with
     | C_env   -> ()
     | C_vo    -> ()
     | C_check -> ()
     | C_parse -> ()
     | C_stats ->
-      Sercomp_stats.do_stats ast
+      Sertop.Sercomp_stats.do_stats ast
     | C_print ->
       printf "@[%a@]@\n%!" Pp.pp_with Ppvernac.(pr_vernac ast)
     | C_sexp ->
@@ -139,13 +139,13 @@ let check_pending_proofs ~pstate =
     ) pstate
 
 let close_document ~pp ~mode ~doc ~in_file ~pstate =
-  let open Sertop_arg in
+  let open Sertop.Sertop_arg in
   match mode with
   | C_parse -> ()
   | C_sexp  -> ()
   | C_print -> ()
   | C_stats ->
-    Sercomp_stats.print_stats ()
+    Sertop.Sercomp_stats.print_stats ()
   | C_check ->
     let _doc = Stm.join ~doc in
     check_pending_proofs ~pstate
@@ -162,7 +162,7 @@ let close_document ~pp ~mode ~doc ~in_file ~pstate =
     Library.save_library_to todo_proofs ~output_native_objects:false ldir out_vo (Global.opaque_tables ())
 
 (* Command line processing *)
-let sercomp_version = Ser_version.ser_git_version
+let sercomp_version = Sertop.Ser_version.ser_git_version
 
 let sercomp_man =
   [
@@ -185,14 +185,14 @@ open Cmdliner
 let driver input mode debug printer async async_workers quick coq_path ml_path load_path rload_path in_file omit_loc omit_att exn_on_opaque =
 
   (* closures *)
-  let pp = Sertop_ser.select_printer printer in
+  let pp = Sertop.Sertop_ser.select_printer printer in
   let process = process_vernac ~mode ~pp in
 
   (* initialization *)
   let options = Serlib.Serlib_init.{ omit_loc; omit_att; exn_on_opaque } in
   Serlib.Serlib_init.init ~options;
 
-  let iload_path = Serapi_paths.coq_loadpath_default ~implicit:true ~coq_path @ ml_path @ load_path @ rload_path in
+  let iload_path = Serapi.Serapi_paths.coq_loadpath_default ~implicit:true ~coq_path @ ml_path @ load_path @ rload_path in
   let doc, sid = create_document ~in_file ~async ~async_workers ~quick ~iload_path ~debug in
 
   (* main loop *)
@@ -212,7 +212,7 @@ let main () =
   in
 
   let sercomp_cmd =
-    let open Sertop_arg in
+    let open Sertop.Sertop_arg in
     Term.(const driver
           $ comp_input $ comp_mode $ debug $ printer $ async $ async_workers $ quick $ prelude
           $ ml_include_path $ load_path $ rload_path $ input_file $ omit_loc $ omit_att $ exn_on_opaque

--- a/sertop/sertok.ml
+++ b/sertop/sertok.ml
@@ -32,7 +32,7 @@ let fatal_exn exn info =
 
 let create_document ~in_file ~async ~async_workers ~quick ~iload_path ~debug =
 
-  let open Sertop_init in
+  let open Sertop.Sertop_init in
 
   (* coq initialization *)
   coq_init
@@ -121,9 +121,9 @@ let input_doc ~pp ~in_file ~in_chan ~doc ~sid =
       try
 	CLexer.set_lexer_state l_pre_st;
         let lex = CLexer.Lexer.tok_func sstr in
-        let sen = Sertop_ser.Sentence (stream_tok 0 [] lex source begin_line begin_char) in
+        let sen = Sertop.Sertop_ser.Sentence (stream_tok 0 [] lex source begin_line begin_char) in
         CLexer.set_lexer_state l_post_st;
-        printf "@[%a@]@\n%!" pp (Sertop_ser.sexp_of_sentence sen);
+        printf "@[%a@]@\n%!" pp (Sertop.Sertop_ser.sexp_of_sentence sen);
         let doc, n_st, tip = Stm.add ~doc ~ontop:sid false ast in
         if tip <> `NewTip then CErrors.user_err ?loc:ast.loc Pp.(str "fatal, got no `NewTip`");
         stt := doc, n_st
@@ -150,7 +150,7 @@ let close_document ~doc ~pstate =
   let _doc = Stm.join ~doc in
   check_pending_proofs ~pstate
 
-let sertok_version = Ser_version.ser_git_version
+let sertok_version = Sertop.Ser_version.ser_git_version
 
 let sertok_man =
   [
@@ -169,13 +169,13 @@ open Cmdliner
 let driver debug printer async async_workers quick coq_path ml_path load_path rload_path in_file omit_loc omit_att exn_on_opaque =
 
   (* closures *)
-  let pp = Sertop_ser.select_printer printer in
+  let pp = Sertop.Sertop_ser.select_printer printer in
 
   (* initialization *)
   let options = Serlib.Serlib_init.{ omit_loc; omit_att; exn_on_opaque } in
   Serlib.Serlib_init.init ~options;
 
-  let iload_path = Serapi_paths.coq_loadpath_default ~implicit:true ~coq_path @ ml_path @ load_path @ rload_path in
+  let iload_path = Serapi.Serapi_paths.coq_loadpath_default ~implicit:true ~coq_path @ ml_path @ load_path @ rload_path in
   let doc, sid = create_document ~in_file ~async ~async_workers ~quick ~iload_path ~debug in
 
   (* main loop *)
@@ -195,7 +195,7 @@ let main () =
   in
 
   let sertok_cmd =
-    let open Sertop_arg in
+    let open Sertop.Sertop_arg in
     Term.(const driver
           $ debug $ printer $ async $ async_workers $ quick $ prelude
           $ ml_include_path $ load_path $ rload_path $ input_file $ omit_loc $ omit_att $ exn_on_opaque

--- a/sertop/sertop_async.ml
+++ b/sertop/sertop_async.ml
@@ -14,7 +14,7 @@
 (************************************************************************)
 
 open Sexplib
-open Serapi_protocol
+open Serapi.Serapi_protocol
 
 (* There a subtles differences between the sync and async loop, so we
    keep a bit of duplication for now. *)
@@ -22,10 +22,10 @@ open Serapi_protocol
 let async_sid = ref 0
 
 let read_cmd cmd_sexp : [`Error of Sexp.t | `Ok of string * cmd ] =
-  try         `Ok (Sertop_ser.tagged_cmd_of_sexp cmd_sexp)
+  try         `Ok (Sertop.Sertop_ser.tagged_cmd_of_sexp cmd_sexp)
   with _exn ->
     try
-      let tag, cmd = string_of_int !async_sid, Sertop_ser.cmd_of_sexp cmd_sexp in
+      let tag, cmd = string_of_int !async_sid, Sertop.Sertop_ser.cmd_of_sexp cmd_sexp in
       incr async_sid;
       `Ok (tag, cmd)
     with | exn ->
@@ -33,9 +33,9 @@ let read_cmd cmd_sexp : [`Error of Sexp.t | `Ok of string * cmd ] =
 
 (* Initialize Coq. *)
 let sertop_init ~(fb_out : Sexp.t -> unit) ~iload_path ~require_libs ~debug =
-  let open! Sertop_init in
+  let open! Sertop.Sertop_init in
 
-  let fb_handler fb = Sertop_ser.sexp_of_answer (Feedback (Sertop_util.feedback_tr fb)) |> fb_out in
+  let fb_handler fb = Sertop.Sertop_ser.sexp_of_answer (Feedback (Sertop.Sertop_util.feedback_tr fb)) |> fb_out in
 
   coq_init {
     fb_handler;
@@ -63,7 +63,7 @@ let async_mut = Mutex.create ()
 (* Callback for a command. Trying to make it thread-safe. *)
 let sertop_callback (out_fn : Sexp.t -> unit) sexp =
   Mutex.lock async_mut;
-  let out_answer a = out_fn (Sertop_ser.sexp_of_answer a) in
+  let out_answer a = out_fn (Sertop.Sertop_ser.sexp_of_answer a) in
   let out_error  a = out_fn a                             in
   begin match read_cmd sexp with
   | `Error err         -> out_error  err

--- a/sertop/sertop_bin.ml
+++ b/sertop/sertop_bin.ml
@@ -18,16 +18,16 @@
 
 open Cmdliner
 
-let sertop_version = Ser_version.ser_git_version
+let sertop_version = Sertop.Ser_version.ser_git_version
 let sertop printer print0 debug lheader coq_path ml_path no_init no_prelude lp1 lp2 _std_impl async deep_edits async_workers omit_loc omit_att exn_on_opaque =
 
-  let open  Sertop_init         in
-  let open! Sertop_sexp         in
+  let open  Sertop.Sertop_init         in
+  let open! Sertop.Sertop_sexp         in
 
   let options = Serlib.Serlib_init.{ omit_loc; omit_att; exn_on_opaque } in
   Serlib.Serlib_init.init ~options;
 
-  let loadpath = Serapi_paths.coq_loadpath_default ~implicit:true ~coq_path @
+  let loadpath = Serapi.Serapi_paths.coq_loadpath_default ~implicit:true ~coq_path @
                  ml_path @ lp1 @ lp2 in
 
   ser_loop
@@ -51,7 +51,7 @@ let sertop printer print0 debug lheader coq_path ml_path no_init no_prelude lp1 
     }
 
 let sertop_cmd =
-  let open Sertop_arg in
+  let open Sertop.Sertop_arg in
   let doc = "SerAPI Coq Toplevel" in
   let man = [
     `S "DESCRIPTION";

--- a/sertop/sertop_ser.ml
+++ b/sertop/sertop_ser.ml
@@ -30,7 +30,7 @@ let select_printer pr = match pr with
   | SP_Mach   -> Sexp.pp
   | SP_Human  -> Sexp.pp_hum
 
-module SP = Serapi_protocol
+module SP = Serapi.Serapi_protocol
 
 (******************************************************************************)
 (* Exception Registration                                                     *)
@@ -104,9 +104,9 @@ module Printer    = Ser_printer
 module Ser_stm    = Ser_stm
 
 module Ltac_plugin = struct
-  module Tacenv       = Ser_tacenv
-  module Profile_ltac = Ser_profile_ltac
-  module Tacexpr      = Ser_tacexpr
+  module Tacenv       = Serlib_ltac.Ser_tacenv
+  module Profile_ltac = Serlib_ltac.Ser_profile_ltac
+  module Tacexpr      = Serlib_ltac.Ser_tacexpr
 end
 
 module Notation   = Ser_notation
@@ -116,62 +116,68 @@ module Vernacexpr   = Ser_vernacexpr
 module Declarations = Ser_declarations
 (* module Richpp       = Ser_richpp *)
 
+module Serapi = struct
 module Serapi_goals = struct
 
   type 'a hyp =
-    [%import: 'a Serapi_goals.hyp]
+    [%import: 'a Serapi.Serapi_goals.hyp]
     [@@deriving sexp]
 
   type info =
-    [%import: Serapi_goals.info]
+    [%import: Serapi.Serapi_goals.info]
     [@@deriving sexp]
 
   type 'a reified_goal =
-    [%import: 'a Serapi_goals.reified_goal]
+    [%import: 'a Serapi.Serapi_goals.reified_goal]
     [@@deriving sexp]
 
   type 'a ser_goals =
-    [%import: 'a Serapi_goals.ser_goals]
+    [%import: 'a Serapi.Serapi_goals.ser_goals]
     [@@deriving sexp]
 
 end
 
 module Serapi_assumptions = struct
 type ax_ctx =
-  [%import: Serapi_assumptions.ax_ctx]
+  [%import: Serapi.Serapi_assumptions.ax_ctx]
   [@@deriving sexp]
 
 type t =
-  [%import: Serapi_assumptions.t]
+  [%import: Serapi.Serapi_assumptions.t]
   [@@deriving sexp]
+
+end
+
+module Serapi_protocol = Serapi.Serapi_protocol
+
 end
 
 (* Serialization to sexp *)
 type coq_object =
-  [%import: Serapi_protocol.coq_object]
+  [%import: Serapi.Serapi_protocol.coq_object]
   [@@deriving sexp]
 
 exception AnswerExn of Sexp.t
 let exn_of_sexp sexp = AnswerExn sexp
 
 type print_format =
-  [%import: Serapi_protocol.print_format]
+  [%import: Serapi.Serapi_protocol.print_format]
   [@@deriving sexp]
 
 type format_opt =
-  [%import: Serapi_protocol.format_opt]
+  [%import: Serapi.Serapi_protocol.format_opt]
   [@@deriving sexp]
 
 type print_opt =
-  [%import: Serapi_protocol.print_opt]
+  [%import: Serapi.Serapi_protocol.print_opt]
   [@@deriving sexp]
 
 type query_pred =
-  [%import: Serapi_protocol.query_pred]
+  [%import: Serapi.Serapi_protocol.query_pred]
   [@@deriving sexp]
 
 type query_opt =
-  [%import: Serapi_protocol.query_opt
+  [%import: Serapi.Serapi_protocol.query_opt
   [@with
      Sexplib.Conv.sexp_list   := sexp_list;
      Sexplib.Conv.sexp_option := sexp_option;
@@ -179,11 +185,11 @@ type query_opt =
   [@@deriving sexp]
 
 type query_cmd =
-  [%import: Serapi_protocol.query_cmd]
+  [%import: Serapi.Serapi_protocol.query_cmd]
   [@@deriving sexp]
 
 type cmd_tag =
-  [%import: Serapi_protocol.cmd_tag]
+  [%import: Serapi.Serapi_protocol.cmd_tag]
   [@@deriving sexp]
 
 type location =
@@ -216,7 +222,7 @@ let sexp_of_raw_backtrace (bt : Printexc.raw_backtrace) : Sexp.t =
 
 module ExnInfo = struct
   type t =
-    [%import: Serapi_protocol.ExnInfo.t
+    [%import: Serapi.Serapi_protocol.ExnInfo.t
     [@with
        Stm.focus := Ser_stm.focus;
        Printexc.raw_backtrace := raw_backtrace;
@@ -226,32 +232,32 @@ module ExnInfo = struct
 end
 
 type answer_kind =
-  [%import: Serapi_protocol.answer_kind
+  [%import: Serapi.Serapi_protocol.answer_kind
   [@with Exninfo.t := Exninfo.t;
   ]]
   [@@deriving sexp]
 
 type feedback_content =
-  [%import: Serapi_protocol.feedback_content]
+  [%import: Serapi.Serapi_protocol.feedback_content]
   [@@deriving sexp]
 
 type feedback =
-  [%import: Serapi_protocol.feedback]
+  [%import: Serapi.Serapi_protocol.feedback]
   [@@deriving sexp]
 
 type answer =
-  [%import: Serapi_protocol.answer]
+  [%import: Serapi.Serapi_protocol.answer]
   [@@deriving sexp]
 
 type add_opts =
-  [%import: Serapi_protocol.add_opts
+  [%import: Serapi.Serapi_protocol.add_opts
   [@with
      Sexplib.Conv.sexp_option := sexp_option;
   ]]
   [@@deriving sexp]
 
 type newdoc_opts =
-  [%import: Serapi_protocol.newdoc_opts
+  [%import: Serapi.Serapi_protocol.newdoc_opts
   [@with
      Stm.interactive_top      := Ser_stm.interactive_top;
      Sexplib.Conv.sexp_list   := sexp_list;
@@ -260,18 +266,18 @@ type newdoc_opts =
   [@@deriving sexp]
 
 type parse_opt =
-  [%import: Serapi_protocol.parse_opt
+  [%import: Serapi.Serapi_protocol.parse_opt
   [@with
      Sexplib.Conv.sexp_option := sexp_option;
   ]]
   [@@deriving sexp]
 
 type cmd =
-  [%import: Serapi_protocol.cmd]
+  [%import: Serapi.Serapi_protocol.cmd]
   [@@deriving sexp]
 
 type tagged_cmd =
-  [%import: Serapi_protocol.tagged_cmd]
+  [%import: Serapi.Serapi_protocol.tagged_cmd]
   [@@deriving sexp]
 
 type sentence = Sentence of Tok.t CAst.t list

--- a/sertop/sertop_ser.mli
+++ b/sertop/sertop_ser.mli
@@ -29,7 +29,7 @@ type ser_printer =
 
 val select_printer : ser_printer -> Format.formatter -> Sexp.t -> unit
 
-open Serapi_protocol
+open Serapi.Serapi_protocol
 
 val coq_object_of_sexp : Sexp.t -> coq_object
 val sexp_of_coq_object : coq_object -> Sexp.t

--- a/sertop/sertop_sexp.ml
+++ b/sertop/sertop_sexp.ml
@@ -19,7 +19,7 @@
 open Sexplib
 open Sexplib.Conv
 
-module SP = Serapi_protocol
+module SP = Serapi.Serapi_protocol
 
 (******************************************************************************)
 (* Global Protocol Options                                                    *)

--- a/sertop/sertop_util.ml
+++ b/sertop/sertop_util.ml
@@ -170,7 +170,7 @@ let default_fb_filter_opts = {
   pp_opt = true;
 }
 
-let feedback_content_tr (fb : F.feedback_content) : Serapi_protocol.feedback_content =
+let feedback_content_tr (fb : F.feedback_content) : Serapi.Serapi_protocol.feedback_content =
   match fb with
   | F.Message (level, loc, pp) ->
     let str = Pp.string_of_ppcmds pp in
@@ -188,7 +188,7 @@ let feedback_content_tr (fb : F.feedback_content) : Serapi_protocol.feedback_con
   | F.FileLoaded (o, p) -> FileLoaded (o, p)
   | F.Custom (_, _, _) -> assert false
 
-let feedback_tr (fb : Feedback.feedback) : Serapi_protocol.feedback =
+let feedback_tr (fb : Feedback.feedback) : Serapi.Serapi_protocol.feedback =
   match fb with
   | { doc_id; span_id; route; contents } ->
     let contents = feedback_content_tr contents in

--- a/sertop/sertop_util.mli
+++ b/sertop/sertop_util.mli
@@ -32,4 +32,4 @@ val default_fb_filter_opts : fb_filter_opts
 
 val feedback_opt_filter : ?opts:fb_filter_opts -> Feedback.feedback -> Feedback.feedback option
 
-val feedback_tr : Feedback.feedback -> Serapi_protocol.feedback
+val feedback_tr : Feedback.feedback -> Serapi.Serapi_protocol.feedback


### PR DESCRIPTION
We now build the OCaml libraries by default; this may allow us to drop
annoying `Serapi_` prefix from module names.