### PR TITLE
added sertop option --topfile <filename>

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,4 +1,5 @@
 Emilio Jesús Gallego Arias
 Karl Palmskog
+Vasily Pestun
 Clément Pit--Claudel
 Kaiyu Yang

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,7 @@
 ## Version 0.11.1:
 
+ * [sertop]  Added option `--topfile` to sertop to set top name from
+             a filename
  * [deps]    Require sexplib >= 0.12 , fixed deprecation warnings
              (#???, @ejgallego)
  * [general] SerAPI is now tested with OCaml 4.08 and 4.09

--- a/sertop/sertop_arg.ml
+++ b/sertop/sertop_arg.ml
@@ -82,6 +82,12 @@ let no_init =
              and set there the proper loadpath, requires, ..." in
   Arg.(value & flag & info ["no_init"] ~doc)
 
+let topfile =
+  let doc = "Set the toplevel name as though compiling $(docv)" in
+  Arg.(value & opt (some string) None & info ["topfile"] ~doc ~docv:"TOPFILE")
+
+
+
 let no_prelude =
   let doc = "Omits requiring any module on start, thus `Prelude`, ltac, etc... won't be available" in
   Arg.(value & flag & info ["no_prelude"] ~doc)

--- a/sertop/sertop_arg.mli
+++ b/sertop/sertop_arg.mli
@@ -33,6 +33,7 @@ val rload_path      : Loadpath.coq_path list Term.t
 val load_path       : Loadpath.coq_path list Term.t
 val ml_include_path : Loadpath.coq_path list Term.t
 val no_init         : bool Term.t
+val topfile         : string option Term.t
 val no_prelude      : bool Term.t
 
 (* sertop options *)

--- a/sertop/sertop_bin.ml
+++ b/sertop/sertop_bin.ml
@@ -19,7 +19,7 @@
 open Cmdliner
 
 let sertop_version = Sertop.Ser_version.ser_git_version
-let sertop printer print0 debug lheader coq_path ml_path no_init no_prelude lp1 lp2 _std_impl async deep_edits async_workers omit_loc omit_att exn_on_opaque =
+let sertop printer print0 debug lheader coq_path ml_path no_init topfile no_prelude lp1 lp2 _std_impl async deep_edits async_workers omit_loc omit_att exn_on_opaque =
 
   let open  Sertop.Sertop_init         in
   let open! Sertop.Sertop_sexp         in
@@ -41,6 +41,7 @@ let sertop printer print0 debug lheader coq_path ml_path no_init no_prelude lp1 
 
        no_init;
        no_prelude;
+       topfile;
        loadpath;
 
        async = {
@@ -71,7 +72,7 @@ let sertop_cmd =
   ]
   in
   Term.(const sertop
-        $ printer $ print0 $ debug $ length $ prelude $ ml_include_path $ no_init $ no_prelude $ load_path $ rload_path $ implicit_stdlib
+        $ printer $ print0 $ debug $ length $ prelude $ ml_include_path $ no_init $topfile $ no_prelude $ load_path $ rload_path $ implicit_stdlib
         $ async $ deep_edits $ async_workers $ omit_loc $ omit_att $ exn_on_opaque ),
   Term.info "sertop" ~version:sertop_version ~doc ~man
 

--- a/sertop/sertop_sexp.ml
+++ b/sertop/sertop_sexp.ml
@@ -38,7 +38,7 @@ type ser_opts =
   (* Coq options *)
 ; no_init  : bool                (* Whether to create the initial document     *)
 ; no_prelude : bool              (* Whether to load stdlib's prelude           *)
-
+; topfile  : string option       (* Top name is derived from topfile name      *)
 ; loadpath : Loadpath.coq_path list (* From -R and -Q options usually *)
 ; async    : Sertop_init.async_flags
 }
@@ -97,6 +97,16 @@ let out_answer opts =
   let pp_sexp = out_sexp opts in
   fun fmt a -> pp_sexp fmt (Sertop_ser.sexp_of_answer a)
 
+(** Set the topname from optional topfile string or default if None **)
+let doc_type topfile =
+  match topfile with
+  | None ->
+     let sertop_dp = Names.(DirPath.make [Id.of_string "SerTop"]) in
+     Stm.Interactive (TopLogical sertop_dp)
+  | Some filename ->
+     Stm.VoDoc filename
+
+
 let ser_loop ser_opts =
 
   let open List   in
@@ -138,8 +148,7 @@ let ser_loop ser_opts =
   let stm_options = Sertop_init.process_stm_flags ser_opts.async in
 
   if not ser_opts.no_init then begin
-    let sertop_dp = Names.(DirPath.make [Id.of_string "SerTop"]) in
-    let ndoc = { Stm.doc_type = Stm.Interactive (TopLogical sertop_dp)
+    let ndoc = { Stm.doc_type = doc_type ser_opts.topfile
                ; require_libs
                ; iload_path
                ; stm_options

--- a/sertop/sertop_sexp.mli
+++ b/sertop/sertop_sexp.mli
@@ -33,6 +33,7 @@ type ser_opts =
 
 ; no_init  : bool                (** Whether to create the initial document   *)
 ; no_prelude : bool              (** Whether to load stdlib's prelude         *)
+; topfile  : string option       (** Top name is derived from topfile name    *)
 
 (* Coq options *)
 ; loadpath : Loadpath.coq_path list (** From -R and -Q options usually           *)


### PR DESCRIPTION
the effect is equivalent to coqtop option -topfile

if --topfile <filename> is present, the top name is set as if <filename> is compiled,
otherwise the top name is (SerTop)