### PR TITLE
* set allow-sprop true by default at the init of coq 

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,7 @@
 ## Version 0.11.1:
+ * [sertop]  Set default value of allow-sprop to be true in agreement with upstream coq v8.11
+             and added option '--disallow-sprop' to optionally switch it off
+			 (--disallow-sprop forbids using the proof irrelevant SProp sort)
 
  * [sertop]  Added option `--topfile` to sertop to set top name from
              a filename

--- a/sertop/sercomp.ml
+++ b/sertop/sercomp.ml
@@ -23,7 +23,7 @@ let fatal_exn exn info =
   Format.eprintf "Error: @[%a@]@\n%!" Pp.pp_with msg;
   exit 1
 
-let create_document ~in_file ~async ~async_workers ~quick ~iload_path ~debug =
+let create_document ~in_file ~async ~async_workers ~quick ~iload_path ~debug ~allow_sprop =
 
   let open Sertop.Sertop_init in
 
@@ -32,6 +32,7 @@ let create_document ~in_file ~async ~async_workers ~quick ~iload_path ~debug =
     { fb_handler = (fun _ -> ())  (* XXXX *)
     ; ml_load    = None
     ; debug
+    ; allow_sprop
     };
 
   (* document initialization *)
@@ -182,7 +183,7 @@ let sercomp_doc = "sercomp Coq Compiler"
 
 open Cmdliner
 
-let driver input mode debug printer async async_workers quick coq_path ml_path load_path rload_path in_file omit_loc omit_att exn_on_opaque =
+let driver input mode debug disallow_sprop printer async async_workers quick coq_path ml_path load_path rload_path in_file omit_loc omit_att exn_on_opaque =
 
   (* closures *)
   let pp = Sertop.Sertop_ser.select_printer printer in
@@ -193,7 +194,8 @@ let driver input mode debug printer async async_workers quick coq_path ml_path l
   Serlib.Serlib_init.init ~options;
 
   let iload_path = Serapi.Serapi_paths.coq_loadpath_default ~implicit:true ~coq_path @ ml_path @ load_path @ rload_path in
-  let doc, sid = create_document ~in_file ~async ~async_workers ~quick ~iload_path ~debug in
+  let allow_sprop = not disallow_sprop in
+  let doc, sid = create_document ~in_file ~async ~async_workers ~quick ~iload_path ~debug ~allow_sprop in
 
   (* main loop *)
   let in_chan = open_in in_file in
@@ -214,7 +216,7 @@ let main () =
   let sercomp_cmd =
     let open Sertop.Sertop_arg in
     Term.(const driver
-          $ comp_input $ comp_mode $ debug $ printer $ async $ async_workers $ quick $ prelude
+          $ comp_input $ comp_mode $ debug $ disallow_sprop $ printer $ async $ async_workers $ quick $ prelude
           $ ml_include_path $ load_path $ rload_path $ input_file $ omit_loc $ omit_att $ exn_on_opaque
          ),
     Term.info "sercomp" ~version:sercomp_version ~doc:sercomp_doc ~man:sercomp_man

--- a/sertop/sertok.ml
+++ b/sertop/sertok.ml
@@ -30,7 +30,7 @@ let fatal_exn exn info =
   Format.eprintf "Error: @[%a@]@\n%!" Pp.pp_with msg;
   exit 1
 
-let create_document ~in_file ~async ~async_workers ~quick ~iload_path ~debug =
+let create_document ~in_file ~async ~async_workers ~quick ~iload_path ~debug ~allow_sprop =
 
   let open Sertop.Sertop_init in
 
@@ -39,6 +39,7 @@ let create_document ~in_file ~async ~async_workers ~quick ~iload_path ~debug =
     { fb_handler = (fun _ -> ())  (* XXXX *)
     ; ml_load    = None
     ; debug
+    ; allow_sprop
     };
 
   (* document initialization *)
@@ -166,7 +167,7 @@ let sertok_doc = "sertok Coq tokenizer"
 
 open Cmdliner
 
-let driver debug printer async async_workers quick coq_path ml_path load_path rload_path in_file omit_loc omit_att exn_on_opaque =
+let driver debug disallow_sprop printer async async_workers quick coq_path ml_path load_path rload_path in_file omit_loc omit_att exn_on_opaque =
 
   (* closures *)
   let pp = Sertop.Sertop_ser.select_printer printer in
@@ -176,7 +177,8 @@ let driver debug printer async async_workers quick coq_path ml_path load_path rl
   Serlib.Serlib_init.init ~options;
 
   let iload_path = Serapi.Serapi_paths.coq_loadpath_default ~implicit:true ~coq_path @ ml_path @ load_path @ rload_path in
-  let doc, sid = create_document ~in_file ~async ~async_workers ~quick ~iload_path ~debug in
+  let allow_sprop = not disallow_sprop in
+  let doc, sid = create_document ~in_file ~async ~async_workers ~quick ~iload_path ~debug ~allow_sprop in
 
   (* main loop *)
   let in_chan = open_in in_file in
@@ -197,7 +199,7 @@ let main () =
   let sertok_cmd =
     let open Sertop.Sertop_arg in
     Term.(const driver
-          $ debug $ printer $ async $ async_workers $ quick $ prelude
+          $ debug $ disallow_sprop $ printer $ async $ async_workers $ quick $ prelude
           $ ml_include_path $ load_path $ rload_path $ input_file $ omit_loc $ omit_att $ exn_on_opaque
          ),
     Term.info "sertok" ~version:sertok_version ~doc:sertok_doc ~man:sertok_man

--- a/sertop/sertop_arg.ml
+++ b/sertop/sertop_arg.ml
@@ -66,6 +66,10 @@ let debug =
   let doc = "Enable debug mode for Coq." in
   Arg.(value & flag & info ["debug"] ~doc)
 
+let disallow_sprop =
+  let doc = "Forbid using the proof irrelevant SProp sort (allowed by default)" in
+  Arg.(value & flag & info ["disallow-sprop"] ~doc)
+
 let print0 =
   let doc = "End responses with a \\\\0 char." in
   Arg.(value & flag & info ["print0"] ~doc)

--- a/sertop/sertop_arg.mli
+++ b/sertop/sertop_arg.mli
@@ -27,6 +27,7 @@ val async_workers   : int Term.t
 val implicit_stdlib : bool Term.t
 val printer         : Sertop_ser.ser_printer Term.t
 val debug           : bool Term.t
+val disallow_sprop  : bool Term.t
 val print0          : bool Term.t
 val length          : bool Term.t
 val rload_path      : Loadpath.coq_path list Term.t

--- a/sertop/sertop_async.ml
+++ b/sertop/sertop_async.ml
@@ -32,7 +32,7 @@ let read_cmd cmd_sexp : [`Error of Sexp.t | `Ok of string * cmd ] =
       `Error (Conv.sexp_of_exn exn)
 
 (* Initialize Coq. *)
-let sertop_init ~(fb_out : Sexp.t -> unit) ~iload_path ~require_libs ~debug =
+let sertop_init ~(fb_out : Sexp.t -> unit) ~iload_path ~require_libs ~debug ~allow_sprop =
   let open! Sertop.Sertop_init in
 
   let fb_handler fb = Sertop.Sertop_ser.sexp_of_answer (Feedback (Sertop.Sertop_util.feedback_tr fb)) |> fb_out in
@@ -41,6 +41,7 @@ let sertop_init ~(fb_out : Sexp.t -> unit) ~iload_path ~require_libs ~debug =
     fb_handler;
     ml_load = None;
     debug;
+    allow_sprop;
   };
 
   let stm_options = process_stm_flags

--- a/sertop/sertop_async.mli
+++ b/sertop/sertop_async.mli
@@ -22,6 +22,7 @@ val sertop_init :
   iload_path:Loadpath.coq_path list ->
   require_libs:(string * string option * bool option) list ->
   debug:bool ->
+  allow_sprop:bool ->
   Stm.doc * Stateid.t
 
 (** [sertop_callback out input] Execute command [input] and send

--- a/sertop/sertop_bin.ml
+++ b/sertop/sertop_bin.ml
@@ -19,7 +19,7 @@
 open Cmdliner
 
 let sertop_version = Sertop.Ser_version.ser_git_version
-let sertop printer print0 debug lheader coq_path ml_path no_init topfile no_prelude lp1 lp2 _std_impl async deep_edits async_workers omit_loc omit_att exn_on_opaque =
+let sertop printer print0 debug disallow_sprop lheader coq_path ml_path no_init topfile no_prelude lp1 lp2 _std_impl async deep_edits async_workers omit_loc omit_att exn_on_opaque =
 
   let open  Sertop.Sertop_init         in
   let open! Sertop.Sertop_sexp         in
@@ -28,13 +28,15 @@ let sertop printer print0 debug lheader coq_path ml_path no_init topfile no_prel
   Serlib.Serlib_init.init ~options;
 
   let loadpath = Serapi.Serapi_paths.coq_loadpath_default ~implicit:true ~coq_path @
-                 ml_path @ lp1 @ lp2 in
+                   ml_path @ lp1 @ lp2 in
+  let allow_sprop = not disallow_sprop in
 
   ser_loop
     {  in_chan  = stdin;
        out_chan = stdout;
 
        debug;
+       allow_sprop;
        printer;
        print0;
        lheader;
@@ -72,7 +74,7 @@ let sertop_cmd =
   ]
   in
   Term.(const sertop
-        $ printer $ print0 $ debug $ length $ prelude $ ml_include_path $ no_init $topfile $ no_prelude $ load_path $ rload_path $ implicit_stdlib
+        $ printer $ print0 $ debug $ disallow_sprop $ length $ prelude $ ml_include_path $ no_init $topfile $ no_prelude $ load_path $ rload_path $ implicit_stdlib
         $ async $ deep_edits $ async_workers $ omit_loc $ omit_att $ exn_on_opaque ),
   Term.info "sertop" ~version:sertop_version ~doc ~man
 

--- a/sertop/sertop_init.ml
+++ b/sertop/sertop_init.ml
@@ -33,6 +33,8 @@ type coq_opts = {
   (* Enable Coq Debug mode *)
   debug        : bool;
 
+  (* Allow SProp *)
+  allow_sprop  : bool;
 }
 
 (**************************************************************************)
@@ -66,6 +68,10 @@ let coq_init opts =
   (* This should be configurable somehow. *)
   Global.set_engagement Declarations.PredicativeSet;
   Global.set_indices_matter false;
+
+  (* --allow-sprop in agreement with coq v8.11  *)
+  Global.set_allow_sprop opts.allow_sprop;
+
 
   (**************************************************************************)
   (* Feedback setup                                                         *)

--- a/sertop/sertop_init.mli
+++ b/sertop/sertop_init.mli
@@ -35,6 +35,10 @@ type coq_opts =
 
   ; debug        : bool
   (** Enable Coq Debug mode             *)
+
+  ; allow_sprop  : bool
+  (** allow using the proof irrelevant SProp sort (default=true) *)
+  (** switch off using --disallow-sprop option *)
 }
 
 val coq_init : coq_opts -> unit

--- a/sertop/sertop_init.mli
+++ b/sertop/sertop_init.mli
@@ -38,7 +38,6 @@ type coq_opts =
 
   ; allow_sprop  : bool
   (** allow using the proof irrelevant SProp sort (default=true) *)
-  (** switch off using --disallow-sprop option *)
 }
 
 val coq_init : coq_opts -> unit

--- a/sertop/sertop_js.ml
+++ b/sertop/sertop_js.ml
@@ -117,7 +117,8 @@ let _ =
       let iload_path  = List.map pkg_to_bb all_pkgs                      in
       let require_libs= ["Coq.Init.Prelude", None, Some true]            in
       let debug       = false                                            in
-      ignore (sertop_init ~fb_out:post_message ~iload_path ~require_libs ~debug);
+      let allow_sprop = true                                             in
+      ignore (sertop_init ~fb_out:post_message ~iload_path ~require_libs ~debug ~allow_sprop);
       (* We only accept messages when Coq is ready.             *)
       Worker.set_onmessage on_msg;
       return_unit

--- a/sertop/sertop_sexp.ml
+++ b/sertop/sertop_sexp.ml
@@ -32,6 +32,7 @@ type ser_opts =
 ; printer  : Sertop_ser.ser_printer
 
 ; debug    : bool
+; allow_sprop: bool
 ; print0   : bool
 ; lheader  : bool                (* Print lenght header (deprecated)           *)
 
@@ -131,6 +132,7 @@ let ser_loop ser_opts =
         { fb_handler   = pp_feed
         ; ml_load      = None
         ; debug        = ser_opts.debug
+        ; allow_sprop  = ser_opts.allow_sprop
         })
   in
 

--- a/sertop/sertop_sexp.mli
+++ b/sertop/sertop_sexp.mli
@@ -28,6 +28,7 @@ type ser_opts =
                                  (** Printer type                             *)
 
 ; debug    : bool                (** Enable Coq debug mode                    *)
+; allow_sprop: bool              (** Allow using the proof irrelevant SProp sort *)
 ; print0   : bool                (** End every answer with [\0]               *)
 ; lheader  : bool                (** Print lenght header (deprecated)         *)
 


### PR DESCRIPTION
in agreement with upstream coq v8.11 as per discussion
https://github.com/ejgallego/coq-serapi/issues/198
with the option  --disallow-sprop that sets allow-sprop false
and thus forbids using the proof irrelevant SProp sort