### PR TITLE
[serapi] New option `--error-recovery` to enable error recovery.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,11 +1,19 @@
 ## Version 0.11.1:
 
+ * [general] Coq's error recovery is now disabled by default
+             (@ejgallego , fixes #201)
+ * [general] New option `--error-recovery` to enable error recovery
+             (@ejgallego , #203)
  * [general] Bump sexplib dependency to v0.13 (@ejgallego , #204)
              Fixes incorrect change in #194.
  * [sertop]  Set default value of allow-sprop to be true in agreement with upstream coq v8.11
              and added option '--disallow-sprop' to optionally switch it off
 			 (--disallow-sprop forbids using the proof irrelevant SProp sort)
              (#199, @pestun)
+ * [sertop]  Set default value of allow-sprop to be true in agreement with upstream coq v8.11
+             and added option '--disallow-sprop' to optionally switch it off
+			 (--disallow-sprop forbids using the proof irrelevant SProp sort)
+             (@pestun , #199)
  * [sertop]  Added option `--topfile` to sertop to set top name from
              a filename (#197, @pestun)
  * [deps]    Require sexplib >= 0.12 , fixed deprecation warnings

--- a/sertop/sercomp.ml
+++ b/sertop/sercomp.ml
@@ -23,7 +23,7 @@ let fatal_exn exn info =
   Format.eprintf "Error: @[%a@]@\n%!" Pp.pp_with msg;
   exit 1
 
-let create_document ~in_file ~async ~async_workers ~quick ~iload_path ~debug ~allow_sprop =
+let create_document ~in_file ~stm_flags ~quick ~iload_path ~debug ~allow_sprop =
 
   let open Sertop.Sertop_init in
 
@@ -37,11 +37,7 @@ let create_document ~in_file ~async ~async_workers ~quick ~iload_path ~debug ~al
 
   (* document initialization *)
 
-  let stm_options = process_stm_flags
-      { enable_async  = async
-      ; deep_edits    = false
-      ; async_workers = async_workers
-      } in
+  let stm_options = process_stm_flags stm_flags in
 
   (* Disable due to https://github.com/ejgallego/coq-serapi/pull/94 *)
   let stm_options =
@@ -66,7 +62,7 @@ let create_document ~in_file ~async ~async_workers ~quick ~iload_path ~debug ~al
 
   (* Workaround, see
      https://github.com/ejgallego/coq-serapi/pull/101 *)
-  if quick || async <> None
+  if quick || stm_flags.enable_async <> None
   then Safe_typing.allow_delayed_constants := true;
 
   Stm.new_doc ndoc
@@ -183,7 +179,8 @@ let sercomp_doc = "sercomp Coq Compiler"
 
 open Cmdliner
 
-let driver input mode debug disallow_sprop printer async async_workers quick coq_path ml_path load_path rload_path in_file omit_loc omit_att exn_on_opaque =
+let driver input mode debug disallow_sprop printer async async_workers error_recovery quick
+    coq_path ml_path load_path rload_path in_file omit_loc omit_att exn_on_opaque =
 
   (* closures *)
   let pp = Sertop.Sertop_ser.select_printer printer in
@@ -195,7 +192,13 @@ let driver input mode debug disallow_sprop printer async async_workers quick coq
 
   let iload_path = Serapi.Serapi_paths.coq_loadpath_default ~implicit:true ~coq_path @ ml_path @ load_path @ rload_path in
   let allow_sprop = not disallow_sprop in
-  let doc, sid = create_document ~in_file ~async ~async_workers ~quick ~iload_path ~debug ~allow_sprop in
+  let stm_flags =
+    { Sertop.Sertop_init.enable_async = async
+    ; deep_edits = false
+    ; async_workers
+    ; error_recovery
+    } in
+  let doc, sid = create_document ~in_file ~stm_flags ~quick ~iload_path ~debug ~allow_sprop in
 
   (* main loop *)
   let in_chan = open_in in_file in
@@ -216,7 +219,7 @@ let main () =
   let sercomp_cmd =
     let open Sertop.Sertop_arg in
     Term.(const driver
-          $ comp_input $ comp_mode $ debug $ disallow_sprop $ printer $ async $ async_workers $ quick $ prelude
+          $ comp_input $ comp_mode $ debug $ disallow_sprop $ printer $ async $ async_workers $ error_recovery $ quick $ prelude
           $ ml_include_path $ load_path $ rload_path $ input_file $ omit_loc $ omit_att $ exn_on_opaque
          ),
     Term.info "sercomp" ~version:sercomp_version ~doc:sercomp_doc ~man:sercomp_man

--- a/sertop/sertop_arg.ml
+++ b/sertop/sertop_arg.ml
@@ -43,6 +43,10 @@ let async_workers =
   let doc = "Maximum number of async workers." in
   Arg.(value & opt int 3 & info ["async-workers"] ~doc)
 
+let error_recovery =
+  let doc = "Enable Coq's error recovery inside tactics and commands." in
+  Arg.(value & flag & info ["error-recovery"] ~doc)
+
 let implicit_stdlib =
   let doc = "No-op (used to allow loading unqualified stdlib libraries, which is now the default)." in
   Arg.(value & flag & info ["implicit"] ~doc)

--- a/sertop/sertop_arg.mli
+++ b/sertop/sertop_arg.mli
@@ -24,6 +24,7 @@ val quick           : bool Term.t
 val async_full      : bool Term.t
 val deep_edits      : bool Term.t
 val async_workers   : int Term.t
+val error_recovery  : bool Term.t
 val implicit_stdlib : bool Term.t
 val printer         : Sertop_ser.ser_printer Term.t
 val debug           : bool Term.t

--- a/sertop/sertop_async.ml
+++ b/sertop/sertop_async.ml
@@ -45,9 +45,10 @@ let sertop_init ~(fb_out : Sexp.t -> unit) ~iload_path ~require_libs ~debug ~all
   };
 
   let stm_options = process_stm_flags
-    { enable_async  = None;
-      deep_edits    = false;
-      async_workers = 0;
+    { enable_async  = None
+    ; deep_edits    = false
+    ; async_workers = 0
+    ; error_recovery = false
     } in
 
   let open Stm in

--- a/sertop/sertop_bin.ml
+++ b/sertop/sertop_bin.ml
@@ -19,7 +19,8 @@
 open Cmdliner
 
 let sertop_version = Sertop.Ser_version.ser_git_version
-let sertop printer print0 debug disallow_sprop lheader coq_path ml_path no_init topfile no_prelude lp1 lp2 _std_impl async deep_edits async_workers omit_loc omit_att exn_on_opaque =
+
+let sertop printer print0 debug disallow_sprop lheader coq_path ml_path no_init topfile no_prelude lp1 lp2 _std_impl async deep_edits async_workers error_recovery omit_loc omit_att exn_on_opaque =
 
   let open  Sertop.Sertop_init         in
   let open! Sertop.Sertop_sexp         in
@@ -46,10 +47,11 @@ let sertop printer print0 debug disallow_sprop lheader coq_path ml_path no_init 
        topfile;
        loadpath;
 
-       async = {
-         enable_async = async;
-         deep_edits = deep_edits;
-         async_workers = async_workers;
+       async =
+         { enable_async = async
+         ; deep_edits
+         ; async_workers
+         ; error_recovery
        }
     }
 
@@ -75,7 +77,7 @@ let sertop_cmd =
   in
   Term.(const sertop
         $ printer $ print0 $ debug $ disallow_sprop $ length $ prelude $ ml_include_path $ no_init $topfile $ no_prelude $ load_path $ rload_path $ implicit_stdlib
-        $ async $ deep_edits $ async_workers $ omit_loc $ omit_att $ exn_on_opaque ),
+        $ async $ deep_edits $ async_workers $ error_recovery $ omit_loc $ omit_att $ exn_on_opaque ),
   Term.info "sertop" ~version:sertop_version ~doc ~man
 
 let main () =

--- a/sertop/sertop_init.mli
+++ b/sertop/sertop_init.mli
@@ -20,6 +20,7 @@ type async_flags =
   { enable_async  : string option
   ; deep_edits    : bool
   ; async_workers : int
+  ; error_recovery : bool
   }
 (** SerAPI flags for asynchronous processing *)
 


### PR DESCRIPTION
Error recovery is now off by default. This seems to be more in line
with what users do expect. Fixes #201