### PR TITLE
[build] Bump minimum sexplib version to v0.13

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,14 +1,16 @@
 ## Version 0.11.1:
+
+ * [general] Bump sexplib dependency to v0.13 (@ejgallego , #204)
+             Fixes incorrect change in #194.
  * [sertop]  Set default value of allow-sprop to be true in agreement with upstream coq v8.11
              and added option '--disallow-sprop' to optionally switch it off
 			 (--disallow-sprop forbids using the proof irrelevant SProp sort)
-             (@pestun , #199)
-
+             (#199, @pestun)
  * [sertop]  Added option `--topfile` to sertop to set top name from
-             a filename
+             a filename (#197, @pestun)
  * [deps]    Require sexplib >= 0.12 , fixed deprecation warnings
-             (#???, @ejgallego)
- * [general] SerAPI is now tested with OCaml 4.08 and 4.09
+             (#194, @ejgallego)
+ * [general] SerAPI is now tested with OCaml 4.08 and 4.09 (#195 , @ejgallego)
 
 ## Version 0.11.0:
 

--- a/coq-serapi.opam
+++ b/coq-serapi.opam
@@ -27,7 +27,7 @@ depends: [
   "coq"                 { !pinned & >= "8.11.0" & < "8.12" }
   "cmdliner"            {           >= "1.0.0"             }
   "ocamlfind"           {           >= "1.8.0"             }
-  "sexplib"             {           >= "v0.12.0"           }
+  "sexplib"             {           >= "v0.13.0"           }
   "dune"                {           >= "1.4.0"             }
   "ppx_import"          { build   & >= "1.5-3"             }
   "ppx_deriving"        {           >= "4.2.1"             }


### PR DESCRIPTION
PR #194 was actually incorrect, deprecations of alias types seem to
have happened in ppx_sexp_conv v0.13 , thus SerAPI was broken in v0.12
after it.