### PR TITLE
[serapi] New query `Comments` to return all comments in a document

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,7 +14,7 @@
              and added option '--disallow-sprop' to optionally switch it off
 			 (--disallow-sprop forbids using the proof irrelevant SProp sort)
              (@pestun , #199)
- * [sertop]  Added option `--topfile` to sertop to set top name from
+ * [sertop]  Added option `--topfile` to `sertop` to set top name from
              a filename (#197, @pestun)
  * [deps]    Require sexplib >= 0.12 , fixed deprecation warnings
              (#194, @ejgallego)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,7 @@
 ## Version 0.11.1:
 
+ * [serapi]  New query `Comments` to return all comments in a document
+             (@ejgallego, #20? , (partially) fixes #191 , #200 )
  * [general] Coq's error recovery is now disabled by default
              (@ejgallego , fixes #201)
  * [general] New option `--error-recovery` to enable error recovery

--- a/serapi/serapi_protocol.mli
+++ b/serapi/serapi_protocol.mli
@@ -229,6 +229,14 @@ type coq_object =
   (** Proof object: really low-level and likely to be deprecated. *)
   | CoqAssumptions of Serapi_assumptions.t
   (** Structured representation of the assumptions of a constant. *)
+  | CoqComments of ((int * int) * string) list list
+  (** List of comments in a document, the list will have one element
+     for each call to [Add]; note that with the current model, it is
+     hard to do better, as a call to [Add] can map to several
+     sentences so comments are really mapped to each of those.
+
+     See https://github.com/coq/coq/issues/12413 for updates on
+     improved support *)
 
 (******************************************************************************)
 (* Printing Sub-Protocol                                                      *)
@@ -346,6 +354,8 @@ type query_cmd =
   (** Return the assumptions of a given global *)
   | Complete of string
   (** Naïve but efficient prefix-based completion of identifiers *)
+  | Comments
+  (** Get all comments of a document *)
 
 (******************************************************************************)
 (* Control Sub-Protocol                                                       *)


### PR DESCRIPTION
This doesn't fully provide a solution for the problem of comments
being ignored by SerAPI, but at least users can now workaround that by
getting all the comments and properly splicing them.

Provides a workaround / improves #191, #200 .

We defer further discussion to the upstream issue
https://github.com/coq/coq/issues/12413