### PR TITLE
coqtop --topfile will create document using Stm.Interactive and not Stm.VoDoc

### DIFF
--- a/sertop/sertop_sexp.ml
+++ b/sertop/sertop_sexp.ml
@@ -104,8 +104,7 @@ let doc_type topfile =
   | None ->
      let sertop_dp = Names.(DirPath.make [Id.of_string "SerTop"]) in
      Stm.Interactive (TopLogical sertop_dp)
-  | Some filename ->
-     Stm.VoDoc filename
+  | Some filename -> Stm.Interactive (Stm.TopPhysical filename)
 
 
 let ser_loop ser_opts =


### PR DESCRIPTION
the purpose of --topfile option is to set the top name while the remaining behaviour is expected to be the same

this patch mirror upstream and uses Stm.TopPhysical filename when --topfile filename is present; 
in particular command (Query () Goals) behaves consistent with interactive mode