### PR TITLE
Some updates with Coq v8.12

### DIFF
--- a/serlib/ser_notation_gram.ml
+++ b/serlib/ser_notation_gram.ml
@@ -37,9 +37,11 @@ type grammar_constr_prod_item =
   [%import: Notation_gram.grammar_constr_prod_item]
   [@@deriving sexp]
 
-type level =
-  [%import: Notation_gram.level]
-  [@@deriving sexp]
+module Notation = struct
+  type level =
+    [%import: Notation.level]
+    [@@deriving sexp]
+end
 
 type one_notation_grammar =
   [%import: Notation_gram.one_notation_grammar]

--- a/serlib/ser_vernacexpr.ml
+++ b/serlib/ser_vernacexpr.ml
@@ -126,6 +126,10 @@ type definition_expr =
   [%import: Vernacexpr.definition_expr]
   [@@deriving sexp,yojson]
 
+type syntax_modifier =
+  [%import: Vernacexpr.syntax_modifier]
+  [@@deriving sexp,yojson]
+
 type decl_notation =
   [%import: Vernacexpr.decl_notation]
   [@@deriving sexp,yojson]
@@ -200,10 +204,6 @@ type one_inductive_expr =
 
 type proof_expr =
   [%import: Vernacexpr.proof_expr]
-  [@@deriving sexp,yojson]
-
-type syntax_modifier =
-  [%import: Vernacexpr.syntax_modifier]
   [@@deriving sexp,yojson]
 
 type opacity_flag =


### PR DESCRIPTION
I encountered a few errors in serlib, probably as a result of some cleanup in Coq.

`Notation.level` is now needed; I wanted to add it in Ser_notation, but there are cyclic deps and Ser_constrexpr does not have an mli...