### PR TITLE
[general] Port to Coq v8.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,11 +27,11 @@ env:
   - OPAMYES="true"
   - NJOBS="2"
   - COQ_REPOS="https://github.com/coq/coq.git"
-  - COQ_VERSION="v8.11"
-  - COQ_BRANCH="v8.11"
+  - COQ_VERSION="v8.12"
+  - COQ_BRANCH="v8.12"
   - COQ_CONF="-local -native-compiler no -coqide no"
   - COMPILER="4.07.1"
-  - EXTRA_OPAM="coq.8.11.2 coq-mathcomp-ssreflect"
+  - EXTRA_OPAM="coq.8.12.0 coq-mathcomp-ssreflect"
   # - SERAPI_COQ_HOME="$HOME/coq-$COQ_VERSION/_build/install/default/lib/"
   # Main test suites
   matrix:
@@ -41,11 +41,13 @@ env:
   # Don't test opam in 8.11 [yet]
   - TEST_TARGET="test"    COMPILER="4.07.1"
   - TEST_TARGET="test"    COMPILER="4.08.1"
-  - TEST_TARGET="test"    COMPILER="4.09.0"
-  - TEST_TARGET="js-dune" COMPILER="4.07.1+32bit" EXTRA_OPAM="coq.8.11.2 js_of_ocaml js_of_ocaml-lwt"
+  - TEST_TARGET="test"    COMPILER="4.09.1"
+  - TEST_TARGET="test"    COMPILER="4.10.1"
+  - TEST_TARGET="js-dune" COMPILER="4.07.1+32bit" EXTRA_OPAM="coq.8.12.0 js_of_ocaml js_of_ocaml-lwt"
+  - TEST_TARGET="test"    COMPILER="4.10.1" EXTRA_OPAM="dune" SERAPI_COQ_HOME="$HOME/coq-$COQ_VERSION/_build/install/default/lib/"
 
 install:
-- sudo curl -sL https://github.com/ocaml/opam/releases/download/2.0.6/opam-2.0.6-x86_64-linux -o /usr/bin/opam
+- sudo curl -sL https://github.com/ocaml/opam/releases/download/2.0.7/opam-2.0.7-x86_64-linux -o /usr/bin/opam
 - sudo chmod 755 /usr/bin/opam
 - opam init -c "$COMPILER" --disable-sandboxing
 - opam switch set "$COMPILER"
@@ -61,7 +63,7 @@ install:
   if [[ -v SERAPI_COQ_HOME ]]; then
     git clone --depth=3 -b "$COQ_BRANCH" "$COQ_REPOS" "$HOME/coq-$COQ_VERSION" &&
     pushd "$HOME/coq-$COQ_VERSION"        &&
-    make -f Makefile.dune coq             &&
+    make -f Makefile.dune world           &&
     popd;
     PATH="$HOME/coq-$COQ_VERSION/_build/install/default/bin":$PATH &&
     git clone --depth=3 -b master https://github.com/math-comp/math-comp.git &&
@@ -69,7 +71,7 @@ install:
     make && make install &&
     popd;
   fi
-- if [[ -v EXTRA_OPAM ]]; then opam install --ignore-constraints-on=coq $EXTRA_OPAM; fi
+- if [[ -v EXTRA_OPAM ]]; then travis_wait opam install --ignore-constraints-on=coq $EXTRA_OPAM; fi
 
 script:
 - set -e

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,10 @@
+## Version 0.12.0:
+
+ * [general] (!) support Coq 8.12, main changes upstream related to
+             the representation of numerals and notations.
+             The rest of the interface does remain relative stable.
+             (@ejgallego).
+
 ## Version 0.11.1:
 
  * [general] Require dune >= 2.0 (@ejgallego, ??)

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 # Leave empty to use OPAM-installed Coq
 SERAPI_COQ_HOME ?=
-# SERAPI_COQ_HOME=/home/egallego/external/coq-v8.11/_build/install/default/lib/
+# SERAPI_COQ_HOME=/home/egallego/external/coq-v8.12/_build/install/default/lib/
 # SERAPI_COQ_HOME=/home/egallego/research/jscoq/coq-external/coq-v8.9+32bit/
 
 ifneq ($SERAPI_COQ_HOME,)

--- a/coq-serapi.opam
+++ b/coq-serapi.opam
@@ -24,7 +24,7 @@ authors: [
 
 depends: [
   "ocaml"               {           >= "4.07.0"              }
-  "coq"                 { !pinned & >= "8.11.0" & < "8.12"   }
+  "coq"                 { !pinned & >= "8.12.0" & < "8.13"   }
   "cmdliner"            {           >= "1.0.0"               }
   "ocamlfind"           {           >= "1.8.0"               }
   "sexplib"             {           >= "v0.13.0"             }

--- a/serapi/serapi_assumptions.ml
+++ b/serapi/serapi_assumptions.ml
@@ -73,9 +73,6 @@ let print env sigma { predicative; type_in_type; vars; axioms; opaque; trans } =
         Pp.(seq [Printer.pr_inductive env (m,0); str "is positive."])
       | Guarded gr ->
         Pp.(seq [Printer.pr_global gr; str "is positive."])
-      | TemplatePolymorphic m ->
-        Pp.(seq [Printer.pr_inductive env (m,0); spc ();
-                 strbrk "is assumed template polymorphic on all its universe parameters."])
       | TypeInType gr ->
         Pp.(seq [Printer.pr_global gr; spc (); strbrk "relies on an unsafe hierarchy."])
     in

--- a/serapi/serapi_goals.ml
+++ b/serapi/serapi_goals.ml
@@ -91,4 +91,4 @@ let get_goals_gen (ppx : Environ.env -> Evd.evar_map -> Constr.t -> 'a) ~doc sid
   | `Expired | `Error _ | `Valid _ -> None
 
 let get_goals  = get_goals_gen (fun _ _ x -> x)
-let get_egoals = get_goals_gen (fun env evd ec -> Constrextern.extern_constr true env evd EConstr.(of_constr ec))
+let get_egoals = get_goals_gen (fun env evd ec -> Constrextern.extern_constr ~inctx:true env evd EConstr.(of_constr ec))

--- a/serapi/serapi_paths.ml
+++ b/serapi/serapi_paths.ml
@@ -23,23 +23,27 @@
 let coq_loadpath_default ~implicit ~coq_path =
   let open Loadpath in
   let mk_path prefix = coq_path ^ "/" ^ prefix in
-  let mk_lp ~ml ~root ~dir ~implicit =
-    { recursive = true;
-      path_spec = VoPath {
-          unix_path = mk_path dir;
-          coq_path  = root;
-          has_ml    = ml;
-          implicit;
-        };
-    } in
+  (* let mk_ml = () in *)
+  let mk_vo ~has_ml ~coq_path ~dir ~implicit =
+    { unix_path = mk_path dir
+    ; coq_path
+    ; has_ml
+    ; recursive = true
+    ; implicit
+    }
+  in
   (* in 8.8 we can use Libnames.default_* *)
   let coq_root     = Names.DirPath.make [Libnames.coq_root] in
   let default_root = Libnames.default_root_prefix in
-  [mk_lp ~ml:AddRecML ~root:coq_root     ~implicit       ~dir:"plugins";
-   mk_lp ~ml:AddNoML  ~root:coq_root     ~implicit       ~dir:"theories";
-   mk_lp ~ml:AddRecML ~root:default_root ~implicit:false ~dir:"user-contrib";
+  let ml_paths =
+    let plugins_dirs = System.all_subdirs ~unix_path:(mk_path "plugins") in
+    List.map fst plugins_dirs
+  in
+  ml_paths ,
+  [ mk_vo ~has_ml:false ~coq_path:coq_root     ~implicit       ~dir:"theories"
+  ; mk_vo ~has_ml:true  ~coq_path:default_root ~implicit:false ~dir:"user-contrib";
   ] @
-  List.map (fun dir -> mk_lp ~ml:AddRecML ~root:default_root ~implicit:false ~dir)
+  List.map (fun dir -> mk_vo ~has_ml:true ~coq_path:default_root ~implicit:false ~dir)
     Envars.coqpath
 
 (******************************************************************************)

--- a/serapi/serapi_paths.mli
+++ b/serapi/serapi_paths.mli
@@ -17,7 +17,7 @@
 (************************************************************************)
 
 (* Default load path for Coq's stdlib *)
-val coq_loadpath_default : implicit:bool -> coq_path:string -> Loadpath.coq_path list
+val coq_loadpath_default : implicit:bool -> coq_path:string -> string list * Loadpath.vo_path list
 
 (* Generate a module name given a file, to be removed in 8.10 *)
 val dirpath_of_file : string -> Names.DirPath.t

--- a/serapi/serapi_protocol.ml
+++ b/serapi/serapi_protocol.ml
@@ -172,9 +172,14 @@ let pp_opt n s =
   let open Pp in
   str (String.concat "." n) ++ str " := " ++ pp_opt_value s.Goptions.opt_value
 
-let pp_implicit = function
-  | None               -> Pp.str "!"
-  | Some (iname, _, _) -> Names.Id.print iname
+let pp_explicitation = let open Constrexpr in function
+  | ExplByPos (i, None) -> Pp.(int i ++ str "None")
+  | ExplByPos (i, Some iname) -> Pp.(int i ++ Names.Id.print iname)
+  | ExplByName iname -> Names.Id.print iname
+
+let pp_implicit : Impargs.implicit_status -> Pp.t = function
+  | None              -> Pp.str "!"
+  | Some (expl, _, _) -> pp_explicitation expl
 
 (*
 let pp_richpp xml =
@@ -209,7 +214,8 @@ let gen_pp_obj env sigma (obj : coq_object) : Pp.t =
     begin match generic_raw_print ga with
       | PrinterBasic pp -> pp env sigma
       (* XXX: Fixme, the level here is random *)
-      | PrinterNeedsLevel pp -> pp.printer env sigma (99,Notation_gram.Any)
+      | PrinterNeedsLevel pp ->
+        pp.printer env sigma Constrexpr.LevelSome
     end
 
   (* Fixme *)
@@ -418,7 +424,8 @@ module QueryUtil = struct
 
   let _query_names prefix =
     let acc = ref [] in
-    Search.generic_search None (fun gr _env _typ ->
+    let env = Global.env () in
+    Search.generic_search env (fun gr _kind _env _typ ->
         (* Not happy with this at ALL:
 
            String of qualid is OK, but shortest_qualid_of_global is an
@@ -466,12 +473,12 @@ module QueryUtil = struct
 
   let query_unparsing (nt : Constrexpr.notation) :
     Ppextend.unparsing_rule * Ppextend.extra_unparsing_rules * Notation_gram.notation_grammar =
-    Ppextend.(find_notation_printing_rule nt,
-              find_notation_extra_printing_rules nt,
-              find_notation_parsing_rules nt)
+    Ppextend.find_notation_printing_rule None nt,
+    Ppextend.find_notation_extra_printing_rules None nt,
+    Notgram_ops.grammar_of_notation nt
 
   let query_pnotations () =
-    Ppextend.get_defined_notations ()
+    Notgram_ops.get_defined_notations ()
 
   let locate id =
     let open Names     in
@@ -555,7 +562,7 @@ module QueryUtil = struct
   (* This should be moved Coq upstream *)
   let _comments = ref []
   let add_comments pa =
-    let comments = Pcoq.Parsable.comment_state pa |> List.rev in
+    let comments = Pcoq.Parsable.comments pa |> List.rev in
     _comments := comments :: !_comments
 
 end
@@ -581,7 +588,7 @@ let obj_query ~doc ~pstate ~env (opt : query_opt) (cmd : query_cmd) : coq_object
   | Unparsing ntn  -> (* Unfortunately this will produce an anomaly if the notation is not found...
                        * To keep protocol promises we need to special wrap it.
                        *)
-                      begin try let up, upe, gr = QueryUtil.query_unparsing (Constrexpr.InConstrEntrySomeLevel,ntn) in
+                      begin try let up, upe, gr = QueryUtil.query_unparsing (Constrexpr.InConstrEntry,ntn) in
                                 [CoqUnparsing(up,upe,gr)]
                       with _exn -> []
                       end
@@ -652,7 +659,7 @@ let exec_query opt cmd =
 (* coq_exn info *)
 let coq_exn_info exn =
   let backtrace = Printexc.get_raw_backtrace () in
-  let exn, info = CErrors.push exn in
+  let exn, info = Exninfo.capture exn in
   let pp = CErrors.iprint (exn, info) in
   CoqExn
     { loc = Loc.get_loc info
@@ -790,12 +797,14 @@ end
 (* Init / new document                                                        *)
 (******************************************************************************)
 type newdoc_opts =
-  (* name of the top-level module *)
   { top_name     : Stm.interactive_top
-  (* Initial LoadPath. [XXX: Use the coq_pkg record?] *)
-  ; iload_path   : Loadpath.coq_path list option [@sexp.option]
-  (* Libs to require in STM init *)
+  (** name of the top-level module of the new document *)
+  ; ml_load_path   : string list option [@sexp.option]
+  (** Initial ML loadpath  *)
+  ; vo_load_path   : Loadpath.vo_path list option [@sexp.option]
+  (** Initial LoadPath for the document *) (* [XXX: Use the coq_pkg record?] *)
   ; require_libs : (string * string option * bool option) list option [@sexp.option]
+  (** Libraries to load in the initial document state *)
   }
 
 (******************************************************************************)
@@ -847,12 +856,15 @@ let exec_cmd (cmd : cmd) =
   | NewDoc opts   ->
     let stm_options = Stm.AsyncOpts.default_opts in
     let require_libs = Option.default (["Coq.Init.Prelude", None, Some true]) opts.require_libs in
-    let iload_path = Option.default
-        Serapi_paths.(coq_loadpath_default ~implicit:true ~coq_path:Coq_config.coqlib)
-        opts.iload_path in
+    let dft_ml, dft_vo =
+      Serapi_paths.(coq_loadpath_default ~implicit:true ~coq_path:Coq_config.coqlib)
+    in
+    let ml_load_path = Option.default dft_ml opts.ml_load_path in
+    let vo_load_path = Option.default dft_vo opts.vo_load_path in
     let ndoc = { Stm.doc_type = Stm.(Interactive opts.top_name)
-               ; require_libs
-               ; iload_path
+               ; injections = List.map (fun x -> Stm.RequireInjection x) require_libs
+               ; ml_load_path
+               ; vo_load_path
                ; stm_options
                } in
     (* doc_id := fst Stm.(get_doc @@ new_doc ndoc); [] *)
@@ -888,15 +900,15 @@ let exec_cmd (cmd : cmd) =
       with _ -> close_in inc; []
     )
   | Tokenize input ->
-    let st = CLexer.get_lexer_state () in
+    let st = CLexer.Lexer.State.get () in
     begin try
         let istr = Stream.of_string input in
         let lex = CLexer.Lexer.tok_func istr in
-        CLexer.set_lexer_state st;
+        CLexer.Lexer.State.set st;
         let objs = Extra.stream_tok 0 [] lex in
         [ObjList [CoqTok objs]]
       with exn ->
-        CLexer.set_lexer_state st;
+        CLexer.Lexer.State.set st;
         raise exn
     end
   | Help           -> serproto_help (); []

--- a/serapi/serapi_protocol.mli
+++ b/serapi/serapi_protocol.mli
@@ -400,7 +400,9 @@ type add_opts = {
 type newdoc_opts =
   { top_name     : Stm.interactive_top
   (** name of the top-level module of the new document *)
-  ; iload_path   : Loadpath.coq_path list option [@sexp.option]
+  ; ml_load_path   : string list option [@sexp.option]
+  (** Initial ML loadpath  *)
+  ; vo_load_path   : Loadpath.vo_path list option [@sexp.option]
   (** Initial LoadPath for the document *) (* [XXX: Use the coq_pkg record?] *)
   ; require_libs : (string * string option * bool option) list option [@sexp.option]
   (** Libraries to load in the initial document state *)

--- a/serlib/plugins/ssr/ser_ssrast.ml
+++ b/serlib/plugins/ssr/ser_ssrast.ml
@@ -92,6 +92,10 @@ type ssrterm =
   [%import: Wrap_ssrast.ssrterm]
   [@@deriving sexp]
 
+type ast_glob_env =
+  [%import: Wrap_ssrast.ast_glob_env]
+  [@@deriving sexp]
+
 type ast_closure_term =
   [%import: Wrap_ssrast.ast_closure_term]
   [@@deriving sexp]

--- a/serlib/ser_cUnix.ml
+++ b/serlib/ser_cUnix.ml
@@ -8,23 +8,13 @@
 
 (************************************************************************)
 (* Coq serialization API/Plugin                                         *)
-(* Copyright 2016-2020 MINES ParisTech / INRIA                          *)
+(* Copyright 2016-2020 MINES ParisTech / Inria                          *)
 (************************************************************************)
 (* Status: Very Experimental                                            *)
 (************************************************************************)
 
-type definition_object_kind =
-  [%import: Decls.definition_object_kind]
-  [@@deriving sexp,yojson]
+open Sexplib.Std
 
-type theorem_kind =
-  [%import: Decls.theorem_kind]
-  [@@deriving sexp,yojson]
-
-type assumption_object_kind =
-  [%import: Decls.assumption_object_kind]
-  [@@deriving sexp,yojson]
-
-type logical_kind =
-  [%import: Decls.logical_kind]
+type physical_path =
+  [%import: CUnix.physical_path]
   [@@deriving sexp,yojson]

--- a/serlib/ser_constr.ml
+++ b/serlib/ser_constr.ml
@@ -109,13 +109,14 @@ and _types = _constr
 
 let rec _constr_put (c : constr) : _constr =
   let cr  = _constr_put           in
+  let crl = List.map _constr_put  in
   let cra = Array.map _constr_put in
   let module C = Constr           in
   match C.kind c with
   | C.Rel i               -> Rel(i)
   | C.Var v               -> Var(v)
   | C.Meta(mv)            -> Meta mv
-  | C.Evar(ek, csa)       -> Evar (ek, cra csa)
+  | C.Evar(ek, csa)       -> Evar (ek, crl csa)
   | C.Sort(st)            -> Sort (st)
   | C.Cast(cs,k,ty)       -> Cast(cr cs, k, cr ty)
   | C.Prod(n,tya,tyr)     -> Prod(n, cr tya, cr tyr)
@@ -135,13 +136,14 @@ let rec _constr_put (c : constr) : _constr =
 
 let rec _constr_get (c : _constr) : constr =
   let cr  = _constr_get           in
+  let crl = List.map _constr_get  in
   let cra = Array.map _constr_get in
   let module C = Constr           in
   match c with
   | Rel i               -> C.mkRel i
   | Var v               -> C.mkVar v
   | Meta(mv)            -> C.mkMeta mv
-  | Evar(ek, csa)       -> C.mkEvar (ek, cra csa)
+  | Evar(ek, csa)       -> C.mkEvar (ek, crl csa)
   | Sort(st)            -> C.mkSort (st)
   | Cast(cs,k,ty)       -> C.mkCast(cr cs, k, cr ty)
   | Prod(n,tya,tyr)     -> C.mkProd(n, cr tya, cr tyr)

--- a/serlib/ser_constrexpr.ml
+++ b/serlib/ser_constrexpr.ml
@@ -27,7 +27,6 @@ module Evar_kinds = Ser_evar_kinds
 module Genarg     = Ser_genarg
 module Libnames   = Ser_libnames
 module Glob_term  = Ser_glob_term
-module Notation   = Ser_notation
 module NumTok     = Ser_numTok
 
 type 'a or_by_notation_r =
@@ -50,12 +49,20 @@ type name_decl =
   [%import: Constrexpr.name_decl]
   [@@deriving sexp,yojson]
 
-type notation_entry_level =
-  [%import: Constrexpr.notation_entry_level]
-  [@@deriving sexp,yojson]
-
 type notation_entry =
   [%import: Constrexpr.notation_entry]
+  [@@deriving sexp,yojson]
+
+type entry_level =
+  [%import: Constrexpr.entry_level]
+  [@@deriving sexp,yojson]
+
+type entry_relative_level =
+  [%import: Constrexpr.entry_relative_level]
+  [@@deriving sexp,yojson]
+
+type notation_entry_level =
+  [%import: Constrexpr.notation_entry_level]
   [@@deriving sexp,yojson]
 
 type notation_key =
@@ -77,16 +84,20 @@ type abstraction_kind = [%import: Constrexpr.abstraction_kind]
 type proj_flag = [%import: Constrexpr.proj_flag]
   [@@deriving sexp,yojson]
 
-type raw_numeral = [%import: Constrexpr.raw_numeral]
-  [@@deriving sexp,yojson]
+(* type raw_numeral = [%import: Constrexpr.raw_numeral]
+ *   [@@deriving sexp,yojson] *)
 
-type sign = [%import: Constrexpr.sign]
-  [@@deriving sexp,yojson]
+(* type sign = [%import: Constrexpr.sign]
+ *   [@@deriving sexp,yojson] *)
 
 type prim_token = [%import: Constrexpr.prim_token]
   [@@deriving sexp,yojson]
 
 type instance_expr = [%import: Constrexpr.instance_expr]
+  [@@deriving sexp,yojson]
+
+type notation_with_optional_scope =
+  [%import: Constrexpr.notation_with_optional_scope]
   [@@deriving sexp,yojson]
 
 type cases_pattern_expr_r = [%import: Constrexpr.cases_pattern_expr_r]

--- a/serlib/ser_constrexpr.mli
+++ b/serlib/ser_constrexpr.mli
@@ -27,6 +27,24 @@ val sexp_of_notation_entry : notation_entry -> Sexp.t
 val notation_entry_of_yojson : Yojson.Safe.t -> (notation_entry, string) Result.result
 val notation_entry_to_yojson : notation_entry -> Yojson.Safe.t
 
+type entry_level = Constrexpr.entry_level
+val entry_level_of_sexp : Sexp.t -> entry_level
+val sexp_of_entry_level : entry_level -> Sexp.t
+val entry_level_of_yojson : Yojson.Safe.t -> (entry_level, string) Result.result
+val entry_level_to_yojson : entry_level -> Yojson.Safe.t
+
+type notation_entry_level = Constrexpr.notation_entry_level
+val notation_entry_level_of_sexp : Sexp.t -> notation_entry_level
+val sexp_of_notation_entry_level : notation_entry_level -> Sexp.t
+val notation_entry_level_of_yojson : Yojson.Safe.t -> (notation_entry_level, string) Result.result
+val notation_entry_level_to_yojson : notation_entry_level -> Yojson.Safe.t
+
+type entry_relative_level = Constrexpr.entry_relative_level
+val entry_relative_level_of_sexp : Sexp.t -> entry_relative_level
+val sexp_of_entry_relative_level : entry_relative_level -> Sexp.t
+val entry_relative_level_of_yojson : Yojson.Safe.t -> (entry_relative_level, string) Result.result
+val entry_relative_level_to_yojson : entry_relative_level -> Yojson.Safe.t
+
 type universe_decl_expr = Constrexpr.universe_decl_expr
 val universe_decl_expr_of_sexp : Sexp.t -> universe_decl_expr
 val sexp_of_universe_decl_expr : universe_decl_expr -> Sexp.t

--- a/serlib/ser_declarations.ml
+++ b/serlib/ser_declarations.ml
@@ -111,6 +111,10 @@ type record_info =
   [%import: Declarations.record_info]
   [@@deriving sexp]
 
+type template_universes =
+  [%import: Declarations.template_universes]
+  [@@deriving sexp,yojson]
+
 type mutual_inductive_body =
   [%import: Declarations.mutual_inductive_body
   [@with Context.section_context := Context.Named.t;]]

--- a/serlib/ser_flags.ml
+++ b/serlib/ser_flags.ml
@@ -12,6 +12,3 @@
 (************************************************************************)
 (* Status: Very Experimental                                            *)
 (************************************************************************)
-
-type compat_version = [%import: Flags.compat_version]
-  [@@deriving sexp,yojson]

--- a/serlib/ser_flags.mli
+++ b/serlib/ser_flags.mli
@@ -12,12 +12,3 @@
 (************************************************************************)
 (* Status: Very Experimental                                            *)
 (************************************************************************)
-
-open Sexplib
-
-type compat_version = Flags.compat_version
-
-val compat_version_of_sexp : Sexp.t -> compat_version
-val sexp_of_compat_version : compat_version -> Sexp.t
-val compat_version_of_yojson : Yojson.Safe.t -> (compat_version, string) Result.result
-val compat_version_to_yojson : compat_version -> Yojson.Safe.t

--- a/serlib/ser_genintern.mli
+++ b/serlib/ser_genintern.mli
@@ -17,6 +17,13 @@
 
 open Sexplib
 
+module Store : SerType.S with type t = Genintern.Store.t
+
+type intern_variable_status = Genintern.intern_variable_status
+
+val intern_variable_status_of_sexp : Sexp.t -> intern_variable_status
+val sexp_of_intern_variable_status : intern_variable_status -> Sexp.t
+
 type glob_sign = Genintern.glob_sign
 
 val glob_sign_of_sexp : Sexp.t -> glob_sign

--- a/serlib/ser_goptions.ml
+++ b/serlib/ser_goptions.ml
@@ -17,6 +17,8 @@
 
 open Sexplib.Std
 
+module Libnames = Ser_libnames
+
 type option_locality =
   [%import: Goptions.option_locality]
   [@@deriving sexp,yojson]
@@ -32,3 +34,8 @@ type option_value =
 type option_state =
   [%import: Goptions.option_state]
   [@@deriving sexp]
+
+type table_value =
+  [%import: Goptions.table_value]
+  [@@deriving sexp,yojson]
+

--- a/serlib/ser_goptions.mli
+++ b/serlib/ser_goptions.mli
@@ -40,3 +40,10 @@ type option_state = Goptions.option_state
 
 val option_state_of_sexp : Sexp.t -> option_state
 val sexp_of_option_state : option_state -> Sexp.t
+
+type table_value = Goptions.table_value
+
+val table_value_of_sexp : Sexp.t -> table_value
+val sexp_of_table_value : table_value -> Sexp.t
+val table_value_of_yojson : Yojson.Safe.t -> (table_value, string) Result.result
+val table_value_to_yojson : table_value -> Yojson.Safe.t

--- a/serlib/ser_hints.ml
+++ b/serlib/ser_hints.ml
@@ -37,22 +37,28 @@ type hints_path =
   [%import: Hints.hints_path]
   [@@deriving sexp,yojson]
 
+(*
 type reference_or_constr =
   [%import: Hints.reference_or_constr]
   [@@deriving sexp,yojson]
+*)
 
 type hint_mode =
   [%import: Hints.hint_mode]
   [@@deriving sexp,yojson]
 
+(*
 type hint_info_expr =
   [%import: Hints.hint_info_expr]
   [@@deriving sexp,yojson]
+*)
 
 type 'a hints_transparency_target =
   [%import: 'a Hints.hints_transparency_target]
   [@@deriving sexp,yojson]
 
+(*
 type hints_expr =
   [%import: Hints.hints_expr]
   [@@deriving sexp,yojson]
+*)

--- a/serlib/ser_hints.mli
+++ b/serlib/ser_hints.mli
@@ -35,22 +35,34 @@ type hints_path = Hints.hints_path
 val sexp_of_hints_path : hints_path -> Sexp.t
 val hints_path_of_sexp : Sexp.t -> hints_path
 
-type reference_or_constr = Hints.reference_or_constr
-val reference_or_constr_of_sexp : Sexp.t -> reference_or_constr
-val sexp_of_reference_or_constr : reference_or_constr -> Sexp.t
+type 'a hints_transparency_target = 'a Hints.hints_transparency_target
+val hints_transparency_target_of_sexp : (Sexp.t -> 'a) -> Sexp.t -> 'a hints_transparency_target
+val sexp_of_hints_transparency_target : ('a -> Sexp.t) -> 'a hints_transparency_target -> Sexp.t
+val hints_transparency_target_of_yojson :
+  (Yojson.Safe.t -> ('a, string) Result.result) ->
+  Yojson.Safe.t -> ('a hints_transparency_target, string) Result.result
+val hints_transparency_target_to_yojson :
+  ('a -> Yojson.Safe.t) ->
+  'a hints_transparency_target -> Yojson.Safe.t
 
+(*
 type hint_info_expr = Hints.hint_info_expr
 val hint_info_expr_of_sexp : Sexp.t -> hint_info_expr
 val sexp_of_hint_info_expr : hint_info_expr -> Sexp.t
 val hint_info_expr_of_yojson : Yojson.Safe.t -> (hint_info_expr, string) Result.result
 val hint_info_expr_to_yojson : hint_info_expr -> Yojson.Safe.t
+*)
 
 type hint_mode = Hints.hint_mode
 val hint_mode_of_sexp : Sexp.t -> hint_mode
 val sexp_of_hint_mode : hint_mode -> Sexp.t
+val hint_mode_of_yojson : Yojson.Safe.t -> (hint_mode, string) Result.result
+val hint_mode_to_yojson : hint_mode -> Yojson.Safe.t
 
+(*
 type hints_expr = Hints.hints_expr
 val hints_expr_of_sexp : Sexp.t -> hints_expr
 val sexp_of_hints_expr : hints_expr -> Sexp.t
 val hints_expr_of_yojson : Yojson.Safe.t -> (hints_expr, string) Result.result
 val hints_expr_to_yojson : hints_expr -> Yojson.Safe.t
+*)

--- a/serlib/ser_impargs.ml
+++ b/serlib/ser_impargs.ml
@@ -17,14 +17,11 @@ open Sexplib
 open Sexplib.Std
 
 module Names = Ser_names
+module Constrexpr = Ser_constrexpr
 
 type argument_position =
   [%import: Impargs.argument_position]
   [@@deriving sexp]
-
-type implicit_kind =
-  [%import: Impargs.implicit_kind]
-  [@@deriving sexp,yojson]
 
 type implicit_explanation =
   [%import: Impargs.implicit_explanation]

--- a/serlib/ser_impargs.mli
+++ b/serlib/ser_impargs.mli
@@ -20,13 +20,6 @@ type argument_position = Impargs.argument_position
 val argument_position_of_sexp : Sexp.t -> argument_position
 val sexp_of_argument_position : argument_position -> Sexp.t
 
-type implicit_kind = Impargs.implicit_kind
-
-val implicit_kind_of_sexp : Sexp.t -> implicit_kind
-val sexp_of_implicit_kind : implicit_kind -> Sexp.t
-val implicit_kind_of_yojson : Yojson.Safe.t -> (implicit_kind, string) Result.result
-val implicit_kind_to_yojson : implicit_kind -> Yojson.Safe.t
-
 type implicit_explanation = Impargs.implicit_explanation
 
 val implicit_explanation_of_sexp : Sexp.t -> implicit_explanation

--- a/serlib/ser_loadpath.ml
+++ b/serlib/ser_loadpath.ml
@@ -22,18 +22,6 @@ type library_location =
   [%import: Loadpath.library_location]
   [@@deriving sexp]
 
-type add_ml =
-  [%import: Loadpath.add_ml]
-  [@@deriving sexp]
-
-type vo_path_spec =
-  [%import: Loadpath.vo_path_spec]
-  [@@deriving sexp]
-
-type coq_path_spec =
-  [%import: Loadpath.coq_path_spec]
-  [@@deriving sexp]
-
-type coq_path =
-  [%import: Loadpath.coq_path]
+type vo_path =
+  [%import: Loadpath.vo_path]
   [@@deriving sexp]

--- a/serlib/ser_locality.ml
+++ b/serlib/ser_locality.ml
@@ -8,11 +8,8 @@
 
 (************************************************************************)
 (* Coq serialization API/Plugin                                         *)
-(* Copyright 2016-2018 MINES ParisTech                                  *)
+(* Copyright 2016-2020 MINES ParisTech / Inria                          *)
 (************************************************************************)
 (* Status: Very Experimental                                            *)
 (************************************************************************)
 
-type opacity_flag =
-  [%import: Proof_global.opacity_flag]
-  [@@deriving sexp,yojson]

--- a/serlib/ser_notation.ml
+++ b/serlib/ser_notation.ml
@@ -13,9 +13,15 @@
 (* Status: Very Experimental                                            *)
 (************************************************************************)
 
-(* open Sexplib.Std *)
+open Sexplib.Std
 
 (* module Ppextend = Ser_ppextend
  * module Notation_term = Ser_notation_term *)
+
+module Constrexpr = Ser_constrexpr
+
+type level =
+  [%import: Notation.level]
+  [@@deriving sexp,yojson]
 
 

--- a/serlib/ser_notation.mli
+++ b/serlib/ser_notation.mli
@@ -13,4 +13,8 @@
 (* Status: Very Experimental                                            *)
 (************************************************************************)
 
+open Sexplib
 
+type level = Notation.level
+val level_of_sexp : Sexp.t -> level
+val sexp_of_level : level -> Sexp.t

--- a/serlib/ser_notation_gram.ml
+++ b/serlib/ser_notation_gram.ml
@@ -20,25 +20,22 @@ module Constrexpr    = Ser_constrexpr
 module Tok           = Ser_tok
 module Extend        = Ser_extend
 module Gramlib       = Ser_gramlib
+module Notation      = Ser_notation
 
-type precedence =
-  [%import: Notation_gram.precedence]
-  [@@deriving sexp]
+(* type precedence =
+ *   [%import: Notation_gram.precedence]
+ *   [@@deriving sexp] *)
 
-type parenRelation =
-  [%import: Notation_gram.parenRelation]
-  [@@deriving sexp]
+(* type parenRelation =
+ *   [%import: Notation_gram.parenRelation]
+ *   [@@deriving sexp] *)
 
-type tolerability =
-  [%import: Notation_gram.tolerability]
-  [@@deriving sexp]
+(* type tolerability =
+ *   [%import: Notation_gram.tolerability]
+ *   [@@deriving sexp] *)
 
 type grammar_constr_prod_item =
   [%import: Notation_gram.grammar_constr_prod_item]
-  [@@deriving sexp]
-
-type level =
-  [%import: Notation_gram.level]
   [@@deriving sexp]
 
 type one_notation_grammar =

--- a/serlib/ser_notation_gram.mli
+++ b/serlib/ser_notation_gram.mli
@@ -15,20 +15,20 @@
 
 open Sexplib
 
-type parenRelation = Notation_gram.parenRelation
-
-val parenRelation_of_sexp : Sexp.t -> parenRelation
-val sexp_of_parenRelation : parenRelation -> Sexp.t
-
-type precedence = Notation_gram.precedence
-
-val precedence_of_sexp : Sexp.t -> precedence
-val sexp_of_precedence : precedence -> Sexp.t
-
-type tolerability = Notation_gram.tolerability
-
-val tolerability_of_sexp : Sexp.t -> tolerability
-val sexp_of_tolerability : tolerability -> Sexp.t
+(* type parenRelation = Notation_gram.parenRelation
+ * 
+ * val parenRelation_of_sexp : Sexp.t -> parenRelation
+ * val sexp_of_parenRelation : parenRelation -> Sexp.t
+ * 
+ * type precedence = Notation_gram.precedence
+ * 
+ * val precedence_of_sexp : Sexp.t -> precedence
+ * val sexp_of_precedence : precedence -> Sexp.t
+ * 
+ * type tolerability = Notation_gram.tolerability
+ * 
+ * val tolerability_of_sexp : Sexp.t -> tolerability
+ * val sexp_of_tolerability : tolerability -> Sexp.t *)
 
 type grammar_constr_prod_item = Notation_gram.grammar_constr_prod_item
 val grammar_constr_prod_item_of_sexp : Sexp.t -> grammar_constr_prod_item

--- a/serlib/ser_numTok.ml
+++ b/serlib/ser_numTok.ml
@@ -15,5 +15,38 @@
 
 open Sexplib.Std
 
-type t =  [%import: NumTok.t]
+type sign =
+  [%import: NumTok.sign]
   [@@deriving sexp,yojson]
+
+type num_class =
+  [%import: NumTok.num_class]
+  [@@deriving sexp,yojson]
+
+type 'a exp =
+  [%import: 'a NumTok.exp]
+  [@@deriving sexp,yojson]
+
+module Unsigned = struct
+
+  type _t = {
+    int : string;
+    frac : string;
+    exp : string
+  } [@@deriving sexp,yojson]
+
+  type t = NumTok.Unsigned.t
+  let t_of_sexp s = Obj.magic (_t_of_sexp s)
+  let sexp_of_t s = sexp_of__t (Obj.magic s)
+  let of_yojson s = Obj.magic (_t_of_yojson s)
+  let to_yojson s = _t_to_yojson (Obj.magic s)
+
+end
+
+module Signed = struct
+
+  type t =
+    [%import: NumTok.Signed.t]
+    [@@deriving sexp,yojson]
+
+end

--- a/serlib/ser_opaqueproof.ml
+++ b/serlib/ser_opaqueproof.ml
@@ -21,26 +21,20 @@ module Univ   = Ser_univ
 module Constr = Ser_constr
 module Mod_subst = Ser_mod_subst
 
-type _work_list =
-  (Univ.Instance.t * Names.Id.t array) Names.Cmap.t * (Univ.Instance.t * Names.Id.t array) Names.Mindmap.t
-  (* Problem with map modules *)
-  (* [%import: Opaqueproof.work_list] *)
+type proofterm = (Constr.constr * Univ.ContextSet.t) Future.computation
   [@@deriving sexp]
 
-type work_list = Opaqueproof.work_list
-let work_list_of_sexp x = Obj.magic (_work_list_of_sexp x)
-let sexp_of_work_list x = sexp_of__work_list (Obj.magic x)
+type work_list =
+  [%import: Opaqueproof.work_list]
+  [@@deriving sexp]
 
 type cooking_info =
   [%import: Opaqueproof.cooking_info]
   [@@deriving sexp]
 
-type proofterm = (Constr.constr * Univ.ContextSet.t) Future.computation
-  [@@deriving sexp]
-
 type _opaque =
-  | Indirect of Mod_subst.substitution list * Names.DirPath.t * int (* subst, lib, index *)
-  | Direct of cooking_info list * proofterm
+  | Indirect of Mod_subst.substitution list * cooking_info list * Names.DirPath.t * int
+  (* subst, discharge, lib, index *)
   [@@deriving sexp]
 
 type opaque = [%import: Opaqueproof.opaque]
@@ -50,7 +44,7 @@ let opaque_of_sexp x = Obj.magic (_opaque_of_sexp x)
 
 module Map = Ser_cMap.Make(Int.Map)(Ser_int)
 type _opaquetab = {
-  opaque_val : (cooking_info list * proofterm) Map.t;
+  opaque_val : proofterm Map.t;
   (** Actual proof terms *)
   opaque_len : int;
   (** Size of the above map *)

--- a/serlib/ser_ppextend.ml
+++ b/serlib/ser_ppextend.ml
@@ -18,6 +18,8 @@ open Sexplib.Std
 module Loc           = Ser_loc
 module Notation_term = Ser_notation_term
 module Notation_gram = Ser_notation_gram
+module Constrexpr    = Ser_constrexpr
+module Extend        = Ser_extend
 
 type ppbox =
   [%import: Ppextend.ppbox]

--- a/serlib/ser_ppextend.mli
+++ b/serlib/ser_ppextend.mli
@@ -25,10 +25,9 @@ type ppcut = Ppextend.ppcut
 val ppcut_of_sexp : Sexp.t -> ppcut
 val sexp_of_ppcut : ppcut -> Sexp.t
 
-type unparsing = Ppextend.unparsing
-
-val unparsing_of_sexp : Sexp.t -> unparsing
-val sexp_of_unparsing : unparsing -> Sexp.t
+(* type unparsing = Ppextend.unparsing
+ * val unparsing_of_sexp : Sexp.t -> unparsing
+ * val sexp_of_unparsing : unparsing -> Sexp.t *)
 
 type unparsing_rule = Ppextend.unparsing_rule
 val unparsing_rule_of_sexp : Sexp.t -> unparsing_rule

--- a/serlib/ser_safe_typing.ml
+++ b/serlib/ser_safe_typing.ml
@@ -25,10 +25,16 @@ module Constr  = Ser_constr
 module Declarations = Ser_declarations
 module Entries = Ser_entries
 module Cooking = Ser_cooking
+module Univ = Ser_univ
 
 (* Side_effects *)
+type certificate = {
+  certif_struc : Declarations.structure_body;
+  certif_univs : Univ.ContextSet.t;
+} [@@deriving sexp]
+
 type side_effect = {
-  from_env : Declarations.structure_body CEphemeron.key;
+  from_env : certificate CEphemeron.key;
   seff_constant : Names.Constant.t;
   seff_body : Constr.t Declarations.constant_body;
 } [@@deriving sexp]

--- a/serlib/ser_tok.ml
+++ b/serlib/ser_tok.ml
@@ -31,7 +31,7 @@ type 'c _p =
   | PPATTERNIDENT of string option
   | PIDENT of string option
   | PFIELD of string option
-  | PNUMERAL of NumTok.t option
+  | PNUMERAL of NumTok.Unsigned.t option
   | PSTRING of string option
   | PLEFTQMARK
   | PBULLET of string option

--- a/serlib/ser_uGraph.ml
+++ b/serlib/ser_uGraph.ml
@@ -13,6 +13,11 @@
 (* Status: Experimental                                                 *)
 (************************************************************************)
 
+module Bound = struct
+  type t = [%import: UGraph.Bound.t]
+  [@@deriving sexp]
+end
+
 type t = [%import: UGraph.t]
 
 let sexp_of_t = Serlib_base.sexp_of_opaque ~typ:"UGraph.t"

--- a/serlib/ser_uGraph.mli
+++ b/serlib/ser_uGraph.mli
@@ -15,6 +15,13 @@
 
 open Sexplib
 
+module Bound : sig
+  type t = UGraph.Bound.t
+
+  val sexp_of_t : t -> Sexp.t
+  val t_of_sexp : Sexp.t -> t
+end
+
 type t = UGraph.t
 
 val sexp_of_t : t -> Sexp.t

--- a/serlib/ser_univ.ml
+++ b/serlib/ser_univ.ml
@@ -51,11 +51,11 @@ module Level = struct
 
   let of_yojson json  =
     Ppx_deriving_yojson_runtime.(_t_of_yojson json >|= Obj.magic)
-  let to_yojson level = _t_to_yojson Obj.(magic level)
+  let to_yojson level = _t_to_yojson (Obj.magic level)
 
 end
 
-module LSet = Ser_cSet.Make(Univ.LSet)(Level)
+module LSet = Ser_cSet.MakeJ(Univ.LSet)(Level)
 
 (* XXX: Think what to do with this  *)
 module Universe = struct
@@ -69,7 +69,7 @@ module Universe = struct
 
   let of_yojson json  =
     Ppx_deriving_yojson_runtime.(_t_of_yojson json >|= Obj.magic)
-  let to_yojson level = _t_to_yojson Obj.(magic level)
+  let to_yojson level = _t_to_yojson (Obj.magic level)
 end
 
 (*************************************************************************)
@@ -119,7 +119,7 @@ module Constraint = Ser_cSet.MakeJ(Univ.Constraint)(struct
 
 type 'a constrained =
   [%import: 'a Univ.constrained]
-  [@@deriving sexp]
+  [@@deriving sexp,yojson]
 
 module UContext = struct
 
@@ -145,7 +145,7 @@ end
 module ContextSet = struct
   type t =
     [%import: Univ.ContextSet.t]
-    [@@deriving sexp]
+    [@@deriving sexp, yojson]
 end
 
 type 'a in_universe_context =

--- a/serlib/ser_univ.mli
+++ b/serlib/ser_univ.mli
@@ -38,7 +38,7 @@ module UContext : SerType.S with type t = Univ.UContext.t
 
 module AUContext : SerType.S with type t = Univ.AUContext.t
 
-module ContextSet : SerType.S with type t = Univ.ContextSet.t
+module ContextSet : SerType.SJ with type t = Univ.ContextSet.t
 
 (** A value in a universe context (resp. context set). *)
 type 'a in_universe_context = 'a Univ.in_universe_context

--- a/serlib/ser_vernacexpr.ml
+++ b/serlib/ser_vernacexpr.ml
@@ -8,13 +8,14 @@
 
 (************************************************************************)
 (* Coq serialization API/Plugin                                         *)
-(* Copyright 2016-2019 MINES ParisTech                                  *)
+(* Copyright 2016-2020 MINES ParisTech / Inria                          *)
 (************************************************************************)
 (* Status: Very Experimental                                            *)
 (************************************************************************)
 
 open Sexplib.Conv
 
+module CUnix       = Ser_cUnix
 module Loc         = Ser_loc
 module CAst        = Ser_cAst
 module Names       = Ser_names
@@ -33,7 +34,6 @@ module Extend      = Ser_extend
 module Stateid     = Ser_stateid
 module Glob_term     = Ser_glob_term
 module Goal_select   = Ser_goal_select
-module Proof_global  = Ser_proof_global
 module Proof_bullet  = Ser_proof_bullet
 module Constrexpr    = Ser_constrexpr
 module Notation_term = Ser_notation_term
@@ -44,6 +44,7 @@ module Universes     = Ser_universes
 module Attributes    = Ser_attributes
 module Gramlib       = Ser_gramlib
 module Impargs       = Ser_impargs
+module Typeclasses   = Ser_typeclasses
 
 type class_rawexpr = [%import: Vernacexpr.class_rawexpr]
   [@@deriving sexp,yojson]
@@ -62,12 +63,20 @@ type printable =
   [%import: Vernacexpr.printable]
   [@@deriving sexp,yojson]
 
-type vernac_cumulative =
-  [%import: Vernacexpr.vernac_cumulative]
+(* type vernac_cumulative =
+ *   [%import: Vernacexpr.vernac_cumulative]
+ *   [@@deriving sexp,yojson] *)
+
+type glob_search_where =
+  [%import: Vernacexpr.glob_search_where]
   [@@deriving sexp,yojson]
 
-type search_about_item =
-  [%import: Vernacexpr.search_about_item]
+type search_item =
+  [%import: Vernacexpr.search_item]
+  [@@deriving sexp,yojson]
+
+type search_request =
+  [%import: Vernacexpr.search_request]
   [@@deriving sexp,yojson]
 
 type searchable =
@@ -87,10 +96,10 @@ type comment =
 type search_restriction =  [%import: Vernacexpr.search_restriction]
   [@@deriving sexp,yojson]
 
-type rec_flag          = [%import: Vernacexpr.rec_flag          ] [@@deriving sexp,yojson]
+(* type rec_flag          = [%import: Vernacexpr.rec_flag          ] [@@deriving sexp,yojson] *)
 type verbose_flag      = [%import: Vernacexpr.verbose_flag      ] [@@deriving sexp,yojson]
 type coercion_flag     = [%import: Vernacexpr.coercion_flag     ] [@@deriving sexp,yojson]
-type inductive_flag    = [%import: Vernacexpr.inductive_flag    ] [@@deriving sexp,yojson]
+(* type inductive_flag    = [%import: Vernacexpr.inductive_flag    ] [@@deriving sexp,yojson] *)
 type instance_flag     = [%import: Vernacexpr.instance_flag     ] [@@deriving sexp,yojson]
 type export_flag       = [%import: Vernacexpr.export_flag       ] [@@deriving sexp,yojson]
 type onlyparsing_flag  = [%import: Vernacexpr.onlyparsing_flag  ] [@@deriving sexp,yojson]
@@ -101,9 +110,9 @@ type option_setting =
   [%import: Vernacexpr.option_setting]
   [@@deriving sexp,yojson]
 
-type option_ref_value =
-  [%import: Vernacexpr.option_ref_value]
-  [@@deriving sexp,yojson]
+(* type option_ref_value =
+ *   [%import: Vernacexpr.option_ref_value]
+ *   [@@deriving sexp,yojson] *)
 
 (* type plident =
  *   [%import: Vernacexpr.plident ]
@@ -115,6 +124,10 @@ type sort_expr =
 
 type definition_expr =
   [%import: Vernacexpr.definition_expr]
+  [@@deriving sexp,yojson]
+
+type syntax_modifier =
+  [%import: Vernacexpr.syntax_modifier]
   [@@deriving sexp,yojson]
 
 type decl_notation =
@@ -177,6 +190,10 @@ type constructor_list_or_record_decl_expr =
   [%import: Vernacexpr.constructor_list_or_record_decl_expr]
   [@@deriving sexp,yojson]
 
+type inductive_params_expr =
+  [%import: Vernacexpr.inductive_params_expr]
+  [@@deriving sexp,yojson]
+
 type inductive_expr =
   [%import: Vernacexpr.inductive_expr]
   [@@deriving sexp,yojson]
@@ -189,12 +206,20 @@ type proof_expr =
   [%import: Vernacexpr.proof_expr]
   [@@deriving sexp,yojson]
 
-type syntax_modifier =
-  [%import: Vernacexpr.syntax_modifier]
+type opacity_flag =
+  [%import: Vernacexpr.opacity_flag]
   [@@deriving sexp,yojson]
 
 type proof_end =
   [%import: Vernacexpr.proof_end]
+  [@@deriving sexp,yojson]
+
+type one_import_filter_name =
+  [%import: Vernacexpr.one_import_filter_name]
+  [@@deriving sexp,yojson]
+
+type import_filter_expr =
+  [%import: Vernacexpr.import_filter_expr]
   [@@deriving sexp,yojson]
 
 type scheme =
@@ -239,6 +264,18 @@ type vernac_one_argument_status =
 
 type vernac_argument_status =
   [%import: Vernacexpr.vernac_argument_status]
+  [@@deriving sexp,yojson]
+
+type hint_info_expr =
+  [%import: Vernacexpr.hint_info_expr]
+  [@@deriving sexp,yojson]
+
+type reference_or_constr =
+  [%import: Vernacexpr.reference_or_constr]
+  [@@deriving sexp,yojson]
+
+type hints_expr =
+  [%import: Vernacexpr.hints_expr]
   [@@deriving sexp,yojson]
 
 type vernac_expr =

--- a/serlib/ser_vernacexpr.mli
+++ b/serlib/ser_vernacexpr.mli
@@ -35,9 +35,9 @@ type printable = Vernacexpr.printable
 val printable_of_sexp : Sexp.t -> printable
 val sexp_of_printable : printable -> Sexp.t
 
-type search_about_item = Vernacexpr.search_about_item
-val search_about_item_of_sexp : Sexp.t -> search_about_item
-val sexp_of_search_about_item : search_about_item -> Sexp.t
+type search_item = Vernacexpr.search_item
+val search_item_of_sexp : Sexp.t -> search_item
+val sexp_of_search_item : search_item -> Sexp.t
 
 type searchable = Vernacexpr.searchable
 val searchable_of_sexp : Sexp.t -> searchable
@@ -59,9 +59,9 @@ type search_restriction = Vernacexpr.search_restriction
 val search_restriction_of_sexp : Sexp.t -> search_restriction
 val sexp_of_search_restriction : search_restriction -> Sexp.t
 
-type rec_flag = Vernacexpr.rec_flag
-val rec_flag_of_sexp : Sexp.t -> rec_flag
-val sexp_of_rec_flag : rec_flag -> Sexp.t
+(* type rec_flag = Vernacexpr.rec_flag
+ * val rec_flag_of_sexp : Sexp.t -> rec_flag
+ * val sexp_of_rec_flag : rec_flag -> Sexp.t *)
 
 type verbose_flag = Vernacexpr.verbose_flag
 val verbose_flag_of_sexp : Sexp.t -> verbose_flag
@@ -71,9 +71,9 @@ type coercion_flag = Vernacexpr.coercion_flag
 val coercion_flag_of_sexp : Sexp.t -> coercion_flag
 val sexp_of_coercion_flag : coercion_flag -> Sexp.t
 
-type inductive_flag = Vernacexpr.inductive_flag
-val inductive_flag_of_sexp : Sexp.t -> inductive_flag
-val sexp_of_inductive_flag : inductive_flag -> Sexp.t
+(* type inductive_flag = Vernacexpr.inductive_flag
+ * val inductive_flag_of_sexp : Sexp.t -> inductive_flag
+ * val sexp_of_inductive_flag : inductive_flag -> Sexp.t *)
 
 type instance_flag = Vernacexpr.instance_flag
 val instance_flag_of_sexp : Sexp.t -> instance_flag
@@ -99,9 +99,9 @@ val sexp_of_locality_flag : locality_flag -> Sexp.t
  * val option_value_of_sexp : Sexp.t -> option_value
  * val sexp_of_option_value : option_value -> Sexp.t *)
 
-type option_ref_value = Vernacexpr.option_ref_value
-val option_ref_value_of_sexp : Sexp.t -> option_ref_value
-val sexp_of_option_ref_value : option_ref_value -> Sexp.t
+(* type option_ref_value = Vernacexpr.option_ref_value
+ * val option_ref_value_of_sexp : Sexp.t -> option_ref_value
+ * val sexp_of_option_ref_value : option_ref_value -> Sexp.t *)
 
 (* type plident = Vernacexpr.plident
  * val plident_of_sexp : Sexp.t -> plident

--- a/serlib/serlib_base.ml
+++ b/serlib/serlib_base.ml
@@ -16,9 +16,10 @@
 exception Ser_error of string
 
 let _ = CErrors.register_handler (function
-    | Ser_error msg -> Pp.(seq [str "Serlib Error: "; str msg])
+    | Ser_error msg ->
+      Some Pp.(seq [str "Serlib Error: "; str msg])
     | _ ->
-      raise CErrors.Unhandled)
+      None)
 
 let opaque_of_sexp ~typ _obj =
   raise (Ser_error ("["^typ^": ABSTRACT / cannot deserialize]"))

--- a/sertop/sercomp.ml
+++ b/sertop/sercomp.ml
@@ -23,7 +23,7 @@ let fatal_exn exn info =
   Format.eprintf "Error: @[%a@]@\n%!" Pp.pp_with msg;
   exit 1
 
-let create_document ~in_file ~stm_flags ~quick ~iload_path ~debug ~allow_sprop ~indices_matter =
+let create_document ~in_file ~stm_flags ~quick ~ml_load_path ~vo_load_path ~debug ~allow_sprop ~indices_matter =
 
   let open Sertop.Sertop_init in
 
@@ -53,11 +53,12 @@ let create_document ~in_file ~stm_flags ~quick ~iload_path ~debug ~allow_sprop ~
     else stm_options
   in
 
-  let require_libs = ["Coq.Init.Prelude", None, Some false] in
+  let injections = [Stm.RequireInjection ("Coq.Init.Prelude", None, Some false)] in
 
   let ndoc = { Stm.doc_type = Stm.VoDoc in_file
-             ; require_libs
-             ; iload_path
+             ; injections
+             ; ml_load_path
+             ; vo_load_path
              ; stm_options
              } in
 
@@ -191,7 +192,11 @@ let driver input mode debug disallow_sprop indices_matter printer async async_wo
   let options = Serlib.Serlib_init.{ omit_loc; omit_att; exn_on_opaque } in
   Serlib.Serlib_init.init ~options;
 
-  let iload_path = Serapi.Serapi_paths.coq_loadpath_default ~implicit:true ~coq_path @ ml_path @ load_path @ rload_path in
+  let dft_ml_path, vo_path =
+    Serapi.Serapi_paths.coq_loadpath_default ~implicit:true ~coq_path in
+  let ml_load_path = dft_ml_path @ ml_path in
+  let vo_load_path = vo_path @ load_path @ rload_path in
+
   let allow_sprop = not disallow_sprop in
   let stm_flags =
     { Sertop.Sertop_init.enable_async = async
@@ -199,7 +204,7 @@ let driver input mode debug disallow_sprop indices_matter printer async async_wo
     ; async_workers
     ; error_recovery
     } in
-  let doc, sid = create_document ~in_file ~stm_flags ~quick ~iload_path ~debug ~allow_sprop ~indices_matter in
+  let doc, sid = create_document ~in_file ~stm_flags ~quick ~ml_load_path ~vo_load_path ~debug ~allow_sprop ~indices_matter in
 
   (* main loop *)
   let in_chan = open_in in_file in
@@ -230,7 +235,7 @@ let main () =
     | `Error _ -> exit 1
     | _        -> exit 0
   with exn ->
-    let (e, info) = CErrors.push exn in
+    let (e, info) = Exninfo.capture exn in
     fatal_exn e info
 
 let _ = main ()

--- a/sertop/sercomp_stats.ml
+++ b/sertop/sercomp_stats.ml
@@ -43,7 +43,7 @@ let do_stats =
   (* Definition *)
   | VernacDefinition (_,_,_)
   | VernacFixpoint   (_,_)
-  | VernacInductive  (_,_,_,_)
+  | VernacInductive  (_,_)
   | VernacCoFixpoint (_,_)
   | VernacNotation   (_,_,_) ->
     stats.specs <- incS ?loc stats.specs

--- a/sertop/sername.ml
+++ b/sertop/sername.ml
@@ -22,7 +22,7 @@ let fatal_exn exn info =
   Format.eprintf "Error: @[%a@]@\n%!" Pp.pp_with msg;
   exit 1
 
-let create_document ~require_lib ~in_file ~stm_flags ~quick ~iload_path ~debug ~allow_sprop =
+let create_document ~require_lib ~in_file ~stm_flags ~quick ~ml_load_path ~vo_load_path ~debug ~allow_sprop =
 
   let open Sertop.Sertop_init in
 
@@ -66,11 +66,12 @@ let create_document ~require_lib ~in_file ~stm_flags ~quick ~iload_path ~debug ~
     | None -> prelude
   in
   *)
-  let require_libs = ["Coq.Init.Prelude", None, Some false] in
+  let injections = [Stm.RequireInjection ("Coq.Init.Prelude", None, Some false)] in
 
   let ndoc = { Stm.doc_type = Stm.VoDoc in_file
-             ; require_libs
-             ; iload_path
+             ; injections
+             ; ml_load_path
+             ; vo_load_path
              ; stm_options
              } in
 
@@ -186,8 +187,13 @@ let driver debug printer disallow_sprop async async_workers error_recovery quick
     ; async_workers
     ; error_recovery
     } in
-  let iload_path = Serapi.Serapi_paths.coq_loadpath_default ~implicit:true ~coq_path @ ml_path @ load_path @ rload_path in
-  let doc, sid = create_document ~require_lib ~in_file:"file.v" ~stm_flags ~allow_sprop ~quick ~iload_path ~debug in
+
+  let dft_ml_path, vo_path =
+    Serapi.Serapi_paths.coq_loadpath_default ~implicit:true ~coq_path in
+  let ml_load_path = dft_ml_path @ ml_path in
+  let vo_load_path = vo_path @ load_path @ rload_path in
+
+  let doc, sid = create_document ~require_lib ~in_file:"file.v" ~stm_flags ~allow_sprop ~quick ~ml_load_path ~vo_load_path ~debug in
 
   (* main loop *)
   let in_chan = open_in in_file in
@@ -218,7 +224,7 @@ let main () =
     | `Error _ -> exit 1
     | _        -> exit 0
   with exn ->
-    let (e, info) = CErrors.push exn in
+    let (e, info) = Exninfo.capture exn in
     fatal_exn e info
 
 let _ = main ()

--- a/sertop/sertok.ml
+++ b/sertop/sertok.ml
@@ -30,7 +30,7 @@ let fatal_exn exn info =
   Format.eprintf "Error: @[%a@]@\n%!" Pp.pp_with msg;
   exit 1
 
-let create_document ~in_file ~stm_flags ~quick ~iload_path ~debug ~allow_sprop =
+let create_document ~in_file ~stm_flags ~quick ~ml_load_path ~vo_load_path ~debug ~allow_sprop =
 
   let open Sertop.Sertop_init in
 
@@ -60,11 +60,12 @@ let create_document ~in_file ~stm_flags ~quick ~iload_path ~debug ~allow_sprop =
     else stm_options
   in
 
-  let require_libs = ["Coq.Init.Prelude", None, Some false] in
+  let injections = [Stm.RequireInjection ("Coq.Init.Prelude", None, Some false)] in
 
   let ndoc = { Stm.doc_type = Stm.VoDoc in_file
-             ; require_libs
-             ; iload_path
+             ; injections
+             ; ml_load_path
+             ; vo_load_path
              ; stm_options
              } in
 
@@ -101,7 +102,7 @@ let input_doc ~pp ~in_file ~in_chan ~doc ~sid =
   let in_pa   = Pcoq.Parsable.make ~loc:(Loc.initial source) in_strm in
   let in_bytes = load_file in_file in
   try while true do
-      let l_pre_st = CLexer.get_lexer_state () in
+      let l_pre_st = CLexer.Lexer.State.get () in
       let doc, sid = !stt in
       let ast =
         match Stm.parse_sentence ~doc ~entry:Pvernac.main_entry sid in_pa with
@@ -114,19 +115,19 @@ let input_doc ~pp ~in_file ~in_chan ~doc ~sid =
       let istr =
 	Bytes.sub_string in_bytes begin_char (end_char - begin_char)
       in
-      let l_post_st = CLexer.get_lexer_state () in
+      let l_post_st = CLexer.Lexer.State.get () in
       let sstr = Stream.of_string istr in
       try
-	CLexer.set_lexer_state l_pre_st;
+	CLexer.Lexer.State.set l_pre_st;
         let lex = CLexer.Lexer.tok_func sstr in
         let sen = Sertop.Sertop_ser.Sentence (stream_tok 0 [] lex source begin_line begin_char) in
-        CLexer.set_lexer_state l_post_st;
+        CLexer.Lexer.State.set l_post_st;
         printf "@[%a@]@\n%!" pp (Sertop.Sertop_ser.sexp_of_sentence sen);
         let doc, n_st, tip = Stm.add ~doc ~ontop:sid false ast in
         if tip <> `NewTip then CErrors.user_err ?loc:ast.loc Pp.(str "fatal, got no `NewTip`");
         stt := doc, n_st
       with exn -> begin
-        CLexer.set_lexer_state l_post_st;
+        CLexer.Lexer.State.set l_post_st;
         raise exn
       end
     done;
@@ -173,7 +174,11 @@ let driver debug disallow_sprop printer async async_workers error_recovery quick
   let options = Serlib.Serlib_init.{ omit_loc; omit_att; exn_on_opaque } in
   Serlib.Serlib_init.init ~options;
 
-  let iload_path = Serapi.Serapi_paths.coq_loadpath_default ~implicit:true ~coq_path @ ml_path @ load_path @ rload_path in
+  let dft_ml_path, vo_path =
+    Serapi.Serapi_paths.coq_loadpath_default ~implicit:true ~coq_path in
+  let ml_load_path = dft_ml_path @ ml_path in
+  let vo_load_path = vo_path @ load_path @ rload_path in
+
   let allow_sprop = not disallow_sprop in
   let stm_flags =
     { Sertop.Sertop_init.enable_async  = async
@@ -182,7 +187,7 @@ let driver debug disallow_sprop printer async async_workers error_recovery quick
     ; error_recovery
     } in
 
-  let doc, sid = create_document ~in_file ~stm_flags ~quick ~iload_path ~debug ~allow_sprop in
+  let doc, sid = create_document ~in_file ~stm_flags ~quick ~ml_load_path ~vo_load_path ~debug ~allow_sprop in
 
   (* main loop *)
   let in_chan = open_in in_file in
@@ -213,7 +218,7 @@ let main () =
     | `Error _ -> exit 1
     | _        -> exit 0
   with exn ->
-    let (e, info) = CErrors.push exn in
+    let (e, info) = Exninfo.capture exn in
     fatal_exn e info
 
 let _ = main ()

--- a/sertop/sertop_arg.ml
+++ b/sertop/sertop_arg.ml
@@ -121,34 +121,26 @@ let no_prelude =
   Arg.(value & flag & info ["no_prelude"] ~doc)
 
 let coq_lp_conv ~implicit (unix_path,lp) = Loadpath.{
-    path_spec = VoPath {
-        coq_path  = Libnames.dirpath_of_string lp;
-        unix_path;
-        has_ml    = AddRecML;
-        implicit;
-      };
-    recursive = true;
+    coq_path  = Libnames.dirpath_of_string lp
+  ; unix_path
+  ; has_ml = true
+  ; recursive = true
+  ; implicit
   }
 
-let rload_path : Loadpath.coq_path list Term.t =
+let rload_path : Loadpath.vo_path list Term.t =
   let doc = "Bind a logical loadpath LP to a directory DIR and implicitly open its namespace." in
   Term.(const List.(map (coq_lp_conv ~implicit:true)) $
         Arg.(value & opt_all (pair dir string) [] & info ["R"; "rec-load-path"] ~docv:"DIR,LP"~doc))
 
-let load_path : Loadpath.coq_path list Term.t =
+let load_path : Loadpath.vo_path list Term.t =
   let doc = "Bind a logical loadpath LP to a directory DIR" in
   Term.(const List.(map (coq_lp_conv ~implicit:false)) $
         Arg.(value & opt_all (pair dir string) [] & info ["Q"; "load-path"] ~docv:"DIR,LP" ~doc))
 
-let coq_include_conv unix_path = Loadpath.{
-    path_spec = MlPath unix_path;
-    recursive = false;
-  }
-
-let ml_include_path : Loadpath.coq_path list Term.t =
+let ml_include_path : string list Term.t =
   let doc = "Include DIR in default loadpath, for locating ML files" in
-  Term.(const List.(map coq_include_conv) $
-        Arg.(value & opt_all dir [] & info ["I"; "ml-include-path"] ~docv:"DIR" ~doc))
+  Arg.(value & opt_all dir [] & info ["I"; "ml-include-path"] ~docv:"DIR" ~doc)
 
 (* Low-level serialization options for display *)
 let omit_loc : bool Term.t =

--- a/sertop/sertop_arg.mli
+++ b/sertop/sertop_arg.mli
@@ -34,9 +34,9 @@ val printer         : Sertop_ser.ser_printer Term.t
 val debug           : bool Term.t
 val print0          : bool Term.t
 val length          : bool Term.t
-val rload_path      : Loadpath.coq_path list Term.t
-val load_path       : Loadpath.coq_path list Term.t
-val ml_include_path : Loadpath.coq_path list Term.t
+val rload_path      : Loadpath.vo_path list Term.t
+val load_path       : Loadpath.vo_path list Term.t
+val ml_include_path : string list Term.t
 val no_init         : bool Term.t
 val topfile         : string option Term.t
 val no_prelude      : bool Term.t

--- a/sertop/sertop_async.ml
+++ b/sertop/sertop_async.ml
@@ -32,7 +32,7 @@ let read_cmd cmd_sexp : [`Error of Sexp.t | `Ok of string * cmd ] =
       `Error (Conv.sexp_of_exn exn)
 
 (* Initialize Coq. *)
-let sertop_init ~(fb_out : Sexp.t -> unit) ~iload_path ~require_libs ~debug ~allow_sprop =
+let sertop_init ~(fb_out : Sexp.t -> unit) ~ml_load_path ~vo_load_path ~injections ~debug ~allow_sprop =
   let open! Sertop.Sertop_init in
 
   let fb_handler fb = Sertop.Sertop_ser.sexp_of_answer (Feedback (Sertop.Sertop_util.feedback_tr fb)) |> fb_out in
@@ -54,9 +54,11 @@ let sertop_init ~(fb_out : Sexp.t -> unit) ~iload_path ~require_libs ~debug ~all
 
   let open Stm in
   let doc_type = Interactive (TopLogical Names.(DirPath.make [Id.of_string "SerTopJS"])) in
+
   let ndoc = { doc_type
-             ; require_libs
-             ; iload_path
+             ; injections
+             ; ml_load_path
+             ; vo_load_path
              ; stm_options
              } in
   new_doc ndoc

--- a/sertop/sertop_async.mli
+++ b/sertop/sertop_async.mli
@@ -19,8 +19,9 @@ open Sexplib
     [fb_handler] *)
 val sertop_init :
   fb_out:(Sexp.t -> unit) ->
-  iload_path:Loadpath.coq_path list ->
-  require_libs:(string * string option * bool option) list ->
+  ml_load_path:string list ->
+  vo_load_path:Loadpath.vo_path list ->
+  injections:Stm.injection_command list ->
   debug:bool ->
   allow_sprop:bool ->
   Stm.doc * Stateid.t

--- a/sertop/sertop_bin.ml
+++ b/sertop/sertop_bin.ml
@@ -28,27 +28,29 @@ let sertop printer print0 debug disallow_sprop indices_matter lheader coq_path m
   let options = Serlib.Serlib_init.{ omit_loc; omit_att; exn_on_opaque } in
   Serlib.Serlib_init.init ~options;
 
-  let loadpath = Serapi.Serapi_paths.coq_loadpath_default ~implicit:true ~coq_path @
-                   ml_path @ lp1 @ lp2 in
+  let dft_ml_path, vo_path =
+    Serapi.Serapi_paths.coq_loadpath_default ~implicit:true ~coq_path in
+  let ml_path = dft_ml_path @ ml_path in
+  let vo_path = vo_path @ lp1 @ lp2 in
   let allow_sprop = not disallow_sprop in
 
   ser_loop
-    {  in_chan  = stdin;
-       out_chan = stdout;
+    { in_chan  = stdin
+    ; out_chan = stdout
 
-       debug;
-       allow_sprop;
-       indices_matter;
-       printer;
-       print0;
-       lheader;
+    ; debug
+    ; allow_sprop
+    ; indices_matter
+    ; printer
+    ; print0
+    ; lheader
 
-       no_init;
-       no_prelude;
-       topfile;
-       loadpath;
-
-       async =
+    ; no_init
+    ; no_prelude
+    ; topfile
+    ; ml_path
+    ; vo_path
+    ; async =
          { enable_async = async
          ; deep_edits
          ; async_workers

--- a/sertop/sertop_init.ml
+++ b/sertop/sertop_init.ml
@@ -45,7 +45,7 @@ type coq_opts = {
 let coq_init opts =
 
   if opts.debug then begin
-    Backtrace.record_backtrace true;
+    Printexc.record_backtrace true;
     Flags.debug := true;
   end;
 
@@ -58,7 +58,6 @@ let coq_init opts =
   let ser_mltop : Mltop.toplevel = let open Mltop in
     { load_obj
     (* We ignore all the other operations for now. *)
-    ; use_file = (fun _ -> ())
     ; add_dir
     ; ml_loop  = (fun _ -> ())
     } in
@@ -74,6 +73,8 @@ let coq_init opts =
   (* --allow-sprop in agreement with coq v8.11  *)
   Global.set_allow_sprop opts.allow_sprop;
 
+  (* XXX fixme *)
+  Flags.set_native_compiler false;
 
   (**************************************************************************)
   (* Feedback setup                                                         *)

--- a/sertop/sertop_sexp.ml
+++ b/sertop/sertop_sexp.ml
@@ -41,7 +41,8 @@ type ser_opts =
 ; no_init  : bool                (* Whether to create the initial document     *)
 ; no_prelude : bool              (* Whether to load stdlib's prelude           *)
 ; topfile  : string option       (* Top name is derived from topfile name      *)
-; loadpath : Loadpath.coq_path list (* From -R and -Q options usually *)
+; ml_path : string list
+; vo_path : Loadpath.vo_path list (** From -R and -Q options usually           *)
 ; async    : Sertop_init.async_flags
 }
 
@@ -144,17 +145,18 @@ let ser_loop ser_opts =
    *)
   Sys.catch_break true;
 
-  let require_libs =
+  let injections =
     if ser_opts.no_prelude then []
-    else ["Coq.Init.Prelude", None, Some false] in
+    else [Stm.RequireInjection ("Coq.Init.Prelude", None, Some false)] in
 
-  let iload_path = ser_opts.loadpath in
+  let ml_load_path, vo_load_path = ser_opts.ml_path, ser_opts.vo_path in
   let stm_options = Sertop_init.process_stm_flags ser_opts.async in
 
   if not ser_opts.no_init then begin
     let ndoc = { Stm.doc_type = doc_type ser_opts.topfile
-               ; require_libs
-               ; iload_path
+               ; injections
+               ; ml_load_path
+               ; vo_load_path
                ; stm_options
                } in
     let _ = Stm.new_doc ndoc in

--- a/sertop/sertop_sexp.mli
+++ b/sertop/sertop_sexp.mli
@@ -38,7 +38,8 @@ type ser_opts =
 ; topfile  : string option       (** Top name is derived from topfile name    *)
 
 (* Coq options *)
-; loadpath : Loadpath.coq_path list (** From -R and -Q options usually           *)
+; ml_path : string list
+; vo_path : Loadpath.vo_path list (** From -R and -Q options usually           *)
 ; async    : Sertop_init.async_flags
                                  (** Async flags                              *)
 }

--- a/tests/genarg/move.v
+++ b/tests/genarg/move.v
@@ -1,5 +1,5 @@
 From Coq Require Import ssreflect ssrbool ssrfun.
-From mathcomp Require Import ssrnat eqtype seq path fintype.
+From mathcomp Require Import ssrnat eqtype.
 Set Implicit Arguments.
 Unset Strict Implicit.
 Unset Printing Implicit Defensive.


### PR DESCRIPTION
[general] Port to Coq v8.12

- a large amount of changes are due to loadpath, we should remove
  duplication.
- some tricky parts upstream are in particular the representation of
  notations and numeral tokens.

For the rest, the release should be relatively stable.