### PR TITLE
[serapi] New command `SaveDoc` to save .vo files.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,10 @@
             return the logical path for a particular `.v` file
             (@ejgallego, see also
             https://github.com/cpitclaudel/alectryon/pull/25)
+ - [serapi] new `(SaveDoc opts)` command supporting saving of .vo
+            files even when from interactive mode; note that using
+            `--topfile` is required (fixes #238, @ejgallego, reported
+            by Jason Gross)
 
 ## Version 0.13.0:
 

--- a/serapi/serapi_doc.ml
+++ b/serapi/serapi_doc.ml
@@ -1,0 +1,43 @@
+(************************************************************************)
+(*         *   The Coq Proof Assistant / The Coq Development Team       *)
+(*  v      *   INRIA, CNRS and contributors - Copyright 1999-2021       *)
+(* <O___,, *       (see CREDITS file for the list of authors)           *)
+(*   \VV/  **************************************************************)
+(*    //   *    This file is distributed under the terms of the         *)
+(*         *     GNU Lesser General Public License Version 2.1          *)
+(*         *     (see LICENSE file for the text of the license)         *)
+(************************************************************************)
+
+(************************************************************************)
+(* Coq serialization API/Plugin                                         *)
+(* Copyright 2016-2019 MINES ParisTech -- Dual License LGPL 2.1 / GPL3+ *)
+(* Copyright 2020-2021 Inria                                            *)
+(* Written by: Emilio J. Gallego Arias                                  *)
+(************************************************************************)
+(* Status: Experimental                                                 *)
+(************************************************************************)
+
+(* Duplicate with sertop, fix in different refactoring *)
+let check_pending_proofs ~pstate =
+  Option.iter (fun _pstate ->
+  (* let pfs = Proof_global.get_all_proof_names pstate in *)
+  let pfs = [] in
+  if not CList.(is_empty pfs) then
+    let msg = let open Pp in
+      seq [ str "There are pending proofs: "
+          ; pfs |> List.rev |> prlist_with_sep pr_comma Names.Id.print; str "."] in
+    CErrors.user_err msg
+    ) pstate
+
+let save_vo ~doc ?ldir ~pstate ~in_file =
+  let _doc = Stm.join ~doc in
+  check_pending_proofs ~pstate;
+  let ldir = match ldir with
+    | None -> Stm.get_ldir ~doc
+    (* EJGA: When in interactive mode, the above won't work due to a
+       STM bug, we thus allow SerAPI clients to override it *)
+    | Some ldir -> ldir
+  in
+  let out_vo = Filename.(remove_extension in_file) ^ ".vo" in
+  let todo_proofs = Library.ProofsTodoNone in
+  Library.save_library_to todo_proofs ~output_native_objects:false ldir out_vo (Global.opaque_tables ())

--- a/serapi/serapi_doc.mli
+++ b/serapi/serapi_doc.mli
@@ -1,0 +1,25 @@
+(************************************************************************)
+(*         *   The Coq Proof Assistant / The Coq Development Team       *)
+(*  v      *   INRIA, CNRS and contributors - Copyright 1999-2021       *)
+(* <O___,, *       (see CREDITS file for the list of authors)           *)
+(*   \VV/  **************************************************************)
+(*    //   *    This file is distributed under the terms of the         *)
+(*         *     GNU Lesser General Public License Version 2.1          *)
+(*         *     (see LICENSE file for the text of the license)         *)
+(************************************************************************)
+
+(************************************************************************)
+(* Coq serialization API/Plugin                                         *)
+(* Copyright 2016-2019 MINES ParisTech -- Dual License LGPL 2.1 / GPL3+ *)
+(* Copyright 2020-2021 Inria                                            *)
+(* Written by: Emilio J. Gallego Arias                                  *)
+(************************************************************************)
+(* Status: Experimental                                                 *)
+(************************************************************************)
+
+val save_vo
+  :  doc:Stm.doc
+  -> ?ldir:Names.DirPath.t
+  -> pstate:Declare.Proof.t option
+  -> in_file:string
+  -> unit

--- a/sertop/sertop_ser.ml
+++ b/sertop/sertop_ser.ml
@@ -265,6 +265,10 @@ type newdoc_opts =
   ]]
   [@@deriving sexp]
 
+type save_opts =
+  [%import: Serapi.Serapi_protocol.save_opts]
+  [@@deriving sexp]
+
 type parse_opt =
   [%import: Serapi.Serapi_protocol.parse_opt
   [@with


### PR DESCRIPTION
We introduce a new commmand:
```lisp
(SaveDoc opts)
```
to save .vo files from an interactive session. `opts` are optional,
and can be

- `(sid s)`: save the document at a specific sentence
- `(prefix_output_dir dir)` add a prefix to the `file.vo` to be saved.

Note that Coq requires that the module name and the filename do match,
thus in order to use this command `sertop` must be called with the
`--topfile file.v` flag, otherwise `CannotSaveVo` will be raised.

Closes #128 #238