### PR TITLE
[sertop] Improve error message when sertop fails to locate a plugin

### DIFF
--- a/sertop/sertop_loader.ml
+++ b/sertop/sertop_loader.ml
@@ -61,6 +61,10 @@ let plugin_handler user_handler =
         let () = loader ml_file in
         ()
     with
-      Dynlink.Error err ->
+    | Dynlink.Error err as exn ->
       let msg = Dynlink.error_message err in
-      Format.eprintf "[sertop] Critical Dynlink error %s@\n%!" msg
+      Format.eprintf "[sertop] Critical Dynlink error %s@\n%!" msg;
+      raise exn
+    | Fl_package_base.No_such_package (pkg, _) as exn ->
+      Format.eprintf "[sertop] Couldn't find the SerAPI plugin %s@; please check `ocamlfind list` does include SerAPI's plugin libraries.\n%!" pkg;
+      raise exn


### PR DESCRIPTION
As witnessed in #241, the current error is confusing, we try to
improve it as this is a common problem with SerAPI's install.