### PR TITLE
Some missing yojson annotations

### DIFF
--- a/serlib/ser_names.ml
+++ b/serlib/ser_names.ml
@@ -132,14 +132,17 @@ module KerName = struct
 type t = [%import: Names.KerName.t]
 
 type _kername = KerName of ModPath.t * Label.t
-      [@@deriving sexp]
+      [@@deriving sexp,yojson]
 
 let _kername_put kn              =
   let mp, l = KerName.repr kn in KerName (mp,l)
 let _kername_get (KerName (mp,l)) = KerName.make mp l
 
 let t_of_sexp sexp = _kername_get (_kername_of_sexp sexp)
-let sexp_of_t dp   = sexp_of__kername (_kername_put dp)
+let sexp_of_t kn   = sexp_of__kername (_kername_put kn)
+
+let of_yojson json = Ppx_deriving_yojson_runtime.(_kername_of_yojson json >|= _kername_get)
+let to_yojson kn   = _kername_to_yojson (_kername_put kn)
 
 end
 

--- a/serlib/ser_names.mli
+++ b/serlib/ser_names.mli
@@ -30,12 +30,12 @@ module Name    : SerType.SJ with type t = Name.t
 module DirPath : SerType.SJ with type t = DirPath.t
 module DPmap   : Ser_cMap.ExtS with type key = DirPath.t and type 'a t = 'a DPmap.t
 
-module Label   : SerType.S with type t = Label.t
-module MBId    : SerType.S with type t = MBId.t
-module ModPath : SerType.S with type t = ModPath.t
+module Label   : SerType.SJ with type t = Label.t
+module MBId    : SerType.SJ with type t = MBId.t
+module ModPath : SerType.SJ with type t = ModPath.t
 module MPmap   : Ser_cMap.ExtS with type key = ModPath.t and type 'a t = 'a MPmap.t
 
-module KerName  : SerType.S with type t = KerName.t
+module KerName  : SerType.SJ with type t = KerName.t
 module Constant : SerType.SJ with type t = Constant.t
 
 module Cmap : Ser_cMap.ExtS with type key = Constant.t and type 'a t = 'a Cmap.t


### PR DESCRIPTION
 * Label, MBId, and ModPath already had yojson but were missing the type annotation in the interface.
 * KerName did not have yojson serialization but one was easy to add.