### PR TITLE
Rename `ground_plugin` into `firstorder_plugin`.

### DIFF
--- a/serlib/plugins/firstorder/dune
+++ b/serlib/plugins/firstorder/dune
@@ -1,6 +1,6 @@
 (library
  (name serlib_firstorder)
- (public_name coq-serapi.serlib.ground_plugin)
+ (public_name coq-serapi.serlib.firstorder_plugin)
  (synopsis "Serialization Library for Coq Firstorder Plugin")
  (preprocess (staged_pps ppx_import ppx_sexp_conv))
  (libraries coq.plugins.firstorder serlib sexplib))

--- a/sertop/sertop_loader.ml
+++ b/sertop/sertop_loader.ml
@@ -29,7 +29,7 @@ let map_serlib ml_mod =
     | "ltac_plugin" -> false
     (* | "tauto_plugin" -> false *)
     (* Supported *)
-    | "ground_plugin"           (* firstorder *)
+    | "firstorder_plugin"       (* firstorder *)
     | "recdef_plugin"           (* funind *)
     | "ring_plugin"             (* setoid_ring *)
     | "extraction_plugin"       (* setoid_ring *)


### PR DESCRIPTION
The failure I was getting in #241 was not due to Coq being improperly registered for `ocamlfind`.
For reasons that I do not precisely understand, this change makes the error disappear.