### PR TITLE
[serlib] Ignore `env` parameter in certain exceptions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,8 +13,10 @@
  - [nix]    Added Nix support (#249, fixes #248, @Zimmi48, reported
             by @nyraghu)
  - [serapi] Fix COQPATH support: interpret paths as absolute (#249, @Zimmi48)
- - [serlib] Ignore `env` parameter in certain exceptions (#251, fixes #250,
+ - [serlib] Ignore `env` parameter in certain exceptions (#254, fixes #250,
             @ejgallego, reported by @cpitclaudel)
+ - [sertop] New option `--omit_env` that will disable the serialization of
+            Coq's super heavy global environments (#254 @ejgallego)
 
 ## Version 0.13.0:
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,8 @@
  - [nix]    Added Nix support (#249, fixes #248, @Zimmi48, reported
             by @nyraghu)
  - [serapi] Fix COQPATH support: interpret paths as absolute (#249, @Zimmi48)
+ - [serlib] Ignore `env` parameter in certain exceptions (#251, fixes #250,
+            @ejgallego, reported by @cpitclaudel)
 
 ## Version 0.13.0:
 

--- a/serlib/ser_environ.ml
+++ b/serlib/ser_environ.ml
@@ -76,6 +76,12 @@ type env =
 
 let env_of_sexp = Serlib_base.opaque_of_sexp ~typ:"Environ.env"
 
+let abstract_env = ref false
+let sexp_of_env env =
+  if !abstract_env
+  then Serlib_base.sexp_of_opaque ~typ:"Environ.env" env
+  else sexp_of_env env
+
 type ('constr, 'term) punsafe_judgment =
   [%import: ('constr, 'term) Environ.punsafe_judgment]
   [@@deriving sexp]

--- a/serlib/ser_environ.mli
+++ b/serlib/ser_environ.mli
@@ -15,22 +15,23 @@
 
 open Sexplib
 
+(** Control whether to output environs, they are huge, and in some
+   case problematic; if abstract_env is true, they will be serialized
+   as abstract *)
+val abstract_env : bool ref
+
 type env = Environ.env
 
-val env_of_sexp : Sexp.t -> env
-val sexp_of_env : env -> Sexp.t
+val env_of_sexp : Sexp.t -> env val sexp_of_env : env -> Sexp.t
 
-type ('constr, 'types) punsafe_judgment = ('constr, 'types) Environ.punsafe_judgment
+type ('constr, 'types) punsafe_judgment = ('constr, 'types)
+   Environ.punsafe_judgment
 
-val punsafe_judgment_of_sexp :
-  (Sexp.t -> 'constr) ->
-  (Sexp.t -> 'types) -> Sexp.t ->
-  ('constr, 'types) punsafe_judgment
-val sexp_of_punsafe_judgment :
-  ('constr -> Sexplib.Sexp.t) ->
-  ('types -> Sexplib.Sexp.t) ->
-  ('constr, 'types) punsafe_judgment -> Sexp.t
+val punsafe_judgment_of_sexp : (Sexp.t -> 'constr) -> (Sexp.t ->
+   'types) -> Sexp.t -> ('constr, 'types) punsafe_judgment val
+   sexp_of_punsafe_judgment : ('constr -> Sexplib.Sexp.t) -> ('types
+   -> Sexplib.Sexp.t) -> ('constr, 'types) punsafe_judgment -> Sexp.t
 
-type unsafe_judgment = Environ.unsafe_judgment
-val unsafe_judgment_of_sexp : Sexp.t -> unsafe_judgment
-val sexp_of_unsafe_judgment : unsafe_judgment -> Sexp.t
+type unsafe_judgment = Environ.unsafe_judgment val
+   unsafe_judgment_of_sexp : Sexp.t -> unsafe_judgment val
+   sexp_of_unsafe_judgment : unsafe_judgment -> Sexp.t

--- a/serlib/serlib_base.mli
+++ b/serlib/serlib_base.mli
@@ -15,6 +15,8 @@
 
 open Sexplib
 
+(** Controls when an opaque type produces and error vs an "abstract"
+   constructor *)
 val exn_on_opaque : bool ref
 
 val sexp_of_opaque : typ:string -> 'a -> Sexp.t

--- a/serlib/serlib_init.ml
+++ b/serlib/serlib_init.ml
@@ -1,6 +1,7 @@
 type options =
   { omit_loc : bool
   ; omit_att : bool
+  ; omit_env : bool
   ; exn_on_opaque : bool
   }
 
@@ -8,4 +9,5 @@ let init ~options =
   Ser_loc.omit_loc  := options.omit_loc;
   Ser_cAst.omit_att := options.omit_att;
   Serlib_base.exn_on_opaque := options.exn_on_opaque;
+  Ser_environ.abstract_env := options.omit_env;
   ()

--- a/serlib/serlib_init.mli
+++ b/serlib/serlib_init.mli
@@ -1,6 +1,7 @@
 type options =
   { omit_loc : bool
   ; omit_att : bool
+  ; omit_env : bool
   ; exn_on_opaque : bool
   }
 

--- a/sertop/sercomp.ml
+++ b/sertop/sercomp.ml
@@ -182,14 +182,14 @@ let sercomp_doc = "sercomp Coq Compiler"
 open Cmdliner
 
 let driver input mode debug disallow_sprop indices_matter printer async async_workers error_recovery quick
-    coq_path ml_path load_path rload_path in_file omit_loc omit_att exn_on_opaque =
+    coq_path ml_path load_path rload_path in_file omit_loc omit_att omit_env exn_on_opaque =
 
   (* closures *)
   let pp = Sertop.Sertop_ser.select_printer printer in
   let process = process_vernac ~mode ~pp in
 
   (* initialization *)
-  let options = Serlib.Serlib_init.{ omit_loc; omit_att; exn_on_opaque } in
+  let options = Serlib.Serlib_init.{ omit_loc; omit_att; exn_on_opaque; omit_env } in
   Serlib.Serlib_init.init ~options;
 
   let dft_ml_path, vo_path =
@@ -226,7 +226,7 @@ let main () =
     let open Sertop.Sertop_arg in
     Term.(const driver
           $ comp_input $ comp_mode $ debug $ disallow_sprop $ indices_matter $ printer $ async $ async_workers $ error_recovery $ quick $ prelude
-          $ ml_include_path $ load_path $ rload_path $ input_file $ omit_loc $ omit_att $ exn_on_opaque
+          $ ml_include_path $ load_path $ rload_path $ input_file $ omit_loc $ omit_att $ omit_env $ exn_on_opaque
          ),
     Term.info "sercomp" ~version:sercomp_version ~doc:sercomp_doc ~man:sercomp_man
   in

--- a/sertop/sername.ml
+++ b/sertop/sername.ml
@@ -170,14 +170,14 @@ let sername_doc = "sername Coq tool"
 
 open Cmdliner
 
-let driver debug printer disallow_sprop async async_workers error_recovery quick coq_path ml_path load_path rload_path require_lib str_pp de_bruijn body in_file omit_loc omit_att exn_on_opaque =
+let driver debug printer disallow_sprop async async_workers error_recovery quick coq_path ml_path load_path rload_path require_lib str_pp de_bruijn body in_file omit_loc omit_att omit_env exn_on_opaque =
 
   (* closures *)
   let pp = Sertop.Sertop_ser.select_printer printer in
   let process = process_line ~pp ~str_pp ~de_bruijn ~body in
 
   (* initialization *)
-  let options = Serlib.Serlib_init.{ omit_loc; omit_att; exn_on_opaque } in
+  let options = Serlib.Serlib_init.{ omit_loc; omit_att; omit_env; exn_on_opaque } in
   Serlib.Serlib_init.init ~options;
 
   let allow_sprop = not disallow_sprop in
@@ -215,7 +215,7 @@ let main () =
     let open Sertop.Sertop_arg in
     Term.(const driver
           $ debug $ printer $ disallow_sprop $ async $ async_workers $ error_recovery $ quick $ prelude
-          $ ml_include_path $ load_path $ rload_path $ require_lib $ str_pp $ de_bruijn $ body $ input_file $ omit_loc $ omit_att $ exn_on_opaque
+          $ ml_include_path $ load_path $ rload_path $ require_lib $ str_pp $ de_bruijn $ body $ input_file $ omit_loc $ omit_att $ omit_env $ exn_on_opaque
          ),
     Term.info "sername" ~version:sername_version ~doc:sername_doc ~man:sername_man
   in

--- a/sertop/sertok.ml
+++ b/sertop/sertok.ml
@@ -165,13 +165,13 @@ let sertok_doc = "sertok Coq tokenizer"
 
 open Cmdliner
 
-let driver debug disallow_sprop printer async async_workers error_recovery quick coq_path ml_path load_path rload_path in_file omit_loc omit_att exn_on_opaque =
+let driver debug disallow_sprop printer async async_workers error_recovery quick coq_path ml_path load_path rload_path in_file omit_loc omit_att omit_env exn_on_opaque =
 
   (* closures *)
   let pp = Sertop.Sertop_ser.select_printer printer in
 
   (* initialization *)
-  let options = Serlib.Serlib_init.{ omit_loc; omit_att; exn_on_opaque } in
+  let options = Serlib.Serlib_init.{ omit_loc; omit_att; exn_on_opaque; omit_env } in
   Serlib.Serlib_init.init ~options;
 
   let dft_ml_path, vo_path =
@@ -209,7 +209,7 @@ let main () =
     let open Sertop.Sertop_arg in
     Term.(const driver
           $ debug $ disallow_sprop $ printer $ async $ async_workers $ error_recovery $ quick $ prelude
-          $ ml_include_path $ load_path $ rload_path $ input_file $ omit_loc $ omit_att $ exn_on_opaque
+          $ ml_include_path $ load_path $ rload_path $ input_file $ omit_loc $ omit_att $ omit_env $ exn_on_opaque
          ),
     Term.info "sertok" ~version:sertok_version ~doc:sertok_doc ~man:sertok_man
   in

--- a/sertop/sertop_arg.ml
+++ b/sertop/sertop_arg.ml
@@ -151,6 +151,10 @@ let omit_att : bool Term.t =
   let doc = "[debug option] omit attribute nodes" in
   Arg.(value & flag & info ["omit_att"] ~doc)
 
+let omit_env : bool Term.t =
+  let doc = "[debug option] turn enviroments into abstract objects" in
+  Arg.(value & flag & info ["omit_env"] ~doc)
+
 let exn_on_opaque : bool Term.t =
   let doc = "[debug option] raise an exception on non-serializeble terms" in
   Arg.(value & flag & info ["exn_on_opaque"] ~doc)

--- a/sertop/sertop_arg.mli
+++ b/sertop/sertop_arg.mli
@@ -56,3 +56,4 @@ val comp_input : comp_input Term.t
 val omit_loc : bool Term.t
 val omit_att : bool Term.t
 val exn_on_opaque : bool Term.t
+val omit_env : bool Term.t

--- a/sertop/sertop_bin.ml
+++ b/sertop/sertop_bin.ml
@@ -20,12 +20,12 @@ open Cmdliner
 
 let sertop_version = Sertop.Ser_version.ser_git_version
 
-let sertop printer print0 debug disallow_sprop indices_matter lheader coq_path ml_path no_init topfile no_prelude lp1 lp2 _std_impl async deep_edits async_workers error_recovery omit_loc omit_att exn_on_opaque =
+let sertop printer print0 debug disallow_sprop indices_matter lheader coq_path ml_path no_init topfile no_prelude lp1 lp2 _std_impl async deep_edits async_workers error_recovery omit_loc omit_att omit_env exn_on_opaque =
 
   let open  Sertop.Sertop_init         in
   let open! Sertop.Sertop_sexp         in
 
-  let options = Serlib.Serlib_init.{ omit_loc; omit_att; exn_on_opaque } in
+  let options = Serlib.Serlib_init.{ omit_loc; omit_att; exn_on_opaque; omit_env } in
   Serlib.Serlib_init.init ~options;
 
   let dft_ml_path, vo_path =


### PR DESCRIPTION
Should fix #250, tho it is far from a principled solution.

Several Coq structures do like to embed a full `env`; what we do here,
it is far from practical, as it won't scale, but at least should
alleviate the immediate pain

Other possible hack would to add an `--omit_env` parameter that would
turn all `env` into abstract; but generally, we should really
introduce a mechanism for the management of contextual info as
discussed in the bug tracker.