### PR TITLE
[serapi] Support for low-level evar information.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,8 @@
  - [nix]    Added Nix support (#249, fixes #248, @Zimmi48, reported
             by @nyraghu)
  - [serapi] Fix COQPATH support: interpret paths as absolute (#249, @Zimmi48)
+ - [serapi] New Query `(Evars (define %bool))` , which will serialize
+            low-level path information (#256, fixes #20, @ejgallego)
 
 ## Version 0.13.0:
 

--- a/serapi/serapi_protocol.mli
+++ b/serapi/serapi_protocol.mli
@@ -237,6 +237,8 @@ type coq_object =
 
      See https://github.com/coq/coq/issues/12413 for updates on
      improved support *)
+  | CoqEvarInfo of (Evar.t * Evd.evar_info) list
+  (** List of evar bindings, maybe defined or undefined *)
 
 (******************************************************************************)
 (* Printing Sub-Protocol                                                      *)
@@ -360,6 +362,8 @@ type query_cmd =
   (** Naïve but efficient prefix-based completion of identifiers *)
   | Comments
   (** Get all comments of a document *)
+  | Evars of { defined : bool }
+  (** Get evar map, if [defined] is true, also output the defined variables. *)
 
 module QueryUtil : sig
   val info_of_id : Environ.env -> string -> coq_object list * coq_object list

--- a/serlib/ser_eConstr.ml
+++ b/serlib/ser_eConstr.ml
@@ -39,4 +39,3 @@ type types =
 type unsafe_judgment =
   [%import: EConstr.unsafe_judgment]
   [@@deriving sexp]
-

--- a/serlib/ser_environ.ml
+++ b/serlib/ser_environ.ml
@@ -42,6 +42,9 @@ type named_context_val =
   [%import: Environ.named_context_val]
   [@@deriving sexp_of]
 
+let named_context_val_of_sexp =
+  Serlib_base.opaque_of_sexp ~typ:"Environ.named_context_val"
+
 type link_info =
   [%import: Environ.link_info]
   [@@deriving sexp]
@@ -83,3 +86,4 @@ type ('constr, 'term) punsafe_judgment =
 type unsafe_judgment =
   [%import: Environ.unsafe_judgment]
   [@@deriving sexp]
+

--- a/serlib/ser_environ.mli
+++ b/serlib/ser_environ.mli
@@ -34,3 +34,5 @@ val sexp_of_punsafe_judgment :
 type unsafe_judgment = Environ.unsafe_judgment
 val unsafe_judgment_of_sexp : Sexp.t -> unsafe_judgment
 val sexp_of_unsafe_judgment : unsafe_judgment -> Sexp.t
+
+type named_context_val = Environ.named_context_val [@@deriving sexp]

--- a/serlib/ser_evd.ml
+++ b/serlib/ser_evd.ml
@@ -15,9 +15,11 @@
 
 open Sexplib.Std
 
+module Loc       = Ser_loc
 module Environ   = Ser_environ
 module Reduction = Ser_reduction
 module Constr    = Ser_constr
+module Evar_kinds = Ser_evar_kinds
 
 type econstr =
   [%import: Evd.econstr]
@@ -25,6 +27,41 @@ type econstr =
 (* ahhh *)
 let econstr_of_sexp s = Obj.magic (Constr.t_of_sexp s)
 let sexp_of_econstr c = Constr.sexp_of_t (Obj.magic c)
+
+type evar_body =
+  [%import: Evd.evar_body]
+  [@@deriving sexp]
+
+module Abstraction = struct
+
+  type abstraction =
+    [%import: Evd.Abstraction.abstraction]
+    [@@deriving sexp]
+
+  type t =
+    [%import: Evd.Abstraction.t]
+    [@@deriving sexp]
+end
+
+module Filter = struct
+
+  type t = Evd.Filter.t
+  let t_of_sexp = Serlib_base.opaque_of_sexp ~typ:"Evd.Filter.t"
+  let sexp_of_t = Serlib_base.sexp_of_opaque ~typ:"Evd.Filter.t"
+
+end
+
+module Identity = struct
+
+  type t = Evd.Identity.t
+  let t_of_sexp = Serlib_base.opaque_of_sexp ~typ:"Evd.Identity.t"
+  let sexp_of_t = Serlib_base.sexp_of_opaque ~typ:"Evd.Identity.t"
+
+end
+
+type evar_info =
+  [%import: Evd.evar_info]
+  [@@deriving sexp]
 
 type conv_pb = Reduction.conv_pb
   [@@deriving sexp]

--- a/serlib/ser_evd.mli
+++ b/serlib/ser_evd.mli
@@ -15,6 +15,8 @@
 
 open Sexplib
 
+type evar_info = Evd.evar_info [@@deriving sexp]
+
 type conv_pb = Evd.conv_pb
 val conv_pb_of_sexp : Sexp.t -> conv_pb
 val sexp_of_conv_pb : conv_pb -> Sexp.t

--- a/sertop/sertop_ser.ml
+++ b/sertop/sertop_ser.ml
@@ -98,6 +98,7 @@ module Notation_gram = Ser_notation_gram
 module Genarg     = Ser_genarg
 module Loadpath   = Ser_loadpath
 module Printer    = Ser_printer
+module Evd        = Ser_evd
 
 (* Alias fails due to the [@@default in protocol] *)
 (* module Stm        = Ser_stm *)


### PR DESCRIPTION
Fixes ejgallego/coq-serapi#20

This is still experimental, in particular we should maybe provide a
better support for handling ejgallego/coq-lsp#332.