### PR TITLE
Update to account for post-8.14 change to Loc.t definition

### DIFF
--- a/sertop/sercomp.ml
+++ b/sertop/sercomp.ml
@@ -79,7 +79,7 @@ let input_doc ~input ~in_file ~in_chan ~process ~doc ~sid =
   | I_vernac ->
      begin
        let in_strm = Stream.of_channel in_chan in
-       let in_pa   = Pcoq.Parsable.make ~loc:(Loc.initial (InFile in_file)) in_strm in
+       let in_pa   = Pcoq.Parsable.make ~loc:(Loc.initial (InFile {dirpath=None; file=in_file})) in_strm in
        try while true do
            let doc, sid = !stt in
            let east =

--- a/sertop/sername.ml
+++ b/sertop/sername.ml
@@ -94,7 +94,7 @@ let create_document ~require_lib ~in_file ~stm_flags ~quick ~ml_load_path ~vo_lo
      let doc,sid = Stm.new_doc ndoc in
      let sent = Printf.sprintf "Require %s." l in
      let in_strm = Stream.of_string sent in
-     let in_pa = Pcoq.Parsable.make ~loc:(Loc.initial (InFile in_file)) in_strm in
+     let in_pa = Pcoq.Parsable.make ~loc:(Loc.initial (InFile {dirpath=None; file=in_file})) in_strm in
      match Stm.parse_sentence ~doc ~entry:Pvernac.main_entry sid in_pa with
      | Some ast ->
 	let doc, sid, tip = Stm.add ~doc ~ontop:sid false ast in

--- a/sertop/sertok.ml
+++ b/sertop/sertok.ml
@@ -98,7 +98,7 @@ let input_doc ~pp ~in_file ~in_chan ~doc ~sid =
   let open Format in
   let stt = ref (doc, sid) in
   let in_strm = Stream.of_channel in_chan in
-  let source = Loc.InFile in_file in
+  let source = Loc.InFile {dirpath=None; file=in_file} in
   let in_pa   = Pcoq.Parsable.make ~loc:(Loc.initial source) in_strm in
   let in_bytes = load_file in_file in
   try while true do


### PR DESCRIPTION
Applies changes to Loc.t from https://github.com/coq/coq/pull/14354 so that SerAPI compiles.  That will let users of the debugger preview to use SerAPI.

I wasn't able to compile SerAPI on my system with dune, but I think these are probably the right changes.  (I was trying to build SerAPI from the command line.)

Also, this should submitted to a new `v8.15` branch since https://github.com/coq/coq/pull/14354 was merged on August 24.

cc: @MSoegtropIMC