### PR TITLE
[serlib] Large refactoring, ppx_hash/compare support, better yojson

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,9 +12,14 @@
             (@ejgallego)
  - [deps]   Require cmdliner >= 1.1.0 (@ejgallego)
  - [deps]   Support Jane Street libraries v0.15.0 (@ejgallego)
- - [serlib] Coq AST now support compare and hash (ignoring locations)
-            (@ejgallego)
  - [serapi] New query `Objects` to dump Coq's libobject (@ejgallego)
+ - [serlib] Much improved yojson / json support (@ejgallego)
+ - [serlib] Coq AST now supports ppx_hash intf (ignoring locations by default)
+            (@ejgallego)
+ - [serlib] Coq AST now supports ppx_compare intf (ignoring locations by default)
+            (@ejgallego)
+ - [serlib] Large refactoring on Serlib, using functors, see serlib/README.md
+            (@ejgallego)
 
 ## Version 0.15.1:
 

--- a/serlib/README.md
+++ b/serlib/README.md
@@ -1,0 +1,5 @@
+## Serlib README
+
+### Builtins
+
+### 

--- a/serlib/plugins/firstorder/dune
+++ b/serlib/plugins/firstorder/dune
@@ -2,5 +2,5 @@
  (name serlib_firstorder)
  (public_name coq-serapi.serlib.firstorder)
  (synopsis "Serialization Library for Coq Firstorder Plugin")
- (preprocess (staged_pps ppx_import ppx_sexp_conv))
+ (preprocess (staged_pps ppx_import ppx_sexp_conv ppx_hash ppx_compare))
  (libraries coq-core.plugins.firstorder serlib sexplib))

--- a/serlib/plugins/firstorder/ser_g_ground.ml
+++ b/serlib/plugins/firstorder/ser_g_ground.ml
@@ -1,5 +1,8 @@
-open Sexplib.Conv
 open Serlib
+
+open Sexplib.Conv
+open Ppx_compare_lib.Builtin
+open Ppx_hash_lib.Std.Hash.Builtin
 
 module Loc = Ser_loc
 module Names = Ser_names
@@ -8,27 +11,33 @@ module Locus = Ser_locus
 (* module Globnames = Ser_globnames *)
 
 type h1 = Libnames.qualid list
-[@@deriving sexp]
+  [@@deriving sexp, hash, compare]
 
 type h2 = Names.GlobRef.t Loc.located Locus.or_var list
-[@@deriving sexp]
+[@@deriving sexp, hash, compare]
 
 type h3 = Names.GlobRef.t list
-[@@deriving sexp]
+[@@deriving sexp,hash,compare]
 
 let ser_wit_firstorder_using :
   (Libnames.qualid list,
    Names.GlobRef.t Loc.located Locus.or_var list,
    Names.GlobRef.t list) Ser_genarg.gen_ser =
   Ser_genarg.{
-    raw_ser = sexp_of_h1;
-    raw_des = h1_of_sexp;
+    raw_ser = sexp_of_h1
+  ; raw_des = h1_of_sexp
+  ; raw_hash = hash_fold_h1
+  ; raw_compare = compare_h1
 
-    glb_ser = sexp_of_h2;
-    glb_des = h2_of_sexp;
+  ; glb_ser = sexp_of_h2
+  ; glb_des = h2_of_sexp
+  ; glb_hash = hash_fold_h2
+  ; glb_compare = compare_h2
 
-    top_ser = sexp_of_h3;
-    top_des = h3_of_sexp;
+  ; top_ser = sexp_of_h3
+  ; top_des = h3_of_sexp
+  ; top_hash = hash_fold_h3
+  ; top_compare = compare_h3
   }
 
 let register () =

--- a/serlib/plugins/funind/dune
+++ b/serlib/plugins/funind/dune
@@ -2,5 +2,5 @@
  (name serlib_funind)
  (public_name coq-serapi.serlib.funind)
  (synopsis "Serialization Library for Coq Fundind Plugin")
- (preprocess (staged_pps ppx_import ppx_sexp_conv))
+ (preprocess (staged_pps ppx_import ppx_sexp_conv ppx_hash ppx_compare))
  (libraries coq-core.plugins.funind serlib serlib_ltac sexplib))

--- a/serlib/plugins/funind/ser_g_indfun.ml
+++ b/serlib/plugins/funind/ser_g_indfun.ml
@@ -1,7 +1,13 @@
-open Sexplib.Conv
 open Serlib
 
+open Ppx_compare_lib.Builtin
+open Ppx_hash_lib.Std.Hash.Builtin
+open Sexplib.Conv
+
 module CAst       = Ser_cAst
+module Names      = Ser_names
+module Sorts      = Ser_sorts
+module Libnames   = Ser_libnames
 module Constrexpr = Ser_constrexpr
 module Tactypes   = Ser_tactypes
 module Genintern  = Ser_genintern
@@ -11,87 +17,76 @@ module Tacexpr    = Serlib_ltac.Ser_tacexpr
 module A1 = struct
 
 type h1 = Constrexpr.constr_expr Tactypes.intro_pattern_expr CAst.t option
-[@@deriving sexp]
+[@@deriving sexp,hash,compare]
 type h2 = Genintern.glob_constr_and_expr Tactypes.intro_pattern_expr CAst.t option
-[@@deriving sexp]
+[@@deriving sexp,hash,compare]
 type h3 = Tacexpr.intro_pattern option
-[@@deriving sexp]
+[@@deriving sexp,hash,compare]
 
 end
 
 let ser_wit_with_names =
   let open A1 in
   Ser_genarg.{
-    raw_ser = sexp_of_h1;
-    raw_des = h1_of_sexp;
+    raw_ser = sexp_of_h1
+  ; raw_des = h1_of_sexp
+  ; raw_hash = hash_fold_h1
+  ; raw_compare = compare_h1
 
-    glb_ser = sexp_of_h2;
-    glb_des = h2_of_sexp;
+  ; glb_ser = sexp_of_h2
+  ; glb_des = h2_of_sexp
+  ; glb_hash = hash_fold_h2
+  ; glb_compare = compare_h2
 
-    top_ser = sexp_of_h3;
-    top_des = h3_of_sexp;
+  ; top_ser = sexp_of_h3
+  ; top_des = h3_of_sexp
+  ; top_hash = hash_fold_h3
+  ; top_compare = compare_h3
   }
 
-module A2 = struct
-type h1 = Constrexpr.constr_expr Tactypes.with_bindings option
-[@@deriving sexp]
-type h2 = Genintern.glob_constr_and_expr Tactypes.with_bindings option
-[@@deriving sexp]
-type h3 = EConstr.t Tactypes.with_bindings Ser_tactypes.delayed_open option
-[@@deriving sexp]
+module WitFI = struct
+  type raw = Constrexpr.constr_expr Tactypes.with_bindings option
+  [@@deriving sexp,hash,compare]
+  type glb = Genintern.glob_constr_and_expr Tactypes.with_bindings option
+  [@@deriving sexp,hash,compare]
+  type top = EConstr.t Tactypes.with_bindings Ser_tactypes.delayed_open option
+  [@@deriving sexp,hash,compare]
 end
 
-let ser_wit_fun_ind_using :
-  (Constrexpr.constr_expr Tactypes.with_bindings option,
-   Genintern.glob_constr_and_expr Tactypes.with_bindings option,
-   EConstr.t Tactypes.with_bindings Tactypes.delayed_open option)
-    Ser_genarg.gen_ser =
-  let open A2 in
-  Ser_genarg.{
-    raw_ser = sexp_of_h1;
-    raw_des = h1_of_sexp;
+let ser_wit_fun_ind_using = let module M = Ser_genarg.GS(WitFI) in M.genser
 
-    glb_ser = sexp_of_h2;
-    glb_des = h2_of_sexp;
+module WitFS = struct
+  type raw = Names.variable * Libnames.qualid * Sorts.family
+  [@@deriving sexp,hash,compare]
+  type glb = unit
+  [@@deriving sexp,hash,compare]
+  type top = unit
+  [@@deriving sexp,hash,compare]
+end
 
-    top_ser = sexp_of_h3;
-    top_des = h3_of_sexp;
-  }
-
-let ser_wit_fun_scheme_arg :
-  (Names.variable * Libnames.qualid * Sorts.family, unit, unit)
-    Ser_genarg.gen_ser =
-  Ser_genarg.{
-    raw_ser = sexp_of_triple Ser_names.sexp_of_variable Ser_libnames.sexp_of_qualid Ser_sorts.sexp_of_family;
-    raw_des = triple_of_sexp Ser_names.variable_of_sexp Ser_libnames.qualid_of_sexp Ser_sorts.family_of_sexp;
-
-    glb_ser = sexp_of_unit;
-    glb_des = unit_of_sexp;
-
-    top_ser = sexp_of_unit;
-    top_des = unit_of_sexp;
-  }
+let ser_wit_fun_scheme_arg = let module M = Ser_genarg.GS(WitFS) in M.genser
 
 module Loc = Ser_loc
 module Vernacexpr = Ser_vernacexpr
 
-type function_fix_definition_loc_argtype = Vernacexpr.fixpoint_expr Loc.located
-  [@@deriving sexp]
+module WFFD = struct
+  type t = Vernacexpr.fixpoint_expr Loc.located
+  [@@deriving sexp,hash,compare]
+end
 
 let ser_wit_function_fix_definition =
-  Ser_genarg.mk_uniform sexp_of_function_fix_definition_loc_argtype function_fix_definition_loc_argtype_of_sexp
+  let module M = Ser_genarg.GS0(WFFD) in M.genser
 
-let ser_wit_auto_using' =
-  Ser_genarg.{
-    raw_ser = sexp_of_list Ser_constrexpr.sexp_of_constr_expr
-  ; raw_des = list_of_sexp Ser_constrexpr.constr_expr_of_sexp
+module WAU = struct
+  type raw = Constrexpr.constr_expr list
+  [@@deriving sexp,hash,compare]
+  type glb = Genintern.glob_constr_and_expr list
+  [@@deriving sexp,hash,compare]
+  type top = EConstr.constr list
+  [@@deriving sexp,hash,compare]
+end
 
-  ; glb_ser = sexp_of_list Ser_genintern.sexp_of_glob_constr_and_expr
-  ; glb_des = list_of_sexp Ser_genintern.glob_constr_and_expr_of_sexp
-
-  ; top_ser = sexp_of_list Ser_eConstr.sexp_of_constr
-  ; top_des = list_of_sexp Ser_eConstr.constr_of_sexp
-  }
+let ser_wit_auto_using' = let module M = Ser_genarg.GS(WAU) in M.genser
 
 let register () =
   Ser_genarg.register_genser Funind_plugin.G_indfun.wit_auto_using' ser_wit_auto_using';

--- a/serlib/plugins/ltac/dune
+++ b/serlib/plugins/ltac/dune
@@ -2,5 +2,5 @@
  (name serlib_ltac)
  (public_name coq-serapi.serlib.ltac)
  (synopsis "Serialization Library for Coq [LTAC plugin]")
- (preprocess (staged_pps ppx_import ppx_sexp_conv))
+ (preprocess (staged_pps ppx_import ppx_sexp_conv ppx_deriving_yojson ppx_hash ppx_compare))
  (libraries coq-core.plugins.ltac serlib sexplib))

--- a/serlib/plugins/ltac/ser_rewrite.ml
+++ b/serlib/plugins/ltac/ser_rewrite.ml
@@ -13,25 +13,30 @@
 (* Status: Very Experimental                                            *)
 (************************************************************************)
 
+open Ppx_hash_lib.Std.Hash.Builtin
+open Ppx_compare_lib.Builtin
 open Sexplib.Conv
 
 type unary_strategy =
   [%import: Rewrite.unary_strategy]
-  [@@deriving sexp]
+  [@@deriving sexp,hash,compare]
 
 type binary_strategy =
   [%import: Rewrite.binary_strategy]
-  [@@deriving sexp]
+  [@@deriving sexp,hash,compare]
 
 type nary_strategy =
   [%import: Rewrite.nary_strategy]
-  [@@deriving sexp]
+  [@@deriving sexp,hash,compare]
 
 type ('a,'b) strategy_ast =
   [%import: ('a,'b) Rewrite.strategy_ast]
-  [@@deriving sexp]
+  [@@deriving sexp,hash,compare]
 
 type strategy = Rewrite.strategy
 
 let strategy_of_sexp = Serlib.Serlib_base.opaque_of_sexp ~typ:"rewrite/strategy"
 let sexp_of_strategy = Serlib.Serlib_base.sexp_of_opaque ~typ:"rewrite/strategy"
+let hash_strategy = Hashtbl.hash
+let hash_fold_strategy st d = Ppx_hash_lib.Std.Hash.Builtin.hash_fold_int st (Hashtbl.hash d)
+let compare_strategy = Stdlib.compare

--- a/serlib/plugins/ltac/ser_rewrite.mli
+++ b/serlib/plugins/ltac/ser_rewrite.mli
@@ -13,21 +13,14 @@
 (* Status: Very Experimental                                            *)
 (************************************************************************)
 
-open Sexplib
-
 type unary_strategy = Rewrite.unary_strategy
-val unary_strategy_of_sexp : Sexp.t -> unary_strategy
-val sexp_of_unary_strategy : unary_strategy -> Sexp.t
+  [@@deriving sexp, hash, compare]
 
 type binary_strategy = Rewrite.binary_strategy
-val binary_strategy_of_sexp : Sexp.t -> binary_strategy
-val sexp_of_binary_strategy : binary_strategy -> Sexp.t
+  [@@deriving sexp, hash, compare]
 
 type ('a,'b) strategy_ast = ('a,'b) Rewrite.strategy_ast
-
-val strategy_ast_of_sexp : (Sexp.t -> 'a) -> (Sexp.t -> 'b) -> Sexp.t -> ('a,'b) strategy_ast
-val sexp_of_strategy_ast : ('a -> Sexp.t) -> ('b -> Sexp.t) -> ('a,'b) strategy_ast -> Sexp.t
+  [@@deriving sexp, hash, compare]
 
 type strategy = Rewrite.strategy
-val strategy_of_sexp : Sexp.t -> strategy
-val sexp_of_strategy : strategy -> Sexp.t
+  [@@deriving sexp, hash, compare]

--- a/serlib/plugins/ltac/ser_tacarg.ml
+++ b/serlib/plugins/ltac/ser_tacarg.ml
@@ -13,18 +13,30 @@
 (* Status: Very Experimental                                            *)
 (************************************************************************)
 
+open Sexplib.Std
+open Ppx_hash_lib.Std.Hash.Builtin
+open Ppx_compare_lib.Builtin
+
 open Serlib
+
 open Ltac_plugin
 
 module CAst         = Ser_cAst
+module Names        = Ser_names
 module Constrexpr   = Ser_constrexpr
 module Tactypes     = Ser_tactypes
+module Locus        = Ser_locus
+module Libnames     = Ser_libnames
 module Genintern    = Ser_genintern
+module Geninterp    = Ser_geninterp
+module EConstr      = Ser_eConstr
+module Hints        = Ser_hints
 
 module Ltac_plugin = struct
   module G_rewrite    = G_rewrite
   module Rewrite      = Ser_rewrite
   module Tacexpr      = Ser_tacexpr
+  module Tacentries   = Ser_tacentries
 end
 
 (* Needed for compat with -pack build method used in Coq's make *)
@@ -32,415 +44,382 @@ open Ltac_plugin
 
 (* Tacarg *)
 module A1 = struct
-  type h1 = Constrexpr.constr_expr Tactypes.intro_pattern_expr CAst.t
-  [@@deriving sexp]
-  type h2 = Genintern.glob_constr_and_expr Tactypes.intro_pattern_expr CAst.t
-  [@@deriving sexp]
-  type h3 = Ltac_plugin.Tacexpr.intro_pattern
-  [@@deriving sexp]
+  type raw = Constrexpr.constr_expr Tactypes.intro_pattern_expr CAst.t
+  [@@deriving sexp,hash,compare]
+  type glb = Genintern.glob_constr_and_expr Tactypes.intro_pattern_expr CAst.t
+  [@@deriving sexp,hash,compare]
+  type top = Ltac_plugin.Tacexpr.intro_pattern
+  [@@deriving sexp,hash,compare]
 end
 
-let ser_wit_simple_intropattern = let open A1 in Ser_genarg.
-  { raw_ser = sexp_of_h1
-  ; raw_des = h1_of_sexp
+let ser_wit_simple_intropattern =
+  let module M = Ser_genarg.GS(A1) in M.genser
 
-  ; glb_ser = sexp_of_h2
-  ; glb_des = h2_of_sexp
+module A2 = struct
+  type raw = Constrexpr.constr_pattern_expr Tactypes.with_bindings Ser_tactics.destruction_arg
+  [@@deriving sexp,hash,compare]
+  type glb = Genintern.glob_constr_and_expr Tactypes.with_bindings Ser_tactics.destruction_arg
+  [@@deriving sexp,hash,compare]
+  type top = Tactypes.delayed_open_constr_with_bindings Ser_tactics.destruction_arg
+  [@@deriving sexp,hash,compare]
+end
 
-  ; top_ser = sexp_of_h3
-  ; top_des = h3_of_sexp
-  }
+let ser_wit_destruction_arg =
+  let module M = Ser_genarg.GS(A2) in M.genser
 
-let ser_wit_destruction_arg = Ser_genarg.{
-    raw_ser = Ser_tactics.sexp_of_destruction_arg (Ser_tactypes.sexp_of_with_bindings Ser_constrexpr.sexp_of_constr_expr);
-    glb_ser = Ser_tactics.sexp_of_destruction_arg (Ser_tactypes.sexp_of_with_bindings Ser_genintern.sexp_of_glob_constr_and_expr);
-    top_ser = Ser_tactics.(sexp_of_destruction_arg Ser_tactypes.sexp_of_delayed_open_constr_with_bindings);
+module A3 = struct
+  type raw = Tacexpr.raw_tactic_expr
+  [@@deriving sexp,hash,compare]
+  type glb = Tacexpr.glob_tactic_expr
+  [@@deriving sexp,hash,compare]
+  type top = Ser_geninterp.Val.t
+  [@@deriving sexp,hash,compare]
+end
 
-    raw_des = Ser_tactics.destruction_arg_of_sexp (Ser_tactypes.with_bindings_of_sexp Ser_constrexpr.constr_expr_of_sexp);
-    glb_des = Ser_tactics.destruction_arg_of_sexp (Ser_tactypes.with_bindings_of_sexp Ser_genintern.glob_constr_and_expr_of_sexp);
-    top_des = Ser_tactics.(destruction_arg_of_sexp Ser_tactypes.delayed_open_constr_with_bindings_of_sexp);
-  }
+let ser_wit_tactic = let module M = Ser_genarg.GS(A3) in M.genser
 
-let ser_wit_tactic = Ser_genarg.{
-    raw_ser = Ser_tacexpr.sexp_of_raw_tactic_expr;
-    glb_ser = Ser_tacexpr.sexp_of_glob_tactic_expr;
-    top_ser = Ser_geninterp.Val.sexp_of_t;
+module A4 = struct
+  type raw = Tacexpr.raw_tactic_expr
+  [@@deriving sexp,hash,compare]
+  type glb = Tacexpr.glob_tactic_expr
+  [@@deriving sexp,hash,compare]
+  type top = unit
+  [@@deriving sexp,hash,compare]
+end
 
-    raw_des = Ser_tacexpr.raw_tactic_expr_of_sexp;
-    glb_des = Ser_tacexpr.glob_tactic_expr_of_sexp;
-    top_des = Ser_geninterp.Val.t_of_sexp;
-  }
+let ser_wit_ltac = let module M = Ser_genarg.GS(A4) in M.genser
 
-let ser_wit_ltac = Ser_genarg.{
-    raw_ser = Ser_tacexpr.sexp_of_raw_tactic_expr;
-    glb_ser = Ser_tacexpr.sexp_of_glob_tactic_expr;
-    top_ser = Sexplib.Conv.sexp_of_unit;
+module A5 = struct
+  type t = Ser_tactypes.quantified_hypothesis [@@deriving sexp,hash,compare]
+end
 
-    raw_des = Ser_tacexpr.raw_tactic_expr_of_sexp;
-    glb_des = Ser_tacexpr.glob_tactic_expr_of_sexp;
-    top_des = Sexplib.Conv.unit_of_sexp;
-  }
+let ser_wit_quant_hyp = let module M = Ser_genarg.GS0(A5) in M.genser
 
-let ser_wit_quant_hyp =
-  Ser_genarg.mk_uniform
-    Ser_tactypes.sexp_of_quantified_hypothesis
-    Ser_tactypes.quantified_hypothesis_of_sexp
+module A6 = struct
+  type raw = Constrexpr.constr_expr Tactypes.bindings
+  [@@deriving sexp,hash,compare]
+  type glb = Genintern.glob_constr_and_expr Tactypes.bindings
+  [@@deriving sexp,hash,compare]
+  type top = EConstr.constr Tactypes.bindings Tactypes.delayed_open
+  [@@deriving sexp,hash,compare]
+end
 
-let ser_wit_bindings :
-  (Constrexpr.constr_expr Tactypes.bindings,
-   Genintern.glob_constr_and_expr Tactypes.bindings,
-   EConstr.constr Tactypes.bindings Tactypes.delayed_open)
-    Ser_genarg.gen_ser
- = Ser_genarg.{
-    raw_ser = Ser_tactypes.sexp_of_bindings Ser_constrexpr.sexp_of_constr_expr;
-    glb_ser = Ser_tactypes.sexp_of_bindings Ser_genintern.sexp_of_glob_constr_and_expr;
-    top_ser = Serlib_base.sexp_of_opaque ~typ:"wit_bindings/top";
+let ser_wit_bindings = let module M = Ser_genarg.GS(A6) in M.genser
 
-    raw_des = Ser_tactypes.bindings_of_sexp Ser_constrexpr.constr_expr_of_sexp;
-    glb_des = Ser_tactypes.bindings_of_sexp Ser_genintern.glob_constr_and_expr_of_sexp;
-    top_des = Serlib_base.opaque_of_sexp ~typ:"wit_bindings/top";
-  }
+module A7 = struct
+  type raw = Constrexpr.constr_expr Tactypes.with_bindings
+  [@@deriving sexp,hash,compare]
+  type glb = Genintern.glob_constr_and_expr Tactypes.with_bindings
+  [@@deriving sexp,hash,compare]
+  type top = EConstr.constr Tactypes.with_bindings Tactypes.delayed_open
+  [@@deriving sexp,hash,compare]
+end
 
-let ser_wit_constr_with_bindings :
-  (Constrexpr.constr_expr Tactypes.with_bindings,
-   Genintern.glob_constr_and_expr Tactypes.with_bindings,
-   EConstr.constr Tactypes.with_bindings Tactypes.delayed_open)
-    Ser_genarg.gen_ser
- = Ser_genarg.{
-    raw_ser = Ser_tactypes.sexp_of_with_bindings Ser_constrexpr.sexp_of_constr_expr;
-    glb_ser = Ser_tactypes.sexp_of_with_bindings Ser_genintern.sexp_of_glob_constr_and_expr;
-    top_ser = Serlib_base.sexp_of_opaque ~typ:"wit_constr_with_bindings/top";
-
-    raw_des = Ser_tactypes.with_bindings_of_sexp Ser_constrexpr.constr_expr_of_sexp;
-    glb_des = Ser_tactypes.with_bindings_of_sexp Ser_genintern.glob_constr_and_expr_of_sexp;
-    top_des = Serlib_base.opaque_of_sexp ~typ:"wit_constr_with_bindings/top";
-  }
+let ser_wit_constr_with_bindings = let module M = Ser_genarg.GS(A7) in M.genser
 
 (* G_ltac *)
 (* Defined in g_ltac but serialized here *)
 
-let ser_wit_ltac_info =
-  let open Sexplib.Conv in
-  Ser_genarg.{
-    raw_ser = sexp_of_int;
-    glb_ser = sexp_of_unit;
-    top_ser = sexp_of_unit;
+module A8 = struct
+  type raw = int
+  [@@deriving sexp,hash,compare]
+  type glb = unit
+  [@@deriving sexp,hash,compare]
+  type top = unit
+  [@@deriving sexp,hash,compare]
+end
 
-    raw_des = int_of_sexp;
-    glb_des = unit_of_sexp;
-    top_des = unit_of_sexp;
-  }
+let ser_wit_ltac_info = let module M = Ser_genarg.GS(A8) in M.genser
 
-let ser_wit_production_item =
-  let open Sexplib.Conv in
-  Ser_genarg.{
-    raw_ser = Ser_tacentries.(sexp_of_grammar_tactic_prod_item_expr sexp_of_raw_argument);
-    glb_ser = sexp_of_unit;
-    top_ser = sexp_of_unit;
+module A9 = struct
+  type raw = Ltac_plugin.Tacentries.raw_argument Ser_tacentries.grammar_tactic_prod_item_expr
+  [@@deriving sexp,hash,compare]
+  type glb = unit
+  [@@deriving sexp,hash,compare]
+  type top = unit
+  [@@deriving sexp,hash,compare]
+end
 
-    raw_des = Ser_tacentries.(grammar_tactic_prod_item_expr_of_sexp raw_argument_of_sexp);
-    glb_des = unit_of_sexp;
-    top_des = unit_of_sexp;
-  }
+let ser_wit_production_item = let module M = Ser_genarg.GS(A9) in M.genser
 
-let ser_wit_ltac_production_sep =
-  let open Sexplib.Conv in
-  Ser_genarg.{
-    raw_ser = sexp_of_string;
-    glb_ser = sexp_of_unit;
-    top_ser = sexp_of_unit;
+module A10 = struct
+  type raw = string
+  [@@deriving sexp,hash,compare]
+  type glb = unit
+  [@@deriving sexp,hash,compare]
+  type top = unit
+  [@@deriving sexp,hash,compare]
+end
+let ser_wit_ltac_production_sep = let module M = Ser_genarg.GS(A10) in M.genser
 
-    raw_des = string_of_sexp;
-    glb_des = unit_of_sexp;
-    top_des = unit_of_sexp;
-  }
+module A11 = struct
+  type raw = Ser_goal_select.t
+  [@@deriving sexp,hash,compare]
+  type glb = unit
+  [@@deriving sexp,hash,compare]
+  type top = unit
+  [@@deriving sexp,hash,compare]
+end
+let ser_wit_ltac_selector = let module M = Ser_genarg.GS(A11) in M.genser
 
-let ser_wit_ltac_selector = Ser_genarg.{
-    raw_ser = Ser_goal_select.sexp_of_t;
-    glb_ser = Sexplib.Conv.sexp_of_unit;
-    top_ser = Sexplib.Conv.sexp_of_unit;
+module A12 = struct
+  type raw = Ser_tacexpr.tacdef_body
+  [@@deriving sexp,hash,compare]
+  type glb = unit
+  [@@deriving sexp,hash,compare]
+  type top = unit
+  [@@deriving sexp,hash,compare]
+end
+let ser_wit_ltac_tacdef_body = let module M = Ser_genarg.GS(A12) in M.genser
 
-    raw_des = Ser_goal_select.t_of_sexp;
-    glb_des = Sexplib.Conv.unit_of_sexp;
-    top_des = Sexplib.Conv.unit_of_sexp;
-  }
+module A13 = struct
+  type raw = int  [@@deriving sexp,hash,compare]
+  type glb = unit [@@deriving sexp,hash,compare]
+  type top = unit [@@deriving sexp,hash,compare]
+end
+let ser_wit_ltac_tactic_level = let module M = Ser_genarg.GS(A13) in M.genser
 
-let ser_wit_ltac_tacdef_body = Ser_genarg.{
-    raw_ser = Ser_tacexpr.sexp_of_tacdef_body;
-    glb_ser = Sexplib.Conv.sexp_of_unit;
-    top_ser = Sexplib.Conv.sexp_of_unit;
-
-    raw_des = Ser_tacexpr.tacdef_body_of_sexp;
-    glb_des = Sexplib.Conv.unit_of_sexp;
-    top_des = Sexplib.Conv.unit_of_sexp;
-  }
-
-let ser_wit_ltac_tactic_level = Ser_genarg.{
-    raw_ser = Sexplib.Conv.sexp_of_int;
-    glb_ser = Sexplib.Conv.sexp_of_unit;
-    top_ser = Sexplib.Conv.sexp_of_unit;
-
-    raw_des = Sexplib.Conv.int_of_sexp;
-    glb_des = Sexplib.Conv.unit_of_sexp;
-    top_des = Sexplib.Conv.unit_of_sexp;
-  }
-
-let ser_wit_ltac_use_default = Ser_genarg.{
-    raw_ser = Sexplib.Conv.sexp_of_bool;
-    glb_ser = Sexplib.Conv.sexp_of_unit;
-    top_ser = Sexplib.Conv.sexp_of_unit;
-
-    raw_des = Sexplib.Conv.bool_of_sexp;
-    glb_des = Sexplib.Conv.unit_of_sexp;
-    top_des = Sexplib.Conv.unit_of_sexp
-  }
+module A14 = struct
+  type raw = bool
+  [@@deriving sexp,hash,compare]
+  type glb = unit
+  [@@deriving sexp,hash,compare]
+  type top = unit
+  [@@deriving sexp,hash,compare]
+end
+let ser_wit_ltac_use_default = let module M = Ser_genarg.GS(A14) in M.genser
 
 (* From G_auto *)
-let ser_wit_auto_using = Ser_genarg.{
-    raw_ser = Sexplib.Conv.sexp_of_list Ser_constrexpr.sexp_of_constr_expr;
-    glb_ser = Sexplib.Conv.sexp_of_list Ser_genintern.sexp_of_glob_constr_and_expr;
-    top_ser = Sexplib.Conv.sexp_of_list Ser_ltac_pretype.sexp_of_closed_glob_constr;
+module A15 = struct
+  type raw = Ser_constrexpr.constr_expr list
+  [@@deriving sexp,hash,compare]
+  type glb = Ser_genintern.glob_constr_and_expr list
+  [@@deriving sexp,hash,compare]
+  type top = Ser_ltac_pretype.closed_glob_constr list
+  [@@deriving sexp,hash,compare]
+end
+let ser_wit_auto_using = let module M = Ser_genarg.GS(A15) in M.genser
 
-    raw_des = Sexplib.Conv.list_of_sexp Ser_constrexpr.constr_expr_of_sexp;
-    glb_des = Sexplib.Conv.list_of_sexp Ser_genintern.glob_constr_and_expr_of_sexp;
-    top_des = Sexplib.Conv.list_of_sexp Ser_ltac_pretype.closed_glob_constr_of_sexp;
-  }
+module A16 = struct
+  type raw = string list option
+  [@@deriving sexp,hash,compare]
+  type glb = string list option
+  [@@deriving sexp,hash,compare]
+  type top = string list option
+  [@@deriving sexp,hash,compare]
+end
+let ser_wit_hintbases = let module M = Ser_genarg.GS(A16) in M.genser
 
-let ser_wit_hintbases =
-  let open Sexplib.Conv in
-  Ser_genarg.{
-    raw_ser = sexp_of_option (sexp_of_list sexp_of_string);
-    glb_ser = sexp_of_option (sexp_of_list sexp_of_string);
-    top_ser = sexp_of_option (sexp_of_list Ser_hints.sexp_of_hint_db_name);
+module A17 = struct
+  type raw = Ser_libnames.qualid Ser_hints.hints_path_gen
+  [@@deriving sexp,hash,compare]
+  type glb = Ser_hints.hints_path
+  [@@deriving sexp,hash,compare]
+  type top = Ser_hints.hints_path
+  [@@deriving sexp,hash,compare]
+end
+let ser_wit_hintbases_path = let module M = Ser_genarg.GS(A17) in M.genser
 
-    raw_des = option_of_sexp (list_of_sexp string_of_sexp);
-    glb_des = option_of_sexp (list_of_sexp string_of_sexp);
-    top_des = option_of_sexp (list_of_sexp Ser_hints.hint_db_name_of_sexp);
-  }
+module A18 = struct
+  type raw = Libnames.qualid Hints.hints_path_atom_gen
+  [@@deriving sexp,hash,compare]
+  type glb = Names.GlobRef.t Hints.hints_path_atom_gen
+  [@@deriving sexp,hash,compare]
+  type top = Names.GlobRef.t Hints.hints_path_atom_gen
+  [@@deriving sexp,hash,compare]
+end
 
-let ser_wit_hintbases_path =
-  Ser_genarg.{
-    raw_ser = Ser_hints.(sexp_of_hints_path_gen Ser_libnames.sexp_of_qualid);
-    glb_ser = Ser_hints.sexp_of_hints_path;
-    top_ser = Ser_hints.sexp_of_hints_path;
+let ser_wit_hintbases_path_atom = let module M = Ser_genarg.GS(A18) in M.genser
 
-    raw_des = Ser_hints.(hints_path_gen_of_sexp Ser_libnames.qualid_of_sexp);
-    glb_des = Ser_hints.hints_path_of_sexp;
-    top_des = Ser_hints.hints_path_of_sexp;
-  }
+module A19 = struct
+  type raw = string list option
+  [@@deriving sexp,hash,compare]
+  type glb = string list option
+  [@@deriving sexp,hash,compare]
+  type top = string list option
+  [@@deriving sexp,hash,compare]
+end
 
-let ser_wit_hintbases_path_atom =
-  Ser_genarg.{
-    raw_ser = Ser_hints.(sexp_of_hints_path_atom_gen Ser_libnames.sexp_of_qualid);
-    glb_ser = Ser_hints.(sexp_of_hints_path_atom_gen Ser_names.GlobRef.sexp_of_t);
-    top_ser = Ser_hints.(sexp_of_hints_path_atom_gen Ser_names.GlobRef.sexp_of_t);
-
-    raw_des = Ser_hints.(hints_path_atom_gen_of_sexp Ser_libnames.qualid_of_sexp);
-    glb_des = Ser_hints.(hints_path_atom_gen_of_sexp Ser_names.GlobRef.t_of_sexp);
-    top_des = Ser_hints.(hints_path_atom_gen_of_sexp Ser_names.GlobRef.t_of_sexp);
-  }
-
-let ser_wit_opthints =
-  let open Sexplib.Conv in
-  Ser_genarg.{
-    raw_ser = sexp_of_option (sexp_of_list sexp_of_string);
-    glb_ser = sexp_of_option (sexp_of_list sexp_of_string);
-    top_ser = sexp_of_option (sexp_of_list Ser_hints.sexp_of_hint_db_name);
-
-    raw_des = option_of_sexp (list_of_sexp string_of_sexp);
-    glb_des = option_of_sexp (list_of_sexp string_of_sexp);
-    top_des = option_of_sexp (list_of_sexp Ser_hints.hint_db_name_of_sexp);
-  }
+let ser_wit_opthints = let module M = Ser_genarg.GS(A19) in M.genser
 
 (* G_rewrite *)
 
 module G_rewrite = struct
 
-open Sexplib.Conv
-
 let wit_binders = Ltac_plugin.G_rewrite.wit_binders
 
-type binders_argtype =
-  [%import: Ltac_plugin.G_rewrite.binders_argtype]
-  [@@deriving sexp]
+module GT0 = struct
+  type t =
+    [%import: Ltac_plugin.G_rewrite.binders_argtype]
+  [@@deriving sexp,hash,compare]
+end
 
-let ser_wit_binders = Ser_genarg.mk_uniform sexp_of_binders_argtype binders_argtype_of_sexp
+let ser_wit_binders = let module M = Ser_genarg.GS0(GT0) in M.genser
 
 let wit_glob_constr_with_bindings = Ltac_plugin.G_rewrite.wit_glob_constr_with_bindings
 
-let ser_wit_glob_constr_with_bindings =
-  let open Sexplib.Conv in
+module GT1 = struct
+  type raw = Constrexpr.constr_expr Tactypes.with_bindings
+  [@@deriving sexp,hash,compare]
+  type glb = Genintern.glob_constr_and_expr Tactypes.with_bindings
+  [@@deriving sexp,hash,compare]
+  type top = Geninterp.interp_sign * Genintern.glob_constr_and_expr Tactypes.with_bindings
+  [@@deriving sexp,hash,compare]
+end
 
-  let _sexp_of_interp_sign = Serlib_base.sexp_of_opaque ~typ:"interp_sign" in
-  let _interp_sign_of_sexp = Serlib_base.opaque_of_sexp ~typ:"interp_sign" in
-
-  Ser_genarg.{
-    raw_ser = Ser_tactypes.sexp_of_with_bindings Ser_constrexpr.sexp_of_constr_expr;
-    glb_ser = Ser_tactypes.sexp_of_with_bindings Ser_genintern.sexp_of_glob_constr_and_expr;
-    top_ser = sexp_of_pair _sexp_of_interp_sign Ser_tactypes.(sexp_of_with_bindings Ser_genintern.sexp_of_glob_constr_and_expr);
-
-    raw_des = Ser_tactypes.with_bindings_of_sexp Ser_constrexpr.constr_expr_of_sexp;
-    glb_des = Ser_tactypes.with_bindings_of_sexp Ser_genintern.glob_constr_and_expr_of_sexp;
-    top_des = pair_of_sexp _interp_sign_of_sexp Ser_tactypes.(with_bindings_of_sexp Ser_genintern.glob_constr_and_expr_of_sexp)
-  }
+let ser_wit_glob_constr_with_bindings = let module M = Ser_genarg.GS(GT1) in M.genser
 
 let wit_rewstrategy = Ltac_plugin.G_rewrite.wit_rewstrategy
 
-type raw_strategy =
-  [%import: Ltac_plugin.G_rewrite.raw_strategy]
-  [@@deriving sexp]
+module GT2 = struct
+  type raw =
+    [%import: Ltac_plugin.G_rewrite.raw_strategy]
+  [@@deriving sexp,hash,compare]
+  type glb =
+    [%import: Ltac_plugin.G_rewrite.glob_strategy]
+  [@@deriving sexp,hash,compare]
+  type top = Ltac_plugin.Rewrite.strategy
+  [@@deriving sexp,hash,compare]
+end
 
-type glob_strategy =
-  [%import: Ltac_plugin.G_rewrite.glob_strategy]
-  [@@deriving sexp]
 
 (* (G_rewrite.raw_strategy, G_rewrite.glob_strategy, Rewrite.strategy) *)
 
-let ser_wit_rewstrategy =
-  Ser_genarg.
-    { raw_ser = sexp_of_raw_strategy
-    ; glb_ser = sexp_of_glob_strategy
-    ; top_ser = Ltac_plugin.Rewrite.sexp_of_strategy
-
-    ; raw_des = raw_strategy_of_sexp
-    ; glb_des = glob_strategy_of_sexp
-    ; top_des = Ltac_plugin.Rewrite.strategy_of_sexp
-    }
+let ser_wit_rewstrategy = let module M = Ser_genarg.GS(GT2) in M.genser
 
 end
 
 let ser_wit_debug =
   let open Sexplib.Conv in
-  Ser_genarg.mk_uniform sexp_of_bool bool_of_sexp
+  Ser_genarg.mk_uniform sexp_of_bool bool_of_sexp hash_fold_bool compare_bool
 
-let ser_wit_eauto_search_strategy =
-  let open Sexplib.Conv in
-  Ser_genarg.mk_uniform
-    (sexp_of_option Ser_class_tactics.sexp_of_search_strategy)
-    (option_of_sexp Ser_class_tactics.search_strategy_of_sexp)
+module SWESS = struct
+  type t = Ser_class_tactics.search_strategy option
+  [@@deriving sexp,hash,compare]
+end
+let ser_wit_eauto_search_strategy = let module M = Ser_genarg.GS0(SWESS) in M.genser
 
-let ser_wit_withtac =
-  let open Sexplib.Conv in
-  Ser_genarg.mk_uniform
-    (sexp_of_option Ser_tacexpr.sexp_of_raw_tactic_expr)
-    (option_of_sexp Ser_tacexpr.raw_tactic_expr_of_sexp)
+module SWWT = struct
+  type t = Ser_tacexpr.raw_tactic_expr option
+  [@@deriving sexp,hash,compare]
+end
+let ser_wit_withtac = let module M = Ser_genarg.GS0(SWWT) in M.genser
 
 (* extraargs *)
 
-open Sexplib.Conv
-
-module Names = Ser_names
-module Locus = Ser_locus
-
 type 'a gen_place =
   [%import: 'a Ltac_plugin.Extraargs.gen_place]
-  [@@deriving sexp]
+  [@@deriving sexp,hash,compare]
 
 type loc_place =
   [%import: Ltac_plugin.Extraargs.loc_place]
-  [@@deriving sexp]
+  [@@deriving sexp,hash,compare]
 
 type place =
   [%import: Ltac_plugin.Extraargs.place]
-  [@@deriving sexp]
+  [@@deriving sexp,hash,compare]
 
-let ser_wit_hloc =
-  Ser_genarg.{
-    raw_ser = sexp_of_loc_place
-  ; glb_ser = sexp_of_loc_place
-  ; top_ser = sexp_of_place
+module GT3 = struct
+  type raw = loc_place
+  [@@deriving sexp,hash,compare]
+  type glb = loc_place
+  [@@deriving sexp,hash,compare]
+  type top = place
+  [@@deriving sexp,hash,compare]
+end
 
-  ; raw_des = loc_place_of_sexp
-  ; glb_des = loc_place_of_sexp
-  ; top_des = place_of_sexp
-  }
+let ser_wit_hloc = let module M = Ser_genarg.GS(GT3) in M.genser
 
-let ser_wit_lglob =
-  Ser_genarg.{
-    raw_ser = Ser_constrexpr.sexp_of_constr_expr
-  ; glb_ser = Ser_genintern.sexp_of_glob_constr_and_expr
-  ; top_ser = sexp_of_pair Ser_geninterp.sexp_of_interp_sign Ser_glob_term.sexp_of_glob_constr
+module GT4 = struct
+  type raw = Constrexpr.constr_expr
+  [@@deriving sexp,hash,compare]
+  type glb = Genintern.glob_constr_and_expr
+  [@@deriving sexp,hash,compare]
+  type top = Geninterp.interp_sign * Ser_glob_term.glob_constr
+  [@@deriving sexp,hash,compare]
+end
 
-  ; raw_des = Ser_constrexpr.constr_expr_of_sexp
-  ; glb_des = Ser_genintern.glob_constr_and_expr_of_sexp
-  ; top_des = pair_of_sexp Ser_geninterp.interp_sign_of_sexp Ser_glob_term.glob_constr_of_sexp
-  }
+let ser_wit_lglob = let module M = Ser_genarg.GS(GT4) in M.genser
 
 let ser_wit_orient =
   let open Sexplib.Conv in
-  Ser_genarg.mk_uniform sexp_of_bool bool_of_sexp
+  Ser_genarg.mk_uniform sexp_of_bool bool_of_sexp hash_fold_bool compare_bool
+
+module WRen = struct
+  type t = Names.Id.t * Names.Id.t
+  [@@deriving sexp,hash,compare]
+end
 
 let ser_wit_rename =
-  let open Sexplib.Conv in
-  Ser_genarg.mk_uniform
-    (sexp_of_pair Ser_names.Id.sexp_of_t Ser_names.Id.sexp_of_t)
-    (pair_of_sexp Ser_names.Id.t_of_sexp Ser_names.Id.t_of_sexp)
+  let module M = Ser_genarg.GS0(WRen) in M.genser
 
 let ser_wit_natural =
   let open Sexplib.Conv in
-  Ser_genarg.mk_uniform sexp_of_int int_of_sexp
+  Ser_genarg.mk_uniform sexp_of_int int_of_sexp hash_fold_int compare_int
+
+module GT5 = struct
+  type raw = Constrexpr.constr_expr
+  [@@deriving sexp,hash,compare]
+  type glb = Genintern.glob_constr_and_expr
+  [@@deriving sexp,hash,compare]
+  type top = EConstr.t
+  [@@deriving sexp,hash,compare]
+end
 
 let ser_wit_lconstr : (Constrexpr.constr_expr, Ser_genintern.glob_constr_and_expr, EConstr.t) Ser_genarg.gen_ser =
-  Ser_genarg.{
-    raw_ser = Ser_constrexpr.sexp_of_constr_expr;
-    glb_ser = Ser_genintern.sexp_of_glob_constr_and_expr;
-    top_ser = Ser_eConstr.sexp_of_t;
+  let module M = Ser_genarg.GS(GT5) in M.genser
 
-    raw_des = Ser_constrexpr.constr_expr_of_sexp;
-    glb_des = Ser_genintern.glob_constr_and_expr_of_sexp;
-    top_des = Ser_eConstr.t_of_sexp;
-  }
+(* let _ser_wit_casted_constr : (Constrexpr.constr_expr, Ser_genintern.glob_constr_and_expr, EConstr.t) Ser_genarg.gen_ser =
+ *   Ser_genarg.{
+ *     raw_ser = Ser_constrexpr.sexp_of_constr_expr
+ *   ; glb_ser = Ser_genintern.sexp_of_glob_constr_and_expr
+ *   ; top_ser = Ser_eConstr.sexp_of_t
+ * 
+ *   ; raw_des = Ser_constrexpr.constr_expr_of_sexp
+ *   ; glb_des = Ser_genintern.glob_constr_and_expr_of_sexp
+ *   ; top_des = Ser_eConstr.t_of_sexp
+ *   } *)
 
-let _ser_wit_casted_constr : (Constrexpr.constr_expr, Ser_genintern.glob_constr_and_expr, EConstr.t) Ser_genarg.gen_ser =
-  Ser_genarg.{
-    raw_ser = Ser_constrexpr.sexp_of_constr_expr;
-    glb_ser = Ser_genintern.sexp_of_glob_constr_and_expr;
-    top_ser = Ser_eConstr.sexp_of_t;
-
-    raw_des = Ser_constrexpr.constr_expr_of_sexp;
-    glb_des = Ser_genintern.glob_constr_and_expr_of_sexp;
-    top_des = Ser_eConstr.t_of_sexp;
-  }
+module GT6 = struct
+  type raw = Names.lident Locus.clause_expr
+  [@@deriving sexp,hash,compare]
+  type glb = Names.lident Locus.clause_expr
+  [@@deriving sexp,hash,compare]
+  type top = Names.Id.t Locus.clause_expr
+  [@@deriving sexp,hash,compare]
+end
 
 let ser_wit_in_clause :
   (Names.lident Locus.clause_expr, Names.lident Locus.clause_expr, Names.Id.t Locus.clause_expr) Ser_genarg.gen_ser =
-  Ser_genarg.{
-    raw_ser = Ser_locus.sexp_of_clause_expr Ser_names.sexp_of_lident;
-    glb_ser = Ser_locus.sexp_of_clause_expr Ser_names.sexp_of_lident;
-    top_ser = Ser_locus.sexp_of_clause_expr Ser_names.Id.sexp_of_t;
+  let module M = Ser_genarg.GS(GT6) in M.genser
 
-    raw_des = Ser_locus.clause_expr_of_sexp Ser_names.lident_of_sexp;
-    glb_des = Ser_locus.clause_expr_of_sexp Ser_names.lident_of_sexp;
-    top_des = Ser_locus.clause_expr_of_sexp Ser_names.Id.t_of_sexp;
-  }
+module GT7 = struct
+  type raw = Tacexpr.raw_tactic_expr option
+  [@@deriving sexp,hash,compare]
+  type glb = Tacexpr.glob_tactic_expr option
+  [@@deriving sexp,hash,compare]
+  type top = Geninterp.Val.t option
+  [@@deriving sexp,hash,compare]
+end
 
 let ser_wit_by_arg_tac :
   (Tacexpr.raw_tactic_expr option, Tacexpr.glob_tactic_expr option, Tacinterp.value option) Ser_genarg.gen_ser =
-  Ser_genarg.{
-    raw_ser = Sexplib.Conv.sexp_of_option Ser_tacexpr.sexp_of_raw_tactic_expr;
-    glb_ser = Sexplib.Conv.sexp_of_option Ser_tacexpr.sexp_of_glob_tactic_expr;
-    top_ser = Sexplib.Conv.sexp_of_option Ser_geninterp.Val.sexp_of_t;
-
-    raw_des = Sexplib.Conv.option_of_sexp Ser_tacexpr.raw_tactic_expr_of_sexp;
-    glb_des = Sexplib.Conv.option_of_sexp Ser_tacexpr.glob_tactic_expr_of_sexp;
-    top_des = Sexplib.Conv.option_of_sexp Ser_geninterp.Val.t_of_sexp;
-  }
+  let module M = Ser_genarg.GS(GT7) in M.genser
 
 let ser_wit_lpar_id_colon =
   let open Sexplib.Conv in
-  Ser_genarg.mk_uniform sexp_of_unit unit_of_sexp
+  Ser_genarg.mk_uniform sexp_of_unit unit_of_sexp hash_fold_unit compare_unit
 
-let ser_wit_occurences =
-  let open Sexplib.Conv in
-  Ser_genarg.{
-    raw_ser = Ser_locus.sexp_of_or_var (sexp_of_list sexp_of_int);
-    glb_ser = Ser_locus.sexp_of_or_var (sexp_of_list sexp_of_int);
-    top_ser = sexp_of_list sexp_of_int;
+module GT8 = struct
+  type raw = int list Locus.or_var
+  [@@deriving sexp,hash,compare]
+  type glb = int list Locus.or_var
+  [@@deriving sexp,hash,compare]
+  type top = int list
+  [@@deriving sexp,hash,compare]
+end
 
-    raw_des = Ser_locus.or_var_of_sexp (list_of_sexp int_of_sexp);
-    glb_des = Ser_locus.or_var_of_sexp (list_of_sexp int_of_sexp);
-    top_des = list_of_sexp int_of_sexp;
-  }
+let ser_wit_occurences = let module M = Ser_genarg.GS(GT8) in M.genser
 
 let register () =
 

--- a/serlib/plugins/ltac/ser_tacentries.ml
+++ b/serlib/plugins/ltac/ser_tacentries.ml
@@ -13,7 +13,10 @@
 (* Status: Very Experimental                                            *)
 (************************************************************************)
 
-open Sexplib.Conv
+open Sexplib.Std
+open Ppx_hash_lib.Std.Hash.Builtin
+open Ppx_compare_lib.Builtin
+
 open Serlib
 
 module Loc   = Ser_loc
@@ -23,8 +26,8 @@ open Ltac_plugin [@@ocaml.warning "-33"]
 
 type 'a grammar_tactic_prod_item_expr =
   [%import: 'a Ltac_plugin.Tacentries.grammar_tactic_prod_item_expr]
-  [@@deriving sexp]
+  [@@deriving sexp,hash,compare]
 
 type raw_argument =
   [%import: Ltac_plugin.Tacentries.raw_argument]
-  [@@deriving sexp]
+  [@@deriving sexp,hash,compare]

--- a/serlib/plugins/ltac/ser_tacentries.mli
+++ b/serlib/plugins/ltac/ser_tacentries.mli
@@ -13,13 +13,10 @@
 (* Status: Very Experimental                                            *)
 (************************************************************************)
 
-open Sexplib
 open Ltac_plugin
 
 type 'a grammar_tactic_prod_item_expr = 'a Tacentries.grammar_tactic_prod_item_expr
-val grammar_tactic_prod_item_expr_of_sexp : (Sexp.t -> 'a) -> Sexp.t -> 'a grammar_tactic_prod_item_expr
-val sexp_of_grammar_tactic_prod_item_expr : ('a -> Sexp.t) -> 'a grammar_tactic_prod_item_expr -> Sexp.t
+[@@deriving sexp,hash,compare]
 
 type raw_argument = Tacentries.raw_argument
-val raw_argument_of_sexp : Sexp.t -> raw_argument
-val sexp_of_raw_argument : raw_argument -> Sexp.t
+[@@deriving sexp,hash,compare]

--- a/serlib/plugins/ltac/ser_tacexpr.ml
+++ b/serlib/plugins/ltac/ser_tacexpr.ml
@@ -17,6 +17,11 @@
 
 open Sexplib
 open Sexplib.Std
+open Ppx_hash_lib.Std.Hash.Builtin
+open Ppx_compare_lib.Builtin
+
+let hash_fold_array = hash_fold_array_frozen
+
 open Serlib
 
 module C = CAst
@@ -47,87 +52,87 @@ module Inv        = Ser_inv
 
 type direction_flag =
   [%import: Ltac_plugin.Tacexpr.direction_flag]
-  [@@deriving sexp]
+  [@@deriving sexp,yojson,hash,compare]
 
 type lazy_flag =
   [%import: Ltac_plugin.Tacexpr.lazy_flag]
-  [@@deriving sexp]
+  [@@deriving sexp,yojson,hash,compare]
 
 type global_flag =
   [%import: Ltac_plugin.Tacexpr.global_flag]
-  [@@deriving sexp]
+  [@@deriving sexp,yojson,hash,compare]
 
 type evars_flag =
   [%import: Ltac_plugin.Tacexpr.evars_flag]
-  [@@deriving sexp]
+  [@@deriving sexp,yojson,hash,compare]
 
 type rec_flag =
   [%import: Ltac_plugin.Tacexpr.rec_flag]
-  [@@deriving sexp]
+  [@@deriving sexp,yojson,hash,compare]
 
 type advanced_flag =
   [%import: Ltac_plugin.Tacexpr.advanced_flag]
-  [@@deriving sexp]
+  [@@deriving sexp,yojson,hash,compare]
 
 type letin_flag =
   [%import: Ltac_plugin.Tacexpr.letin_flag]
-  [@@deriving sexp]
+  [@@deriving sexp,yojson,hash,compare]
 
 type clear_flag =
   [%import: Ltac_plugin.Tacexpr.clear_flag]
-  [@@deriving sexp]
+  [@@deriving sexp,yojson,hash,compare]
 
 type check_flag =
   [%import: Ltac_plugin.Tacexpr.check_flag]
-  [@@deriving sexp]
+  [@@deriving sexp,yojson,hash,compare]
 
 type ltac_constant =
   [%import: Ltac_plugin.Tacexpr.ltac_constant]
-  [@@deriving sexp]
+  [@@deriving sexp,yojson,hash,compare]
 
 type ('c,'d,'id) inversion_strength =
   [%import: ('c,'d,'id) Ltac_plugin.Tacexpr.inversion_strength]
-  [@@deriving sexp]
+  [@@deriving sexp,yojson,hash,compare]
 
 type ('a,'b) location =
   [%import: ('a, 'b) Ltac_plugin.Tacexpr.location]
-  [@@deriving sexp]
+  [@@deriving sexp,yojson,hash,compare]
 
 type 'id message_token =
   [%import: ('id) Ltac_plugin.Tacexpr.message_token]
-  [@@deriving sexp]
+  [@@deriving sexp,yojson,hash,compare]
 
 type ('dconstr,'id) induction_clause =
   [%import: ('dconstr,'id) Ltac_plugin.Tacexpr.induction_clause]
-  [@@deriving sexp]
+  [@@deriving sexp,yojson,hash,compare]
 
 type ('constr,'dconstr,'id) induction_clause_list =
   [%import: ('constr,'dconstr,'id) Ltac_plugin.Tacexpr.induction_clause_list]
-  [@@deriving sexp]
+  [@@deriving sexp,yojson,hash,compare]
 
 type 'a with_bindings_arg =
   [%import: 'a Ltac_plugin.Tacexpr.with_bindings_arg]
-  [@@deriving sexp]
+  [@@deriving sexp,yojson,hash,compare]
 
 type 'a match_pattern =
   [%import: 'a Ltac_plugin.Tacexpr.match_pattern]
-  [@@deriving sexp]
+  [@@deriving sexp,yojson,hash,compare]
 
 type 'a match_context_hyps =
   [%import: 'a Ltac_plugin.Tacexpr.match_context_hyps]
-  [@@deriving sexp]
+  [@@deriving sexp,yojson,hash,compare]
 
 type ('a,'t) match_rule =
   [%import: ('a, 't) Ltac_plugin.Tacexpr.match_rule]
-  [@@deriving sexp]
+  [@@deriving sexp,yojson,hash,compare]
 
 type ml_tactic_name =
   [%import: Ltac_plugin.Tacexpr.ml_tactic_name]
-  [@@deriving sexp]
+  [@@deriving sexp,yojson,hash,compare]
 
 type ml_tactic_entry =
   [%import: Ltac_plugin.Tacexpr.ml_tactic_entry]
-  [@@deriving sexp]
+  [@@deriving sexp,yojson,hash,compare]
 
 (* type dyn = Ser_Dyn [@@deriving sexp] *)
 (* let to_dyn _   = Ser_Dyn *)
@@ -139,6 +144,7 @@ type ml_tactic_entry =
 (* We thus iso-project the tactic definition in a virtually identical copy (but for the Dyn) *)
 module ITac = struct
 
+[@@@ocaml.warning "-27"]
 type ('trm, 'dtrm, 'pat, 'cst, 'ref, 'nam, 'tacexpr, 'lev) gen_atomic_tactic_expr =
   | TacIntroPattern of evars_flag * 'dtrm Tactypes.intro_pattern_expr CAst.t list
   | TacApply of advanced_flag * evars_flag * 'trm with_bindings_arg list *
@@ -239,11 +245,12 @@ and ('t, 'dtrm, 'p, 'c, 'r, 'n, 'tacexpr, 'l) gen_tactic_expr =
 
 and ('t, 'dtrm, 'p, 'c, 'r, 'n, 'tacexpr, 'l) gen_tactic_fun_ast =
     Names.Name.t list * ('t, 'dtrm, 'p, 'c, 'r, 'n, 'tacexpr, 'l) gen_tactic_expr
-   [@@deriving sexp]
+   [@@deriving sexp,yojson,hash,compare]
 
 end
+[@@@ocaml.warning "+27"]
 
-let rec _gen_atom_tactic_expr_put (t : 'a Ltac_plugin.Tacexpr.gen_atomic_tactic_expr) :
+let rec _gen_atomic_tactic_expr_put (t : 'a Ltac_plugin.Tacexpr.gen_atomic_tactic_expr) :
   ('t, 'dtrm, 'p, 'c, 'r, 'n, 'tacexpr, 'l) ITac.gen_atomic_tactic_expr = match t with
   | Ltac_plugin.Tacexpr.TacIntroPattern(a,b)         -> ITac.TacIntroPattern(a,b)
   | Ltac_plugin.Tacexpr.TacApply (a,b,c,d)           -> ITac.TacApply (a,b,c,d)
@@ -275,7 +282,7 @@ and _gen_tactic_expr_r_put (t : 'a Ltac_plugin.Tacexpr.gen_tactic_expr_r) :
   let uu x = List.map u x           in
   let ua x = Array.map u x          in
   match t with
-  | Ltac_plugin.Tacexpr.TacAtom l                -> ITac.TacAtom (_gen_atom_tactic_expr_put l)
+  | Ltac_plugin.Tacexpr.TacAtom l                -> ITac.TacAtom (_gen_atomic_tactic_expr_put l)
   | Ltac_plugin.Tacexpr.TacThen (a,b)            -> ITac.TacThen (u a, u b)
   | Ltac_plugin.Tacexpr.TacDispatch a            -> ITac.TacDispatch (uu a)
   | Ltac_plugin.Tacexpr.TacExtendTac (a,b,c)     -> ITac.TacExtendTac (ua a, u b, ua c)
@@ -426,9 +433,11 @@ and _gen_tactic_fun_ast_get (t : ('t, 'dtrm, 'p, 'c, 'r, 'n, 'tacexpr, 'l) ITac.
 
 type 'd gen_atomic_tactic_expr = 'd Ltac_plugin.Tacexpr.gen_atomic_tactic_expr
 
+(* Sexp part for generic functions *)
+
 let sexp_of_gen_atomic_tactic_expr
   t d p c r n te l (tac : 'a Ltac_plugin.Tacexpr.gen_atomic_tactic_expr) : Sexp.t =
-  ITac.sexp_of_gen_atomic_tactic_expr t d p c r n te l (_gen_atom_tactic_expr_put tac)
+  ITac.sexp_of_gen_atomic_tactic_expr t d p c r n te l (_gen_atomic_tactic_expr_put tac)
 
 let sexp_of_gen_tactic_expr
   t d p c r n te l (tac : 'a Ltac_plugin.Tacexpr.gen_tactic_expr) : Sexp.t =
@@ -457,6 +466,40 @@ let gen_tactic_arg_of_sexp (tac : Sexp.t)
 let gen_fun_ast_of_sexp (tac : Sexp.t)
   t d p c r n te l : 'a Ltac_plugin.Tacexpr.gen_tactic_fun_ast =
   _gen_tactic_fun_ast_get (ITac.gen_tactic_fun_ast_of_sexp t d p c r n te l tac)
+
+(* Yojson part for generic functions *)
+
+let gen_atomic_tactic_expr_to_yojson
+  t d p c r n te l (tac : 'a Ltac_plugin.Tacexpr.gen_atomic_tactic_expr) : _ =
+  ITac.gen_atomic_tactic_expr_to_yojson t d p c r n te l (_gen_atomic_tactic_expr_put tac)
+
+let gen_tactic_expr_to_yojson
+  t d p c r n te l (tac : 'a Ltac_plugin.Tacexpr.gen_tactic_expr) : Yojson.Safe.t =
+  ITac.gen_tactic_expr_to_yojson t d p c r n te l (_gen_tactic_expr_put tac)
+
+let gen_tactic_expr_of_yojson tac
+  t d p c r n te l : ('a Ltac_plugin.Tacexpr.gen_tactic_expr, _) result =
+  Result.map _gen_tactic_expr_get (ITac.gen_tactic_expr_of_yojson t d p c r n te l tac)
+
+let gen_atomic_tactic_expr_of_yojson tac
+  t d p c r n te l : ('a Ltac_plugin.Tacexpr.gen_atomic_tactic_expr, _) result =
+  Result.map _gen_atom_tactic_expr_get (ITac.gen_atomic_tactic_expr_of_yojson t d p c r n te l tac)
+
+(* Hash part for generic functions *)
+
+let hash_fold_gen_tactic_expr t d p c r n te l st tac =
+  ITac.hash_fold_gen_tactic_expr t d p c r n te l st (_gen_tactic_expr_put tac)
+
+let hash_fold_gen_atomic_tactic_expr t d p c r n te l st tac =
+  ITac.hash_fold_gen_atomic_tactic_expr t d p c r n te l st (_gen_atomic_tactic_expr_put tac)
+
+(* Compare part for generic functions *)
+
+let compare_gen_tactic_expr t d p c r n te l t1 t2 : int =
+  ITac.compare_gen_tactic_expr t d p c r n te l (_gen_tactic_expr_put t1) (_gen_tactic_expr_put t2)
+
+let compare_gen_atomic_tactic_expr t d p c r n te l t1 t2 =
+  ITac.compare_gen_atomic_tactic_expr t d p c r n te l (_gen_atomic_tactic_expr_put t1) (_gen_atomic_tactic_expr_put t2)
 
 (************************************************************************)
 (* Main tactics types, we follow tacexpr and provide glob,raw, and      *)
@@ -513,6 +556,101 @@ and sexp_of_glob_atomic_tactic_expr (tac : glob_atomic_tactic_expr) =
     Genarg.sexp_of_glevel
     tac
 
+let rec glob_tactic_expr_of_yojson tac =
+  gen_tactic_expr_of_yojson
+    tac
+    Genintern.glob_constr_and_expr_of_yojson
+    Genintern.glob_constr_and_expr_of_yojson
+    Genintern.glob_constr_pattern_and_expr_of_yojson
+    (Locus.or_var_of_yojson (Genredexpr.and_short_name_of_yojson Tacred.evaluable_global_reference_of_yojson))
+    (Locus.or_var_of_yojson (Loc.located_of_yojson ltac_constant_of_yojson))
+    Names.lident_of_yojson
+    glob_tactic_expr_of_yojson
+    Genarg.glevel_of_yojson
+and glob_atomic_tactic_expr_of_yojson tac =
+  gen_atomic_tactic_expr_of_yojson
+    tac
+    Genintern.glob_constr_and_expr_of_yojson
+    Genintern.glob_constr_and_expr_of_yojson
+    Genintern.glob_constr_pattern_and_expr_of_yojson
+    (Locus.or_var_of_yojson (Genredexpr.and_short_name_of_yojson Tacred.evaluable_global_reference_of_yojson))
+    (Locus.or_var_of_yojson (Loc.located_of_yojson ltac_constant_of_yojson))
+    Names.lident_of_yojson
+    glob_tactic_expr_of_yojson
+    Genarg.glevel_of_yojson
+
+let rec glob_tactic_expr_to_yojson tac =
+  gen_tactic_expr_to_yojson
+    Genintern.glob_constr_and_expr_to_yojson
+    Genintern.glob_constr_and_expr_to_yojson
+    Genintern.glob_constr_pattern_and_expr_to_yojson
+    (Locus.or_var_to_yojson (Genredexpr.and_short_name_to_yojson Tacred.evaluable_global_reference_to_yojson))
+    (Locus.or_var_to_yojson (Loc.located_to_yojson ltac_constant_to_yojson))
+    Names.lident_to_yojson
+    glob_tactic_expr_to_yojson
+    Genarg.glevel_to_yojson
+    tac
+and glob_atomic_tactic_expr_to_yojson tac =
+  gen_atomic_tactic_expr_to_yojson
+    Genintern.glob_constr_and_expr_to_yojson
+    Genintern.glob_constr_and_expr_to_yojson
+    Genintern.glob_constr_pattern_and_expr_to_yojson
+    (Locus.or_var_to_yojson (Genredexpr.and_short_name_to_yojson Tacred.evaluable_global_reference_to_yojson))
+    (Locus.or_var_to_yojson (Loc.located_to_yojson ltac_constant_to_yojson))
+    Names.lident_to_yojson
+    glob_tactic_expr_to_yojson
+    Genarg.glevel_to_yojson
+    tac
+
+let rec hash_fold_glob_tactic_expr st tac =
+  hash_fold_gen_tactic_expr
+    Genintern.hash_fold_glob_constr_and_expr
+    Genintern.hash_fold_glob_constr_and_expr
+    Genintern.hash_fold_glob_constr_pattern_and_expr
+    (Locus.hash_fold_or_var (Genredexpr.hash_fold_and_short_name Tacred.hash_fold_evaluable_global_reference))
+    (Locus.hash_fold_or_var (Loc.hash_fold_located hash_fold_ltac_constant))
+    Names.hash_fold_lident
+    hash_fold_glob_tactic_expr
+    Genarg.hash_fold_glevel
+    st tac
+and hash_fold_glob_atomic_tactic_expr st tac =
+  hash_fold_gen_atomic_tactic_expr
+    Genintern.hash_fold_glob_constr_and_expr
+    Genintern.hash_fold_glob_constr_and_expr
+    Genintern.hash_fold_glob_constr_pattern_and_expr
+    (Locus.hash_fold_or_var (Genredexpr.hash_fold_and_short_name Tacred.hash_fold_evaluable_global_reference))
+    (Locus.hash_fold_or_var (Loc.hash_fold_located hash_fold_ltac_constant))
+    Names.hash_fold_lident
+    hash_fold_glob_tactic_expr
+    Genarg.hash_fold_glevel
+    st tac
+
+let hash_glob_tactic_expr = Ppx_hash_lib.Std.Hash.of_fold hash_fold_glob_tactic_expr
+let hash_glob_atomic_tactic_expr = Ppx_hash_lib.Std.Hash.of_fold hash_fold_glob_atomic_tactic_expr
+
+let rec compare_glob_tactic_expr tac =
+  compare_gen_tactic_expr
+    Genintern.compare_glob_constr_and_expr
+    Genintern.compare_glob_constr_and_expr
+    Genintern.compare_glob_constr_pattern_and_expr
+    (Locus.compare_or_var (Genredexpr.compare_and_short_name Tacred.compare_evaluable_global_reference))
+    (Locus.compare_or_var (Loc.compare_located compare_ltac_constant))
+    Names.compare_lident
+    compare_glob_tactic_expr
+    Genarg.compare_glevel
+    tac
+and compare_glob_atomic_tactic_expr tac =
+  compare_gen_atomic_tactic_expr
+    Genintern.compare_glob_constr_and_expr
+    Genintern.compare_glob_constr_and_expr
+    Genintern.compare_glob_constr_pattern_and_expr
+    (Locus.compare_or_var (Genredexpr.compare_and_short_name Tacred.compare_evaluable_global_reference))
+    (Locus.compare_or_var (Loc.compare_located compare_ltac_constant))
+    Names.compare_lident
+    compare_glob_tactic_expr
+    Genarg.compare_glevel
+    tac
+
 (* Raw *)
 type raw_tactic_expr = Ltac_plugin.Tacexpr.raw_tactic_expr
 type raw_atomic_tactic_expr = Ltac_plugin.Tacexpr.raw_atomic_tactic_expr
@@ -563,6 +701,102 @@ and sexp_of_raw_atomic_tactic_expr tac =
     Genarg.sexp_of_rlevel
     tac
 
+(* Yojson *)
+let rec raw_tactic_expr_of_yojson tac =
+  gen_tactic_expr_of_yojson
+    tac
+    Constrexpr.constr_expr_of_yojson
+    Constrexpr.constr_expr_of_yojson
+    Constrexpr.constr_pattern_expr_of_yojson
+    (Constrexpr.or_by_notation_of_yojson Libnames.qualid_of_yojson)
+    Libnames.qualid_of_yojson
+    Names.lident_of_yojson
+    raw_tactic_expr_of_yojson
+    Genarg.rlevel_of_yojson
+and raw_atomic_tactic_expr_of_yojson tac =
+  gen_atomic_tactic_expr_of_yojson
+    tac
+    Constrexpr.constr_expr_of_yojson
+    Constrexpr.constr_expr_of_yojson
+    Constrexpr.constr_pattern_expr_of_yojson
+    (Constrexpr.or_by_notation_of_yojson Libnames.qualid_of_yojson)
+    Libnames.qualid_of_yojson
+    Names.lident_of_yojson
+    raw_tactic_expr_of_yojson
+    Genarg.rlevel_of_yojson
+
+let rec raw_tactic_expr_to_yojson (tac : raw_tactic_expr) =
+  gen_tactic_expr_to_yojson
+    Constrexpr.constr_expr_to_yojson
+    Constrexpr.constr_expr_to_yojson
+    Constrexpr.constr_pattern_expr_to_yojson
+    (Constrexpr.or_by_notation_to_yojson Libnames.qualid_to_yojson)
+    Libnames.qualid_to_yojson
+    Names.lident_to_yojson
+    raw_tactic_expr_to_yojson
+    Genarg.rlevel_to_yojson
+    tac
+and raw_atomic_tactic_expr_to_yojson tac =
+  gen_atomic_tactic_expr_to_yojson
+    Constrexpr.constr_expr_to_yojson
+    Constrexpr.constr_expr_to_yojson
+    Constrexpr.constr_pattern_expr_to_yojson
+    (Constrexpr.or_by_notation_to_yojson Libnames.qualid_to_yojson)
+    Libnames.qualid_to_yojson
+    Names.lident_to_yojson
+    raw_tactic_expr_to_yojson
+    Genarg.rlevel_to_yojson
+    tac
+
+let rec hash_fold_raw_tactic_expr st tac =
+  hash_fold_gen_tactic_expr
+    Constrexpr.hash_fold_constr_expr
+    Constrexpr.hash_fold_constr_expr
+    Constrexpr.hash_fold_constr_pattern_expr
+    (Constrexpr.hash_fold_or_by_notation Libnames.hash_fold_qualid)
+    Libnames.hash_fold_qualid
+    Names.hash_fold_lident
+    hash_fold_raw_tactic_expr
+    Genarg.hash_fold_rlevel
+    st tac
+and hash_fold_raw_atomic_tactic_expr st tac =
+  hash_fold_gen_atomic_tactic_expr
+    Constrexpr.hash_fold_constr_expr
+    Constrexpr.hash_fold_constr_expr
+    Constrexpr.hash_fold_constr_pattern_expr
+    (Constrexpr.hash_fold_or_by_notation Libnames.hash_fold_qualid)
+    Libnames.hash_fold_qualid
+    Names.hash_fold_lident
+    hash_fold_raw_tactic_expr
+    Genarg.hash_fold_rlevel
+    st tac
+
+let hash_raw_tactic_expr = Ppx_hash_lib.Std.Hash.of_fold hash_fold_raw_tactic_expr
+let hash_raw_atomic_tactic_expr = Ppx_hash_lib.Std.Hash.of_fold hash_fold_raw_atomic_tactic_expr
+
+let rec compare_raw_tactic_expr tac =
+  compare_gen_tactic_expr
+    Constrexpr.compare_constr_expr
+    Constrexpr.compare_constr_expr
+    Constrexpr.compare_constr_pattern_expr
+    (Constrexpr.compare_or_by_notation Libnames.compare_qualid)
+    Libnames.compare_qualid
+    Names.compare_lident
+    compare_raw_tactic_expr
+    Genarg.compare_rlevel
+    tac
+and compare_raw_atomic_tactic_expr tac =
+  compare_gen_atomic_tactic_expr
+    Constrexpr.compare_constr_expr
+    Constrexpr.compare_constr_expr
+    Constrexpr.compare_constr_pattern_expr
+    (Constrexpr.compare_or_by_notation Libnames.compare_qualid)
+    Libnames.compare_qualid
+    Names.compare_lident
+    compare_raw_tactic_expr
+    Genarg.compare_rlevel
+    tac
+
 (* Atomic *)
 type atomic_tactic_expr = Ltac_plugin.Tacexpr.atomic_tactic_expr
 
@@ -592,29 +826,29 @@ let sexp_of_atomic_tactic_expr tac =
 (* Helpers for raw_red_expr *)
 type tacdef_body =
   [%import: Ltac_plugin.Tacexpr.tacdef_body]
-  [@@deriving sexp]
+  [@@deriving sexp,yojson,hash,compare]
 
 (* Unsupported serializers *)
 type intro_pattern =
   [%import: Ltac_plugin.Tacexpr.intro_pattern]
-  [@@deriving sexp]
+  [@@deriving sexp,yojson,hash,compare]
 
 type raw_red_expr =
   [%import: Ltac_plugin.Tacexpr.raw_red_expr]
-  [@@deriving sexp]
+  [@@deriving sexp,yojson,hash,compare]
 
 type g_trm =
   [%import: Ltac_plugin.Tacexpr.g_trm]
-  [@@deriving sexp]
+  [@@deriving sexp,yojson,hash,compare]
 
 type g_cst =
   [%import: Ltac_plugin.Tacexpr.g_cst]
-  [@@deriving sexp]
+  [@@deriving sexp,yojson,hash,compare]
 
 type g_pat =
   [%import: Ltac_plugin.Tacexpr.g_pat]
-  [@@deriving sexp]
+  [@@deriving sexp,yojson,hash,compare]
 
 type glob_red_expr =
   [%import: Ltac_plugin.Tacexpr.glob_red_expr]
-  [@@deriving sexp]
+  [@@deriving sexp,yojson,hash,compare]

--- a/serlib/plugins/ltac/ser_tacexpr.mli
+++ b/serlib/plugins/ltac/ser_tacexpr.mli
@@ -74,14 +74,7 @@ type ('a, 'b) location =
   ('a, 'b) Tacexpr.location =
     HypLocation of 'a
   | ConclLocation of 'b
-
-val location_of_sexp :
-  (Sexp.t -> 'a) ->
-  (Sexp.t -> 'b) -> Sexp.t -> ('a, 'b) location
-
-val sexp_of_location :
-  ('a -> Sexp.t) ->
-  ('b -> Sexp.t) -> ('a, 'b) location -> Sexp.t
+  [@@deriving sexp,hash,compare]
 
 type 'id message_token = 'id Tacexpr.message_token
 
@@ -260,37 +253,29 @@ val gen_fun_ast_of_sexp :
   Tacexpr.gen_tactic_fun_ast
 
 type glob_tactic_expr = Tacexpr.glob_tactic_expr
-val glob_tactic_expr_of_sexp : Sexp.t -> glob_tactic_expr
-val sexp_of_glob_tactic_expr : glob_tactic_expr -> Sexp.t
+  [@@deriving sexp,yojson,hash,compare]
 
 type glob_atomic_tactic_expr = Tacexpr.glob_atomic_tactic_expr
-val glob_atomic_tactic_expr_of_sexp : Sexp.t -> glob_atomic_tactic_expr
-val sexp_of_glob_atomic_tactic_expr : glob_atomic_tactic_expr -> Sexp.t
+  [@@deriving sexp,yojson,hash,compare]
 
 type raw_tactic_expr = Tacexpr.raw_tactic_expr
-val raw_tactic_expr_of_sexp : Sexp.t -> raw_tactic_expr
-val sexp_of_raw_tactic_expr : raw_tactic_expr -> Sexp.t
+  [@@deriving sexp,yojson,hash,compare]
 
 type raw_atomic_tactic_expr = Tacexpr.raw_atomic_tactic_expr
-val raw_atomic_tactic_expr_of_sexp : Sexp.t -> raw_atomic_tactic_expr
-val sexp_of_raw_atomic_tactic_expr : raw_atomic_tactic_expr -> Sexp.t
+  [@@deriving sexp,yojson,hash,compare]
 
 type atomic_tactic_expr = Tacexpr.atomic_tactic_expr
 val atomic_tactic_expr_of_sexp : Sexp.t -> atomic_tactic_expr
 val sexp_of_atomic_tactic_expr : atomic_tactic_expr -> Sexp.t
 
 type tacdef_body = Tacexpr.tacdef_body
-val tacdef_body_of_sexp : Sexp.t -> tacdef_body
-val sexp_of_tacdef_body : tacdef_body -> Sexp.t
+  [@@deriving sexp,hash,compare]
 
 type intro_pattern = Tacexpr.intro_pattern
-val intro_pattern_of_sexp : Sexp.t -> intro_pattern
-val sexp_of_intro_pattern : intro_pattern -> Sexp.t
+  [@@deriving sexp,hash,compare]
 
 type raw_red_expr = Tacexpr.raw_red_expr
-val raw_red_expr_of_sexp : Sexp.t -> raw_red_expr
-val sexp_of_raw_red_expr : raw_red_expr -> Sexp.t
+  [@@deriving sexp,hash,compare]
 
 type glob_red_expr = Tacexpr.glob_red_expr
-val glob_red_expr_of_sexp : Sexp.t -> glob_red_expr
-val sexp_of_glob_red_expr : glob_red_expr -> Sexp.t
+  [@@deriving sexp,hash,compare]

--- a/serlib/plugins/ring/dune
+++ b/serlib/plugins/ring/dune
@@ -2,5 +2,5 @@
  (name serlib_ring)
  (public_name coq-serapi.serlib.ring)
  (synopsis "Serialization Library for Coq Setoid Newring Plugin")
- (preprocess (staged_pps ppx_import ppx_sexp_conv))
+ (preprocess (staged_pps ppx_import ppx_sexp_conv ppx_hash ppx_compare))
  (libraries coq-core.plugins.ring serlib serlib_ltac sexplib))

--- a/serlib/plugins/ring/ser_g_ring.ml
+++ b/serlib/plugins/ring/ser_g_ring.ml
@@ -1,4 +1,6 @@
 open Sexplib.Conv
+open Ppx_hash_lib.Std.Hash.Builtin
+open Ppx_compare_lib.Builtin
 open Serlib
 
 module CAst       = Ser_cAst
@@ -15,67 +17,63 @@ end
 
 type 'constr coeff_spec =
   [%import: 'constr Ring_plugin.Ring_ast.coeff_spec]
-  [@@deriving sexp]
+  [@@deriving sexp,hash,compare]
 
 type cst_tac_spec =
   [%import: Ring_plugin.Ring_ast.cst_tac_spec]
-  [@@deriving sexp]
+  [@@deriving sexp,hash,compare]
 
 type 'constr ring_mod =
   [%import: 'constr Ring_plugin.Ring_ast.ring_mod]
-  [@@deriving sexp]
+  [@@deriving sexp,hash,compare]
 
 type 'a field_mod =
   [%import: 'a Ring_plugin.Ring_ast.field_mod]
-  [@@deriving sexp]
+  [@@deriving sexp,hash,compare]
 
-let ser_wit_field_mod =
-  Ser_genarg.
-    { raw_ser = sexp_of_field_mod Constrexpr.sexp_of_constr_expr
-    ; raw_des = field_mod_of_sexp Constrexpr.constr_expr_of_sexp
+module A0 = struct
+  type raw = Constrexpr.constr_expr field_mod
+    [@@deriving sexp,hash,compare]
+  type glb = unit
+    [@@deriving sexp,hash,compare]
+  type top = unit
+    [@@deriving sexp,hash,compare]
+end
 
-    ; glb_ser = sexp_of_unit
-    ; glb_des = unit_of_sexp
+let ser_wit_field_mod = let module M = Ser_genarg.GS(A0) in M.genser
 
-    ; top_ser = sexp_of_unit
-    ; top_des = unit_of_sexp
-  }
+module A1 = struct
+  type raw = Constrexpr.constr_expr field_mod list
+    [@@deriving sexp,hash,compare]
+  type glb = unit
+    [@@deriving sexp,hash,compare]
+  type top = unit
+    [@@deriving sexp,hash,compare]
+end
 
-let ser_wit_field_mods =
-  Ser_genarg.
-    { raw_ser = sexp_of_list (sexp_of_field_mod Constrexpr.sexp_of_constr_expr)
-    ; raw_des = list_of_sexp (field_mod_of_sexp Constrexpr.constr_expr_of_sexp)
+let ser_wit_field_mods = let module M = Ser_genarg.GS(A1) in M.genser
 
-    ; glb_ser = sexp_of_unit
-    ; glb_des = unit_of_sexp
+module A2 = struct
+  type raw = Constrexpr.constr_expr ring_mod
+    [@@deriving sexp,hash,compare]
+  type glb = unit
+    [@@deriving sexp,hash,compare]
+  type top = unit
+    [@@deriving sexp,hash,compare]
+end
 
-    ; top_ser = sexp_of_unit
-    ; top_des = unit_of_sexp
-  }
+let ser_wit_ring_mod = let module M = Ser_genarg.GS(A2) in M.genser
 
-let ser_wit_ring_mod =
-  Ser_genarg.
-    { raw_ser = sexp_of_ring_mod Constrexpr.sexp_of_constr_expr
-    ; raw_des = ring_mod_of_sexp Constrexpr.constr_expr_of_sexp
+module A3 = struct
+  type raw = Constrexpr.constr_expr ring_mod list
+    [@@deriving sexp,hash,compare]
+  type glb = unit
+    [@@deriving sexp,hash,compare]
+  type top = unit
+    [@@deriving sexp,hash,compare]
+end
 
-    ; glb_ser = sexp_of_unit
-    ; glb_des = unit_of_sexp
-
-    ; top_ser = sexp_of_unit
-    ; top_des = unit_of_sexp
-  }
-
-let ser_wit_ring_mods =
-  Ser_genarg.
-    { raw_ser = sexp_of_list (sexp_of_ring_mod Constrexpr.sexp_of_constr_expr)
-    ; raw_des = list_of_sexp (ring_mod_of_sexp Constrexpr.constr_expr_of_sexp)
-
-    ; glb_ser = sexp_of_unit
-    ; glb_des = unit_of_sexp
-
-    ; top_ser = sexp_of_unit
-    ; top_des = unit_of_sexp
-  }
+let ser_wit_ring_mods = let module M = Ser_genarg.GS(A3) in M.genser
 
 let register () =
   Ser_genarg.register_genser Ring_plugin.G_ring.wit_field_mod  ser_wit_field_mod;

--- a/serlib/plugins/ssr/dune
+++ b/serlib/plugins/ssr/dune
@@ -2,5 +2,5 @@
  (name serlib_ssr)
  (public_name coq-serapi.serlib.ssreflect)
  (synopsis "Serialization Library for Coq [SSR plugin]")
- (preprocess (staged_pps ppx_import ppx_sexp_conv))
+ (preprocess (staged_pps ppx_import ppx_sexp_conv ppx_deriving_yojson ppx_hash ppx_compare))
  (libraries coq-core.plugins.ssreflect serlib serlib_ltac serlib_ssrmatching sexplib))

--- a/serlib/plugins/ssr/ser_ssrast.ml
+++ b/serlib/plugins/ssr/ser_ssrast.ml
@@ -16,6 +16,9 @@
 (************************************************************************)
 
 open Sexplib.Std
+open Ppx_hash_lib.Std.Hash.Builtin
+open Ppx_compare_lib.Builtin
+
 open Serlib
 
 module Loc        = Ser_loc
@@ -34,7 +37,7 @@ module Ltac_plugin = struct
 end
 
 type ssrtermkind = Ssrmatching_plugin.Ssrmatching.ssrtermkind
-  [@@deriving sexp]
+  [@@deriving sexp,yojson,hash,compare]
 
 (* What a hack is ssreflect using... *)
 module Proofview = struct
@@ -45,67 +48,67 @@ end
 
 type ssrhyp =
   [%import: Wrap_ssrast.ssrhyp]
-  [@@deriving sexp]
+  [@@deriving sexp,yojson,hash,compare]
 
 type ssrhyp_or_id =
   [%import: Wrap_ssrast.ssrhyp_or_id]
-  [@@deriving sexp]
+  [@@deriving sexp,yojson,hash,compare]
 
 type ssrhyps =
   [%import: Wrap_ssrast.ssrhyps]
-  [@@deriving sexp]
+  [@@deriving sexp,yojson,hash,compare]
 
 type ssrdir =
   [%import: Wrap_ssrast.ssrdir]
-  [@@deriving sexp]
+  [@@deriving sexp,yojson,hash,compare]
 
 type ssrsimpl =
   [%import: Wrap_ssrast.ssrsimpl]
-  [@@deriving sexp]
+  [@@deriving sexp,yojson,hash,compare]
 
 type ssrmmod =
   [%import: Wrap_ssrast.ssrmmod]
-  [@@deriving sexp]
+  [@@deriving sexp,yojson,hash,compare]
 
 type ssrmult =
   [%import: Wrap_ssrast.ssrmult]
-  [@@deriving sexp]
+  [@@deriving sexp,yojson,hash,compare]
 
 type ssrocc =
   [%import: Wrap_ssrast.ssrocc]
-  [@@deriving sexp]
+  [@@deriving sexp,yojson,hash,compare]
 
 type ssrindex =
   [%import: Wrap_ssrast.ssrindex]
-  [@@deriving sexp]
+  [@@deriving sexp,yojson,hash,compare]
 
 type ssrclear =
   [%import: Wrap_ssrast.ssrclear]
-  [@@deriving sexp]
+  [@@deriving sexp,yojson,hash,compare]
 
 type ssrdocc =
   [%import: Wrap_ssrast.ssrdocc]
-  [@@deriving sexp]
+  [@@deriving sexp,yojson,hash,compare]
 
 type ssrterm =
   [%import: Wrap_ssrast.ssrterm]
-  [@@deriving sexp]
+  [@@deriving sexp,yojson,hash,compare]
 
 type ast_glob_env =
   [%import: Wrap_ssrast.ast_glob_env]
-  [@@deriving sexp]
+  [@@deriving sexp,yojson,hash,compare]
 
 type ast_closure_term =
   [%import: Wrap_ssrast.ast_closure_term]
-  [@@deriving sexp]
+  [@@deriving sexp,yojson,hash,compare]
 
 type ssrview =
   [%import: Wrap_ssrast.ssrview]
-  [@@deriving sexp]
+  [@@deriving sexp,yojson,hash,compare]
 
 type anon_kind =
   [%import: Wrap_ssrast.anon_kind]
-  [@@deriving sexp]
+  [@@deriving sexp,yojson,hash,compare]
 
 (* type anon_iter =
  *   [%import: Wrap_ssrast.anon_iter]
@@ -113,105 +116,105 @@ type anon_kind =
 
 type id_block =
   [%import: Wrap_ssrast.id_block]
-  [@@deriving sexp]
+  [@@deriving sexp,yojson,hash,compare]
 
 type ssripat =
   [%import: Wrap_ssrast.ssripat]
-  [@@deriving sexp]
+  [@@deriving sexp,yojson,hash,compare]
 and ssripats =
   [%import: Wrap_ssrast.ssripats]
-  [@@deriving sexp]
+  [@@deriving sexp,yojson,hash,compare]
 and ssripatss =
   [%import: Wrap_ssrast.ssripatss]
-  [@@deriving sexp]
+  [@@deriving sexp,yojson,hash,compare]
 and ssripatss_or_block =
   [%import: Wrap_ssrast.ssripatss_or_block]
-  [@@deriving sexp]
+  [@@deriving sexp,yojson,hash,compare]
 
 type ssrhpats =
   [%import: Wrap_ssrast.ssrhpats]
-  [@@deriving sexp]
+  [@@deriving sexp,yojson,hash,compare]
 
 type ssrhpats_wtransp =
   [%import: Wrap_ssrast.ssrhpats_wtransp]
-  [@@deriving sexp]
+  [@@deriving sexp,yojson,hash,compare]
 
 type ssrintrosarg =
   [%import: Wrap_ssrast.ssrintrosarg]
-  [@@deriving sexp]
+  [@@deriving sexp,yojson,hash,compare]
 
 type ssrfwdid =
   [%import: Wrap_ssrast.ssrfwdid]
-  [@@deriving sexp]
+  [@@deriving sexp,yojson,hash,compare]
 
 type 'term ssrbind =
   [%import: 'term Wrap_ssrast.ssrbind]
-  [@@deriving sexp]
+  [@@deriving sexp,yojson,hash,compare]
 
 type ssrbindfmt =
   [%import: Wrap_ssrast.ssrbindfmt]
-  [@@deriving sexp]
+  [@@deriving sexp,yojson,hash,compare]
 
 type 'term ssrbindval =
   [%import: 'term Wrap_ssrast.ssrbindval]
-  [@@deriving sexp]
+  [@@deriving sexp,yojson,hash,compare]
 
 type ssrfwdkind =
   [%import: Wrap_ssrast.ssrfwdkind]
-  [@@deriving sexp]
+  [@@deriving sexp,yojson,hash,compare]
 
 type ssrfwdfmt =
   [%import: Wrap_ssrast.ssrfwdfmt]
-  [@@deriving sexp]
+  [@@deriving sexp,yojson,hash,compare]
 
 type ssrclseq =
   [%import: Wrap_ssrast.ssrclseq]
-  [@@deriving sexp]
+  [@@deriving sexp,yojson,hash,compare]
 
 type 'tac ssrhint =
   [%import: 'tac Wrap_ssrast.ssrhint]
-  [@@deriving sexp]
+  [@@deriving sexp,yojson,hash,compare]
 
 type 'tac fwdbinders =
   [%import: 'tac Wrap_ssrast.fwdbinders]
-  [@@deriving sexp]
+  [@@deriving sexp,yojson,hash,compare]
 
 type 'tac ffwbinders =
   [%import: 'tac Wrap_ssrast.ffwbinders]
-  [@@deriving sexp]
+  [@@deriving sexp,yojson,hash,compare]
 
 type clause =
   [%import: Wrap_ssrast.clause]
-  [@@deriving sexp]
+  [@@deriving sexp,yojson,hash,compare]
 
 type clauses =
   [%import: Wrap_ssrast.clauses]
-  [@@deriving sexp]
+  [@@deriving sexp,yojson,hash,compare]
 
 type wgen =
   [%import: Wrap_ssrast.wgen]
-  [@@deriving sexp]
+  [@@deriving sexp,yojson,hash,compare]
 
 type 'a ssrdoarg =
   [%import: 'a Wrap_ssrast.ssrdoarg]
-  [@@deriving sexp]
+  [@@deriving sexp,yojson,hash,compare]
 
 type 'a ssrseqarg =
   [%import: 'a Wrap_ssrast.ssrseqarg]
-  [@@deriving sexp]
+  [@@deriving sexp,yojson,hash,compare]
 
 type 'a ssragens =
   [%import: 'a Wrap_ssrast.ssragens]
-  [@@deriving sexp]
+  [@@deriving sexp,yojson,hash,compare]
 
 type ssrapplyarg =
   [%import: Wrap_ssrast.ssrapplyarg]
-  [@@deriving sexp]
+  [@@deriving sexp,yojson,hash,compare]
 
 type 'a ssrcasearg =
   [%import: 'a Wrap_ssrast.ssrcasearg]
-  [@@deriving sexp]
+  [@@deriving sexp,yojson,hash,compare]
 
 type 'a ssrmovearg =
   [%import: 'a Wrap_ssrast.ssrmovearg]
-  [@@deriving sexp]
+  [@@deriving sexp,yojson,hash,compare]

--- a/serlib/plugins/ssr/ser_ssrequality.ml
+++ b/serlib/plugins/ssr/ser_ssrequality.ml
@@ -13,7 +13,9 @@
 (* Status: Very Experimental                                            *)
 (************************************************************************)
 
-open Sexplib.Conv
+open Sexplib.Std
+open Ppx_hash_lib.Std.Hash.Builtin
+open Ppx_compare_lib.Builtin
 
 module Ssrmatching_plugin = struct
   module Ssrmatching = Serlib_ssrmatching.Ser_ssrmatching
@@ -28,12 +30,12 @@ open Ssreflect_plugin [@@ocaml.warning "-33"]
 
 type ssrwkind =
   [%import: Ssreflect_plugin.Ssrequality.ssrwkind]
-  [@@deriving sexp]
+  [@@deriving sexp,hash,compare]
 
 type ssrrule =
   [%import: Ssreflect_plugin.Ssrequality.ssrrule]
-  [@@deriving sexp]
+  [@@deriving sexp,hash,compare]
 
 type ssrrwarg =
   [%import: Ssreflect_plugin.Ssrequality.ssrrwarg]
-  [@@deriving sexp]
+  [@@deriving sexp,hash,compare]

--- a/serlib/plugins/ssr/ser_ssrparser.ml
+++ b/serlib/plugins/ssr/ser_ssrparser.ml
@@ -15,7 +15,10 @@
 (* Status: Very Experimental                                            *)
 (************************************************************************)
 
-open Sexplib.Conv
+open Sexplib.Std
+open Ppx_hash_lib.Std.Hash.Builtin
+open Ppx_compare_lib.Builtin
+
 open Serlib
 
 module Ssrmatching = Serlib_ssrmatching.Ser_ssrmatching
@@ -36,208 +39,173 @@ end
 open! Ssrast
 
 type t_movearg = (cpattern ssragens) ssrmovearg
-[@@deriving sexp]
+[@@deriving sexp,yojson,hash,compare]
 
 let ser_wit_ssrmovearg  =
-  Ser_genarg.mk_uniform sexp_of_t_movearg t_movearg_of_sexp
+  Ser_genarg.mk_uniform sexp_of_t_movearg t_movearg_of_sexp hash_fold_t_movearg compare_t_movearg
 
 let ser_wit_ssrapplyarg =
-  Ser_genarg.mk_uniform sexp_of_ssrapplyarg ssrapplyarg_of_sexp
+  Ser_genarg.mk_uniform sexp_of_ssrapplyarg ssrapplyarg_of_sexp hash_fold_ssrapplyarg compare_ssrapplyarg
 
 let ser_wit_clauses =
-  Ser_genarg.mk_uniform sexp_of_clauses clauses_of_sexp
+  Ser_genarg.mk_uniform sexp_of_clauses clauses_of_sexp hash_fold_clauses compare_clauses
 
-type t_rwarg = Ssreflect_plugin.Ssrequality.ssrrwarg list [@@deriving sexp]
+type t_rwarg = Ssreflect_plugin.Ssrequality.ssrrwarg list [@@deriving sexp,hash,compare]
 
 let ser_wit_ssrrwargs =
-  Ser_genarg.mk_uniform sexp_of_t_rwarg t_rwarg_of_sexp
+  Ser_genarg.mk_uniform sexp_of_t_rwarg t_rwarg_of_sexp hash_fold_t_rwarg compare_t_rwarg
 
-type t_h1 = Ltac_plugin.Tacexpr.raw_tactic_expr fwdbinders
-[@@deriving sexp]
+module A0 = struct
+  type raw = Ltac_plugin.Tacexpr.raw_tactic_expr fwdbinders
+  [@@deriving sexp,yojson,hash,compare]
 
-type t_h2 = Ltac_plugin.Tacexpr.glob_tactic_expr fwdbinders
-[@@deriving sexp]
+  type glb = Ltac_plugin.Tacexpr.glob_tactic_expr fwdbinders
+  [@@deriving sexp,yojson,hash,compare]
 
-type t_h3 = Geninterp.Val.t fwdbinders
-[@@deriving sexp]
+  type top = Geninterp.Val.t fwdbinders
+  [@@deriving sexp,yojson,hash,compare]
+end
 
-let ser_wit_ssrhavefwdwbinders =
-  Ser_genarg.{
-    raw_ser = sexp_of_t_h1;
-    raw_des = t_h1_of_sexp;
-
-    glb_ser = sexp_of_t_h2;
-    glb_des = t_h2_of_sexp;
-
-    top_ser = sexp_of_t_h3;
-    top_des = t_h3_of_sexp;
-  }
+let ser_wit_ssrhavefwdwbinders = let module M = Ser_genarg.GS(A0) in M.genser
 
 type ssrfwdview =
   [%import: Ssreflect_plugin.Ssrparser.ssrfwdview]
-  [@@deriving sexp]
+  [@@deriving sexp,yojson,hash,compare]
 
 type ssreqid =
   [%import: Ssreflect_plugin.Ssrparser.ssreqid]
-  [@@deriving sexp]
+  [@@deriving sexp,yojson,hash,compare]
 
 type ssrarg =
   [%import: Ssreflect_plugin.Ssrparser.ssrarg]
-  [@@deriving sexp]
+  [@@deriving sexp,yojson,hash,compare]
 
 let ser_wit_ssrarg =
-  Ser_genarg.mk_uniform sexp_of_ssrarg ssrarg_of_sexp
-
-type h_h1 = Ltac_plugin.Tacexpr.raw_tactic_expr ssrhint
-[@@deriving sexp]
-type h_h2 = Ltac_plugin.Tacexpr.glob_tactic_expr ssrhint
-[@@deriving sexp]
-type h_h3 = Geninterp.Val.t ssrhint
-[@@deriving sexp]
-
-let ser_wit_ssrhintarg =
-  Ser_genarg.{
-    raw_ser = sexp_of_h_h1;
-    raw_des = h_h1_of_sexp;
-
-    glb_ser = sexp_of_h_h2;
-    glb_des = h_h2_of_sexp;
-
-    top_ser = sexp_of_h_h3;
-    top_des = h_h3_of_sexp;
-  }
+  Ser_genarg.mk_uniform sexp_of_ssrarg ssrarg_of_sexp hash_fold_ssrarg compare_ssrarg
 
 module A1 = struct
-  type h1 = Serlib_ltac.Ser_tacexpr.raw_tactic_expr ssrseqarg
-  [@@deriving sexp]
-  type h2 = Serlib_ltac.Ser_tacexpr.glob_tactic_expr ssrseqarg
-  [@@deriving sexp]
-  type h3 = Geninterp.Val.t ssrseqarg
-  [@@deriving sexp]
+  type raw = Ltac_plugin.Tacexpr.raw_tactic_expr ssrhint
+  [@@deriving sexp,yojson,hash,compare]
+  type glb = Ltac_plugin.Tacexpr.glob_tactic_expr ssrhint
+  [@@deriving sexp,yojson,hash,compare]
+  type top = Geninterp.Val.t ssrhint
+  [@@deriving sexp,yojson,hash,compare]
 end
 
-let ser_wit_ssrseqarg = let open A1 in Ser_genarg.
-  { raw_ser = sexp_of_h1
-  ; raw_des = h1_of_sexp
-
-  ; glb_ser = sexp_of_h2
-  ; glb_des = h2_of_sexp
-
-  ; top_ser = sexp_of_h3
-  ; top_des = h3_of_sexp
-  }
+let ser_wit_ssrhintarg = let module M = Ser_genarg.GS(A1) in M.genser
 
 module A2 = struct
-  type h1 = Serlib_ltac.Ser_tacexpr.raw_tactic_expr * ssripats
-  [@@deriving sexp]
-  type h2 = Serlib_ltac.Ser_tacexpr.glob_tactic_expr * ssripats
-  [@@deriving sexp]
-  type h3 = Geninterp.Val.t * ssripats
-  [@@deriving sexp]
+  type raw = Serlib_ltac.Ser_tacexpr.raw_tactic_expr ssrseqarg
+  [@@deriving sexp,yojson,hash,compare]
+
+  type glb = Serlib_ltac.Ser_tacexpr.glob_tactic_expr ssrseqarg
+  [@@deriving sexp,yojson,hash,compare]
+
+  type top = Geninterp.Val.t ssrseqarg
+  [@@deriving sexp,yojson,hash,compare]
 end
 
-let ser_wit_ssrintrosarg = let open A2 in Ser_genarg.
-  { raw_ser = sexp_of_h1
-  ; raw_des = h1_of_sexp
-
-  ; glb_ser = sexp_of_h2
-  ; glb_des = h2_of_sexp
-
-  ; top_ser = sexp_of_h3
-  ; top_des = h3_of_sexp
-  }
+let ser_wit_ssrseqarg = let module M = Ser_genarg.GS(A2) in M.genser
 
 module A3 = struct
-  type h1 = Serlib_ltac.Ser_tacexpr.raw_tactic_expr ffwbinders
-  [@@deriving sexp]
-  type h2 = Serlib_ltac.Ser_tacexpr.glob_tactic_expr ffwbinders
-  [@@deriving sexp]
-  type h3 = Geninterp.Val.t ffwbinders
-  [@@deriving sexp]
+  type raw = Serlib_ltac.Ser_tacexpr.raw_tactic_expr * ssripats
+  [@@deriving sexp,yojson,hash,compare]
+  type glb = Serlib_ltac.Ser_tacexpr.glob_tactic_expr * ssripats
+  [@@deriving sexp,yojson,hash,compare]
+  type top = Geninterp.Val.t * ssripats
+  [@@deriving sexp,yojson,hash,compare]
 end
 
-let ser_wit_ssrsufffwd = let open A3 in Ser_genarg.
-  { raw_ser = sexp_of_h1 ; raw_des = h1_of_sexp ; glb_ser = sexp_of_h2
-  ; glb_des = h2_of_sexp ; top_ser = sexp_of_h3 ; top_des = h3_of_sexp
-  }
+let ser_wit_ssrintrosarg = let module M = Ser_genarg.GS(A3) in M.genser
 
 module A4 = struct
-  type h1 = ((int * Ssreflect_plugin.Ssrast.ssrterm) * Ssrmatching_plugin.Ssrmatching.cpattern ssragens)
-  [@@deriving sexp]
+  type raw = Serlib_ltac.Ser_tacexpr.raw_tactic_expr ffwbinders
+  [@@deriving sexp,yojson,hash,compare]
+  type glb = Serlib_ltac.Ser_tacexpr.glob_tactic_expr ffwbinders
+  [@@deriving sexp,yojson,hash,compare]
+  type top = Geninterp.Val.t ffwbinders
+  [@@deriving sexp,yojson,hash,compare]
 end
 
-let ser_wit_ssrcongrarg = let open A4 in Ser_genarg.mk_uniform sexp_of_h1 h1_of_sexp
+let ser_wit_ssrsufffwd = let module M = Ser_genarg.GS(A4) in M.genser
 
 module A5 = struct
-  type h1 = Serlib_ltac.Ser_tacexpr.raw_tactic_expr ssrdoarg
-  [@@deriving sexp]
-  type h2 = Serlib_ltac.Ser_tacexpr.glob_tactic_expr ssrdoarg
-  [@@deriving sexp]
-  type h3 = Geninterp.Val.t ssrdoarg
-  [@@deriving sexp]
-
+  type t = ((int * Ssreflect_plugin.Ssrast.ssrterm) * Ssrmatching_plugin.Ssrmatching.cpattern ssragens)
+  [@@deriving sexp,yojson,hash,compare]
 end
 
-let ser_wit_ssrdoarg = let open A5 in Ser_genarg.
-  { raw_ser = sexp_of_h1 ; raw_des = h1_of_sexp ; glb_ser = sexp_of_h2
-  ; glb_des = h2_of_sexp ; top_ser = sexp_of_h3 ; top_des = h3_of_sexp
-  }
+let ser_wit_ssrcongrarg = let module M = Ser_genarg.GS0(A5) in M.genser
 
 module A6 = struct
-  type h1 = ((ssrfwdfmt * (cpattern * ast_closure_term option)) * ssrdocc)
-  [@@deriving sexp]
+  type raw = Serlib_ltac.Ser_tacexpr.raw_tactic_expr ssrdoarg
+  [@@deriving sexp,yojson,hash,compare]
+  type glb = Serlib_ltac.Ser_tacexpr.glob_tactic_expr ssrdoarg
+  [@@deriving sexp,yojson,hash,compare]
+  type top = Geninterp.Val.t ssrdoarg
+  [@@deriving sexp,yojson,hash,compare]
 end
 
-let ser_wit_ssrsetfwd = let open A6 in Ser_genarg.mk_uniform sexp_of_h1 h1_of_sexp
+let ser_wit_ssrdoarg = let module M = Ser_genarg.GS(A6) in M.genser
 
 module A7 = struct
-  type h1 = Serlib_ltac.Ser_tacexpr.raw_tactic_expr ssrhint
-  [@@deriving sexp]
-  type h2 = Serlib_ltac.Ser_tacexpr.glob_tactic_expr ssrhint
-  [@@deriving sexp]
-  type h3 = Geninterp.Val.t ssrhint
-  [@@deriving sexp]
+  type t = ((ssrfwdfmt * (cpattern * ast_closure_term option)) * ssrdocc)
+  [@@deriving sexp,yojson,hash,compare]
 end
 
-let ser_wit_ssrhint = let open A7 in Ser_genarg.
-  { raw_ser = sexp_of_h1 ; raw_des = h1_of_sexp ; glb_ser = sexp_of_h2
-  ; glb_des = h2_of_sexp ; top_ser = sexp_of_h3 ; top_des = h3_of_sexp
-  }
+let ser_wit_ssrsetfwd = let module M = Ser_genarg.GS0(A7) in M.genser
 
 module A8 = struct
-  type h1 = ssrfwdfmt * ast_closure_term
-  [@@deriving sexp]
+  type raw = Serlib_ltac.Ser_tacexpr.raw_tactic_expr ssrhint
+  [@@deriving sexp,yojson,hash,compare]
+  type glb = Serlib_ltac.Ser_tacexpr.glob_tactic_expr ssrhint
+  [@@deriving sexp,yojson,hash,compare]
+  type top = Geninterp.Val.t ssrhint
+  [@@deriving sexp,yojson,hash,compare]
 end
 
-let ser_wit_ssrposefwd = let open A8 in Ser_genarg.mk_uniform sexp_of_h1 h1_of_sexp
+let ser_wit_ssrhint = let module M = Ser_genarg.GS(A8) in M.genser
 
 module A9 = struct
-  type h1 = ssrocc * ssrterm
-  [@@deriving sexp]
+  type t = ssrfwdfmt * ast_closure_term
+  [@@deriving sexp,yojson,hash,compare]
 end
 
-let ser_wit_ssrunlockarg = let open A9 in Ser_genarg.mk_uniform sexp_of_h1 h1_of_sexp
+let ser_wit_ssrposefwd = let module M = Ser_genarg.GS0(A9) in M.genser
 
 module A10 = struct
-  type h1 = clause list * (ssrfwdfmt * ast_closure_term)
-  [@@deriving sexp]
+  type t = ssrocc * ssrterm
+  [@@deriving sexp,yojson,hash,compare]
 end
 
-let ser_wit_ssrwlogfwd = let open A10 in Ser_genarg.mk_uniform sexp_of_h1 h1_of_sexp
+let ser_wit_ssrunlockarg = let module M = Ser_genarg.GS0(A10) in M.genser
 
 module A11 = struct
-  type h1 = Names.Id.t * (ssrfwdfmt * ast_closure_term)
-  [@@deriving sexp]
+  type t = clause list * (ssrfwdfmt * ast_closure_term)
+  [@@deriving sexp,yojson,hash,compare]
 end
 
-let ser_wit_ssrfixfwd = let open A11 in Ser_genarg.mk_uniform sexp_of_h1 h1_of_sexp
+let ser_wit_ssrwlogfwd = let module M = Ser_genarg.GS0(A11) in M.genser
 
 module A12 = struct
-  type h1 = ssrfwdfmt * ast_closure_term
-  [@@deriving sexp]
+  type t = Names.Id.t * (ssrfwdfmt * ast_closure_term)
+  [@@deriving sexp,yojson,hash,compare]
 end
 
-let ser_wit_ssrfwd = let open A12 in Ser_genarg.mk_uniform sexp_of_h1 h1_of_sexp
+let ser_wit_ssrfixfwd = let module M = Ser_genarg.GS0(A12) in M.genser
+
+module A13 = struct
+  type t = ssrfwdfmt * ast_closure_term
+  [@@deriving sexp,yojson,hash,compare]
+end
+
+let ser_wit_ssrfwd = let module M = Ser_genarg.GS0(A13) in M.genser
+
+module A14 = struct
+  type t = cpattern ssragens
+  [@@deriving sexp,yojson,hash,compare]
+end
+
+let ser_wit_ssrdgens = let module M = Ser_genarg.GS0(A14) in M.genser
 
 let register () =
   let open Ser_genarg in
@@ -267,10 +235,10 @@ let register () =
      register_genser wit_ssrcofixfwd       ser_wit_ssrcofixfwd *)
 
   register_genser wit_ssrcongrarg ser_wit_ssrcongrarg;
-  register_genser wit_ssrcpat     (mk_uniform sexp_of_ssripat ssripat_of_sexp);
-  register_genser wit_ssrdgens    (mk_uniform (sexp_of_ssragens sexp_of_cpattern) (ssragens_of_sexp cpattern_of_sexp));
-  register_genser wit_ssrdgens_tl (mk_uniform (sexp_of_ssragens sexp_of_cpattern) (ssragens_of_sexp cpattern_of_sexp));
-  register_genser wit_ssrdir      (mk_uniform sexp_of_ssrdir ssrdir_of_sexp);
+  register_genser wit_ssrcpat     (mk_uniform sexp_of_ssripat ssripat_of_sexp hash_fold_ssripat compare_ssripat);
+  register_genser wit_ssrdgens    ser_wit_ssrdgens;
+  register_genser wit_ssrdgens_tl ser_wit_ssrdgens;
+  register_genser wit_ssrdir      (mk_uniform sexp_of_ssrdir ssrdir_of_sexp hash_fold_ssrdir compare_ssrdir);
   register_genser wit_ssrdoarg    ser_wit_ssrdoarg;
 (*
   Ssreflect_plugin.Ssrparser.wit_ssrdocc
@@ -279,8 +247,8 @@ let register () =
   register_genser wit_ssrexactarg ser_wit_ssrapplyarg;
   register_genser wit_ssrfixfwd   ser_wit_ssrfixfwd;
   register_genser wit_ssrfwd      ser_wit_ssrfwd;
-  register_genser wit_ssrfwdfmt   (mk_uniform sexp_of_ssrfwdfmt ssrfwdfmt_of_sexp);
-  register_genser wit_ssrfwdid    Ser_names.(mk_uniform Id.sexp_of_t Id.t_of_sexp);
+  register_genser wit_ssrfwdfmt   (mk_uniform sexp_of_ssrfwdfmt ssrfwdfmt_of_sexp hash_fold_ssrfwdfmt compare_ssrfwdfmt);
+  register_genser wit_ssrfwdid    (let module M = Ser_genarg.GS0(Ser_names.Id) in M.genser);
 
 (*
   Ssreflect_plugin.Ssrparser.wit_ssrfwdview
@@ -292,9 +260,9 @@ let register () =
   Ssreflect_plugin.Ssrparser.wit_ssrhoi_hyp
   Ssreflect_plugin.Ssrparser.wit_ssrhoi_id
 *)
-  register_genser wit_ssrhpats         (mk_uniform sexp_of_ssrhpats ssrhpats_of_sexp);
-  register_genser wit_ssrhpats_nobs    (mk_uniform sexp_of_ssrhpats ssrhpats_of_sexp);
-  register_genser wit_ssrhpats_wtransp (mk_uniform sexp_of_ssrhpats_wtransp ssrhpats_wtransp_of_sexp);
+  register_genser wit_ssrhpats         (mk_uniform sexp_of_ssrhpats ssrhpats_of_sexp hash_fold_ssrhpats compare_ssrhpats);
+  register_genser wit_ssrhpats_nobs    (mk_uniform sexp_of_ssrhpats ssrhpats_of_sexp hash_fold_ssrhpats compare_ssrhpats);
+  register_genser wit_ssrhpats_wtransp (mk_uniform sexp_of_ssrhpats_wtransp ssrhpats_wtransp_of_sexp hash_fold_ssrhpats_wtransp compare_ssrhpats_wtransp);
 
 (*
   Ssreflect_plugin.Ssrparser.wit_ssrhyp
@@ -324,7 +292,7 @@ let register () =
   Ssreflect_plugin.Ssrparser.wit_ssrpattern_ne_squarep
 *)
   register_genser wit_ssrposefwd ser_wit_ssrposefwd;
-  register_genser wit_ssrrpat    (mk_uniform sexp_of_ssripat ssripat_of_sexp);
+  register_genser wit_ssrrpat    (mk_uniform sexp_of_ssripat ssripat_of_sexp hash_fold_ssripat compare_ssripat);
 
 (*
   Ssreflect_plugin.Ssrparser.wit_ssrrule
@@ -336,7 +304,7 @@ let register () =
   *)
 
   register_genser wit_ssrseqarg ser_wit_ssrseqarg;
-  register_genser wit_ssrseqdir (mk_uniform sexp_of_ssrdir ssrdir_of_sexp);
+  register_genser wit_ssrseqdir (mk_uniform sexp_of_ssrdir ssrdir_of_sexp hash_fold_ssrdir compare_ssrdir);
   register_genser wit_ssrsetfwd ser_wit_ssrsetfwd;
 (*
   Ssreflect_plugin.Ssrparser.wit_ssrsimpl
@@ -348,10 +316,10 @@ let register () =
   register_genser wit_ssrtacarg Serlib_ltac.Ser_tacarg.ser_wit_tactic;
   register_genser wit_ssrtclarg Serlib_ltac.Ser_tacarg.ser_wit_tactic;
 
-  register_genser wit_ssrterm       (mk_uniform sexp_of_ssrterm ssrterm_of_sexp);
+  register_genser wit_ssrterm       (mk_uniform sexp_of_ssrterm ssrterm_of_sexp hash_fold_ssrterm compare_ssrterm);
   register_genser wit_ssrunlockarg  ser_wit_ssrunlockarg;
   register_genser wit_ssrunlockargs (gen_ser_list ser_wit_ssrunlockarg);
-  register_genser wit_ssrwgen       (mk_uniform sexp_of_clause clause_of_sexp);
+  register_genser wit_ssrwgen       (mk_uniform sexp_of_clause clause_of_sexp hash_fold_clause compare_clause);
   register_genser wit_ssrwlogfwd    ser_wit_ssrwlogfwd;
   ()
 

--- a/serlib/plugins/ssrmatching/dune
+++ b/serlib/plugins/ssrmatching/dune
@@ -2,5 +2,5 @@
  (name serlib_ssrmatching)
  (public_name coq-serapi.serlib.ssrmatching)
  (synopsis "Serialization Library for Coq [SSR Matching plugin]")
- (preprocess (staged_pps ppx_import ppx_sexp_conv))
+ (preprocess (staged_pps ppx_import ppx_sexp_conv ppx_deriving_yojson ppx_hash ppx_compare))
  (libraries coq-core.plugins.ssrmatching serlib serlib_ltac sexplib))

--- a/serlib/plugins/ssrmatching/ser_ssrmatching.ml
+++ b/serlib/plugins/ssrmatching/ser_ssrmatching.ml
@@ -14,34 +14,44 @@
 (************************************************************************)
 
 open Sexplib.Std
+open Ppx_hash_lib.Std.Hash.Builtin
+open Ppx_compare_lib.Builtin
+
 open Serlib
+
+module Genintern = Ser_genintern
+module Geninterp = Ser_geninterp
 
 type ssrtermkind =
   [%import: Ssrmatching_plugin.Ssrmatching.ssrtermkind]
-  [@@deriving sexp]
+  [@@deriving sexp,yojson,hash,compare]
 
 type cpattern =
   [%import: Ssrmatching_plugin.Ssrmatching.cpattern]
-
-(* XXX *)
-type _cpattern = char * Ser_genintern.glob_constr_and_expr * Ser_geninterp.interp_sign option
-  [@@deriving sexp]
-
-let cpattern_of_sexp o = Obj.magic (_cpattern_of_sexp o)
-let sexp_of_cpattern o = sexp_of__cpattern (Obj.magic o)
+  [@@deriving sexp,yojson,hash,compare]
 
 type ('a, 'b) ssrpattern =
   [%import: ('a, 'b) Ssrmatching_plugin.Ssrmatching.ssrpattern]
-  [@@deriving sexp]
+  [@@deriving sexp,yojson,hash,compare]
 
-type _rpattern = (cpattern, cpattern) ssrpattern
-  [@@deriving sexp]
+module PierceRPattern = struct
 
-type rpattern =
-  [%import: Ssrmatching_plugin.Ssrmatching.rpattern]
+  type t = Ssrmatching_plugin.Ssrmatching.rpattern
 
-let rpattern_of_sexp o = Obj.magic (_rpattern_of_sexp o)
-let sexp_of_rpattern o = sexp_of__rpattern (Obj.magic o)
+  type _t = (cpattern, cpattern) ssrpattern
+  [@@deriving sexp,yojson,hash,compare]
+end
+
+module B_ = SerType.Pierce(PierceRPattern)
+
+type rpattern = B_.t
+let sexp_of_rpattern = B_.sexp_of_t
+let rpattern_of_sexp = B_.t_of_sexp
+let rpattern_of_yojson = B_.of_yojson
+let rpattern_to_yojson = B_.to_yojson
+let hash_rpattern = B_.hash
+let hash_fold_rpattern = B_.hash_fold_t
+let compare_rpattern = B_.compare
 
 type ssrdir =
   [%import: Ssrmatching_plugin.Ssrmatching.ssrdir]

--- a/serlib/serType.ml
+++ b/serlib/serType.ml
@@ -45,3 +45,197 @@ module type SJ1 = sig
   val to_yojson : ('a -> Yojson.Safe.t) -> 'a t -> Yojson.Safe.t
 
 end
+
+module type SJH1 = sig
+
+  include SJ1
+
+  open Ppx_hash_lib.Std.Hash
+
+  val hash_fold_t : 'a folder -> 'a t folder
+
+end
+
+module type SJHC1 = sig
+
+  include SJH1
+
+  open Ppx_compare_lib
+
+  val compare : 'a compare -> 'a t compare
+
+end
+
+(* Bijection with serializable types *)
+module type Bijectable = sig
+
+  (* Base Type *)
+  type t
+
+  (* Representation type *)
+  type _t [@@deriving sexp,yojson,hash,compare]
+
+  (* Need to be bijetive *)
+  val to_t : _t -> t
+  val of_t : t -> _t
+
+end
+
+module Biject(M : Bijectable) : SJHC with type t = M.t = struct
+
+  type t = M.t
+
+  let sexp_of_t x = M.sexp_of__t (M.of_t x)
+  let t_of_sexp s = M.to_t (M._t_of_sexp s)
+
+  let to_yojson p = M._t_to_yojson (M.of_t p)
+  let of_yojson p = M._t_of_yojson p |> Result.map M.to_t
+
+  let hash x = M.hash__t (M.of_t x)
+  let hash_fold_t st x = M.hash_fold__t st (M.of_t x)
+
+  let compare x1 x2 = M.compare__t (M.of_t x1) (M.of_t x2)
+end
+
+(* Bijection with serializable types *)
+module type Bijectable1 = sig
+
+  (* Base Type *)
+  type 'a t
+
+  (* Representation type *)
+  type 'a _t [@@deriving sexp,yojson,hash,compare]
+
+  (* Need to be bijetive *)
+  val to_t : 'a _t -> 'a t
+  val of_t : 'a t -> 'a _t
+
+end
+
+module Biject1(M : Bijectable1) : SJHC1 with type 'a t = 'a M.t = struct
+
+  type 'a t = 'a M.t
+
+  let sexp_of_t f x = M.sexp_of__t f (M.of_t x)
+  let t_of_sexp f s = M.to_t (M._t_of_sexp f s)
+
+  let to_yojson f p = M._t_to_yojson f (M.of_t p)
+  let of_yojson f p = M._t_of_yojson f p |> Result.map M.to_t
+
+  let hash_fold_t f st x = M.hash_fold__t f st (M.of_t x)
+
+  let compare f x1 x2 = M.compare__t f (M.of_t x1) (M.of_t x2)
+end
+
+(* We do our own alias as to have better control *)
+let _sercast = Obj.magic
+
+(* Obj.magic piercing *)
+module type Pierceable = sig
+
+  (* Type to pierce *)
+  type t
+
+  (* Representation type *)
+  type _t [@@deriving sexp,yojson,hash,compare]
+end
+
+module type Pierceable1 = sig
+
+  (* Type to pierce *)
+  type 'a t
+
+  (* Representation type *)
+  type 'a _t [@@deriving sexp,yojson,hash,compare]
+end
+
+module Pierce(M : Pierceable) : SJHC with type t = M.t = struct
+
+  type t = M.t
+
+  let sexp_of_t x = M.sexp_of__t (_sercast x)
+  let t_of_sexp s = _sercast (M._t_of_sexp s)
+
+  let to_yojson p = M._t_to_yojson (_sercast p)
+  let of_yojson p = M._t_of_yojson p |> Result.map _sercast
+
+  let hash x = M.hash__t (_sercast x)
+  let hash_fold_t st x = M.hash_fold__t st (_sercast x)
+
+  let compare x1 x2 = M.compare__t (_sercast x1) (_sercast x2)
+
+end
+
+module Pierce1(M : Pierceable1) : SJHC1 with type 'a t = 'a M.t = struct
+
+  type 'a t = 'a M.t
+
+  let sexp_of_t f x = M.sexp_of__t f (_sercast x)
+  let t_of_sexp f s = _sercast (M._t_of_sexp f s)
+
+  let to_yojson f p = M._t_to_yojson f (_sercast p)
+  let of_yojson f p = M._t_of_yojson f p |> Result.map _sercast
+
+  (* let hash x = M.hash__t (_sercast x) *)
+  let hash_fold_t f st x = M.hash_fold__t f st (_sercast x)
+
+  let compare f x1 x2 = M.compare__t f (_sercast x1) (_sercast x2)
+
+end
+
+(* Unfortunately this doesn't really work for types that are named as
+   the functions would have to be sexp_of_name etc... Maybe fixme in
+   the future *)
+module PierceAlt(M : Pierceable) : SJHC with type t := M.t = struct
+
+  let sexp_of_t x = M.sexp_of__t (_sercast x)
+  let t_of_sexp s = _sercast (M._t_of_sexp s)
+
+  let to_yojson p = M._t_to_yojson (_sercast p)
+  let of_yojson p = M._t_of_yojson p |> Result.map _sercast
+
+  let hash x = M.hash__t (_sercast x)
+  let hash_fold_t st x = M.hash_fold__t st (_sercast x)
+
+  let compare x1 x2 = M.compare__t (_sercast x1) (_sercast x2)
+
+end
+
+module type OpaqueDesc = sig type t val name : string end
+
+module Opaque(M : OpaqueDesc) : SJHC with type t = M.t = struct
+
+  type t = M.t
+  let typ = M.name
+
+  let sexp_of_t x = Serlib_base.sexp_of_opaque ~typ x
+  let t_of_sexp s = Serlib_base.opaque_of_sexp ~typ s
+
+  let to_yojson p = Serlib_base.opaque_to_yojson ~typ p
+  let of_yojson p = Serlib_base.opaque_of_yojson ~typ p
+
+  let hash x = Serlib_base.hash_opaque ~typ x
+  let hash_fold_t st x = Serlib_base.hash_fold_opaque ~typ st x
+
+  let compare x1 x2 = Serlib_base.compare_opaque ~typ x1 x2
+
+end
+
+module type OpaqueDesc1 = sig type 'a t val name : string end
+
+module Opaque1(M : OpaqueDesc1) : SJHC1 with type 'a t = 'a M.t = struct
+
+  type 'a  t = 'a M.t
+  let typ = M.name
+
+  let sexp_of_t _ x = Serlib_base.sexp_of_opaque ~typ x
+  let t_of_sexp _ s = Serlib_base.opaque_of_sexp ~typ s
+
+  let to_yojson _ p = Serlib_base.opaque_to_yojson ~typ p
+  let of_yojson _ p = Serlib_base.opaque_of_yojson ~typ p
+
+  let hash_fold_t _ st x = Serlib_base.hash_fold_opaque ~typ st x
+
+  let compare _ x1 x2 = Serlib_base.compare_opaque ~typ x1 x2
+
+end

--- a/serlib/ser_cEphemeron.ml
+++ b/serlib/ser_cEphemeron.ml
@@ -15,5 +15,20 @@
 
 type 'a key = 'a CEphemeron.key
 
-let key_of_sexp f x = CEphemeron.create (f x)
-let sexp_of_key f v = f CEphemeron.(get v)
+module EBiject = struct
+  type 'a t = 'a CEphemeron.key
+
+  type 'a _t = 'a [@@deriving sexp,yojson,hash,compare]
+
+  let to_t x = CEphemeron.create x
+  let of_t x = CEphemeron.get x
+end
+
+module B = SerType.Biject1(EBiject)
+
+let sexp_of_key = B.sexp_of_t
+let key_of_sexp = B.t_of_sexp
+let key_of_yojson = B.of_yojson
+let key_to_yojson = B.to_yojson
+let hash_fold_key = B.hash_fold_t
+let compare_key = B.compare

--- a/serlib/ser_cMap.mli
+++ b/serlib/ser_cMap.mli
@@ -20,13 +20,11 @@ module type ExtS = sig
 
   include CSig.MapS
 
-  (* module SSet : Ser_cSet.ExtS *)
-
-  include SerType.S1 with type 'a t := 'a t
+  include SerType.SJHC1 with type 'a t := 'a t
 
 end
 
-module Make (M : CSig.MapS) (S : SerType.S with type t := M.key)
+module Make (M : CSig.MapS) (S : SerType.SJHC with type t = M.key)
   : ExtS
     with type key = M.key
      and type 'a t = 'a M.t

--- a/serlib/ser_cPrimitives.ml
+++ b/serlib/ser_cPrimitives.ml
@@ -13,14 +13,14 @@
 (* Status: Very Experimental                                            *)
 (************************************************************************)
 
-open Ppx_hash_lib.Std.Hash.Builtin
-open Ppx_compare_lib.Builtin
 open Sexplib
 open Sexplib.Std
+open Ppx_hash_lib.Std.Hash.Builtin
+open Ppx_compare_lib.Builtin
 
 type t =
   [%import: CPrimitives.t]
-  [@@deriving sexp,yojson,hash]
+  [@@deriving sexp,yojson,hash,compare]
 
 type const =
   [%import: CPrimitives.const]

--- a/serlib/ser_cSet.mli
+++ b/serlib/ser_cSet.mli
@@ -20,25 +20,11 @@ module type ExtS = sig
 
   include CSig.SetS
 
-  include SerType.S with type t := t
+  include SerType.SJHC with type t := t
 
 end
 
-module Make (M : CSig.SetS) (S : SerType.S with type t := M.elt)
+module Make (M : CSig.SetS) (S : SerType.SJHC with type t = M.elt)
   : ExtS
     with type t = M.t
      and type elt = M.elt
-
-module type ExtSJ = sig
-
-  include CSig.SetS
-
-  include SerType.SJ with type t := t
-
-end
-
-module MakeJ (M : CSig.SetS) (S : SerType.SJ with type t := M.elt)
-  : ExtSJ
-    with type t = M.t
-     and type elt = M.elt
-

--- a/serlib/ser_class_tactics.ml
+++ b/serlib/ser_class_tactics.ml
@@ -15,4 +15,4 @@
 
 type search_strategy =
   [%import: Class_tactics.search_strategy]
-  [@@deriving sexp]
+  [@@deriving sexp,hash,compare]

--- a/serlib/ser_class_tactics.mli
+++ b/serlib/ser_class_tactics.mli
@@ -13,8 +13,4 @@
 (* Status: Very Experimental                                            *)
 (************************************************************************)
 
-open Sexplib
-type search_strategy = Class_tactics.search_strategy
-
-val search_strategy_of_sexp : Sexp.t -> search_strategy
-val sexp_of_search_strategy : search_strategy -> Sexp.t
+type search_strategy = Class_tactics.search_strategy [@@deriving sexp,hash,compare]

--- a/serlib/ser_constr.ml
+++ b/serlib/ser_constr.ml
@@ -21,8 +21,11 @@
    need to recurse throu the constr to build the clone.
 *)
 
-open Sexplib
 open Sexplib.Std
+open Ppx_compare_lib.Builtin
+open Ppx_hash_lib.Std.Hash.Builtin
+
+let hash_fold_array = hash_fold_array_frozen
 
 module Names   = Ser_names
 module Sorts   = Ser_sorts
@@ -34,19 +37,19 @@ module Float64 = Ser_float64
 
 type metavariable =
   [%import: Constr.metavariable]
-  [@@deriving sexp, yojson]
+  [@@deriving sexp, yojson, hash, compare]
 
 type pconstant =
   [%import: Constr.pconstant]
-  [@@deriving sexp, yojson]
+  [@@deriving sexp, yojson, hash, compare]
 
 type pinductive =
   [%import: Constr.pinductive]
-  [@@deriving sexp, yojson]
+  [@@deriving sexp, yojson, hash, compare]
 
 type pconstructor =
   [%import: Constr.pconstructor]
-  [@@deriving sexp, yojson]
+  [@@deriving sexp, yojson, hash, compare]
 
 type cast_kind =
   [%import: Constr.cast_kind]
@@ -58,34 +61,34 @@ type case_style =
 
 type case_printing =
   [%import: Constr.case_printing]
-  [@@deriving sexp,yojson]
+  [@@deriving sexp,yojson,hash,compare]
 
 type case_info =
   [%import: Constr.case_info]
-  [@@deriving sexp,yojson]
+  [@@deriving sexp,yojson, hash, compare]
 
 type 'constr pexistential =
   [%import: 'constr Constr.pexistential]
-  [@@deriving sexp,yojson]
+  [@@deriving sexp,yojson,hash,compare]
 
 type ('constr, 'types) prec_declaration =
   [%import: ('constr, 'types) Constr.prec_declaration]
-  [@@deriving sexp,yojson]
+  [@@deriving sexp,yojson,hash,compare]
 
 type ('constr, 'types) pfixpoint =
   [%import: ('constr, 'types) Constr.pfixpoint]
-  [@@deriving sexp,yojson]
+  [@@deriving sexp,yojson,hash,compare]
 
 type ('constr, 'types) pcofixpoint =
   [%import: ('constr, 'types) Constr.pcofixpoint]
-  [@@deriving sexp,yojson]
+  [@@deriving sexp,yojson,hash,compare]
 
 type constr = Constr.constr
 type types  = Constr.constr
 
 type 'constr pcase_invert =
   [%import: 'constr Constr.pcase_invert]
-  [@@deriving sexp,yojson]
+  [@@deriving sexp,yojson,hash,compare]
 
 let map_pcase_invert f = function
   | NoInvert -> NoInvert
@@ -94,13 +97,13 @@ let map_pcase_invert f = function
 
 type 'constr pcase_branch =
   [%import: 'constr Constr.pcase_branch]
-  [@@deriving sexp,yojson]
+  [@@deriving sexp,yojson,hash,compare]
 
 let map_pcase_branch f (bi, c) = (bi, f c)
 
 type 'types pcase_return =
   [%import: 'types Constr.pcase_return]
-  [@@deriving sexp,yojson]
+  [@@deriving sexp,yojson,hash,compare]
 
 let map_pcase_return f (bi, c) = (bi, f c)
 
@@ -125,7 +128,7 @@ type _constr =
   | Int       of Uint63.t
   | Float     of Float64.t
   | Array     of Univ.Instance.t * _constr array * _constr * _constr
-[@@deriving sexp,yojson]
+[@@deriving sexp,yojson,hash,compare]
 
 let rec _constr_put (c : constr) : _constr =
   let cr  = _constr_put           in
@@ -189,28 +192,46 @@ let rec _constr_get (c : _constr) : constr =
   | Float f             -> C.mkFloat f
   | Array (u,a,e,t)     -> C.mkArray(u, cra a, cr e, cr t)
 
-let constr_of_sexp (c : Sexp.t) : constr =
-  _constr_get (_constr_of_sexp c)
+module ConstrBij = struct
 
-let sexp_of_constr (c : constr) : Sexp.t =
-  sexp_of__constr (_constr_put c)
+  type t = constr
 
-let constr_of_yojson json = Ppx_deriving_yojson_runtime.(_constr_of_yojson json >|= _constr_get)
-let constr_to_yojson level = _constr_to_yojson (_constr_put level)
+  type _t = _constr
+  [@@deriving sexp,yojson,hash,compare]
 
-let types_of_sexp = constr_of_sexp
-let sexp_of_types = sexp_of_constr
+  let to_t = _constr_get
+  let of_t = _constr_put
 
-let types_of_yojson = constr_of_yojson
-let types_to_yojson = constr_to_yojson
+end
+
+module CC = SerType.Biject(ConstrBij)
+
+(* type constr = CC.t *)
+let sexp_of_constr = CC.sexp_of_t
+let constr_of_sexp = CC.t_of_sexp
+let constr_of_yojson = CC.of_yojson
+let constr_to_yojson = CC.to_yojson
+let hash_constr = CC.hash
+let hash_fold_constr = CC.hash_fold_t
+let compare_constr = CC.compare
+
+let sexp_of_types = CC.sexp_of_t
+let types_of_sexp = CC.t_of_sexp
+let types_of_yojson = CC.of_yojson
+let types_to_yojson = CC.to_yojson
+let hash_types = CC.hash
+let hash_fold_types = CC.hash_fold_t
+let compare_types = CC.compare
 
 type t = constr
 
 let t_of_sexp = constr_of_sexp
 let sexp_of_t = sexp_of_constr
-
 let of_yojson = constr_of_yojson
 let to_yojson = constr_to_yojson
+let hash = hash_constr
+let hash_fold_t = hash_fold_constr
+let compare = compare_constr
 
 type case_invert =
   [%import: Constr.case_invert]
@@ -238,16 +259,16 @@ let sexp_of_sorts_family = Sorts.sexp_of_family
 
 type named_declaration =
   [%import: Constr.named_declaration]
-  [@@deriving sexp]
+  [@@deriving sexp,yojson,hash,compare]
 
 type named_context =
   [%import: Constr.named_context]
-  [@@deriving sexp]
+  [@@deriving sexp,yojson,hash,compare]
 
 type rel_declaration =
   [%import: Constr.rel_declaration]
-  [@@deriving sexp]
+  [@@deriving sexp,yojson,hash,compare]
 
 type rel_context =
   [%import: Constr.rel_context]
-  [@@deriving sexp]
+  [@@deriving sexp,yojson,hash,compare]

--- a/serlib/ser_constr.mli
+++ b/serlib/ser_constr.mli
@@ -65,9 +65,7 @@ val cofixpoint_of_sexp : Sexp.t -> cofixpoint
 val sexp_of_cofixpoint : cofixpoint -> Sexp.t
 
 type 'constr pexistential = 'constr Constr.pexistential
-
-val pexistential_of_sexp : (Sexp.t -> 'constr) -> Sexp.t -> 'constr pexistential
-val sexp_of_pexistential : ('constr -> Sexp.t) -> 'constr pexistential -> Sexp.t
+  [@@deriving sexp, yojson, hash, compare]
 
 type ('constr, 'types) prec_declaration = ('constr, 'types) Constr.prec_declaration
 
@@ -99,27 +97,13 @@ val sexp_of_pcofixpoint :
   ('constr, 'types) pcofixpoint -> Sexp.t
 
 type t = Constr.t
-
-val t_of_sexp : Sexp.t -> t
-val sexp_of_t : t -> Sexp.t
-
-val of_yojson : Yojson.Safe.t -> (t, string) Result.result
-val to_yojson : t -> Yojson.Safe.t
+  [@@deriving sexp,yojson,hash,compare]
 
 type constr = t
-
-val constr_of_sexp : Sexp.t -> constr
-val sexp_of_constr : constr -> Sexp.t
-
-val constr_of_yojson : Yojson.Safe.t -> (constr, string) Result.result
-val constr_to_yojson : constr -> Yojson.Safe.t
+  [@@deriving sexp,yojson,hash,compare]
 
 type types  = constr
-val types_of_sexp : Sexp.t -> types
-val sexp_of_types : types -> Sexp.t
-
-val types_of_yojson : Yojson.Safe.t -> (types, string) Result.result
-val types_to_yojson : types -> Yojson.Safe.t
+  [@@deriving sexp,yojson,hash,compare]
 
 type existential = Constr.existential
 val existential_of_sexp : Sexp.t -> existential
@@ -134,13 +118,11 @@ val named_declaration_of_sexp : Sexp.t -> named_declaration
 val sexp_of_named_declaration : named_declaration -> Sexp.t
 
 type named_context = Constr.named_context
-val named_context_of_sexp : Sexp.t -> named_context
-val sexp_of_named_context : named_context -> Sexp.t
+  [@@deriving sexp,yojson,hash,compare]
 
 type rel_declaration = Constr.rel_declaration
 val rel_declaration_of_sexp : Sexp.t -> rel_declaration
 val sexp_of_rel_declaration : rel_declaration -> Sexp.t
 
 type rel_context = Constr.rel_context
-val rel_context_of_sexp : Sexp.t -> rel_context
-val sexp_of_rel_context : rel_context -> Sexp.t
+  [@@deriving sexp,yojson,hash,compare]

--- a/serlib/ser_context.ml
+++ b/serlib/ser_context.ml
@@ -14,14 +14,16 @@
 (* Status: Very Experimental                                            *)
 (************************************************************************)
 
-open Sexplib.Conv
+open Sexplib.Std
+open Ppx_hash_lib.Std.Hash.Builtin
+open Ppx_compare_lib.Builtin
 
 module Names   = Ser_names
 module Sorts   = Ser_sorts
 
 type 'a binder_annot =
   [%import: 'a Context.binder_annot]
-  [@@deriving sexp,yojson]
+  [@@deriving sexp,yojson,hash,compare]
 
 module Rel = struct
 
@@ -29,13 +31,14 @@ module Rel = struct
 
   type ('constr, 'types) pt =
     [%import: ('constr, 'types) Context.Rel.Declaration.pt]
-    [@@deriving sexp]
+    [@@deriving sexp,yojson,hash,compare]
+
 
   end
 
   type ('constr, 'types) pt =
     [%import: ('constr, 'types) Context.Rel.pt]
-    [@@deriving sexp]
+    [@@deriving sexp,yojson,hash,compare]
 
 end
 
@@ -45,13 +48,13 @@ module Named = struct
 
   type ('constr, 'types) pt =
     [%import: ('constr, 'types) Context.Named.Declaration.pt]
-    [@@deriving sexp]
+    [@@deriving sexp,yojson,hash,compare]
 
   end
 
   type ('constr, 'types) pt =
     [%import: ('constr, 'types) Context.Named.pt]
-    [@@deriving sexp]
+    [@@deriving sexp,yojson,hash,compare]
 
 end
 

--- a/serlib/ser_context.mli
+++ b/serlib/ser_context.mli
@@ -17,25 +17,18 @@
 open Sexplib
 
 type 'a binder_annot = 'a Context.binder_annot
-val binder_annot_of_sexp : (Sexp.t -> 'a) -> Sexp.t -> 'a binder_annot
-val sexp_of_binder_annot : ('a -> Sexp.t) -> 'a binder_annot -> Sexp.t
-
-val binder_annot_of_yojson : (Yojson.Safe.t -> ('a, string) Result.result) -> Yojson.Safe.t -> ('a binder_annot, string) Result.result
-val binder_annot_to_yojson : ('a -> Yojson.Safe.t) -> 'a binder_annot -> Yojson.Safe.t
-
+  [@@deriving sexp,yojson,hash,compare]
 
 module Rel : sig
   module Declaration : sig
 
     type ('c,'t) pt = ('c,'t) Context.Rel.Declaration.pt
-    val pt_of_sexp : (Sexp.t -> 'c) -> (Sexp.t -> 't) -> Sexp.t -> ('c,'t) pt
-    val sexp_of_pt : ('c -> Sexp.t) -> ('t -> Sexp.t) -> ('c,'t) pt -> Sexp.t
+     [@@deriving sexp,yojson,hash,compare]
 
   end
 
   type ('c, 't) pt = ('c,'t) Context.Rel.pt
-  val pt_of_sexp : (Sexp.t -> 'c) -> (Sexp.t -> 't) -> Sexp.t -> ('c,'t) pt
-  val sexp_of_pt : ('c -> Sexp.t) -> ('t -> Sexp.t) -> ('c,'t) pt -> Sexp.t
+   [@@deriving sexp,yojson,hash,compare]
 
 end
 
@@ -44,14 +37,12 @@ module Named : sig
   module Declaration : sig
 
     type ('c, 't) pt = ('c, 't) Context.Named.Declaration.pt
-    val pt_of_sexp : (Sexp.t -> 'c) -> (Sexp.t -> 't) -> Sexp.t -> ('c,'t) pt
-    val sexp_of_pt : ('c -> Sexp.t) -> ('t -> Sexp.t) -> ('c,'t) pt -> Sexp.t
+     [@@deriving sexp,yojson,hash,compare]
 
   end
 
   type ('c, 't) pt = ('c, 't) Context.Named.pt
-  val pt_of_sexp : (Sexp.t -> 'c) -> (Sexp.t -> 't) -> Sexp.t -> ('c,'t) pt
-  val sexp_of_pt : ('c -> Sexp.t) -> ('t -> Sexp.t) -> ('c,'t) pt -> Sexp.t
+   [@@deriving sexp,yojson,hash,compare]
 
 end
 

--- a/serlib/ser_conv_oracle.ml
+++ b/serlib/ser_conv_oracle.ml
@@ -21,11 +21,18 @@ type level =
   [%import: Conv_oracle.level]
   [@@deriving sexp,yojson,hash,compare]
 
-(* XXX: Fixme *)
-type oracle =
-  [%import: Conv_oracle.oracle]
+module OpaqueOracle = struct
+  type t = Conv_oracle.oracle
+  let name = "Conv_oracle.oracle"
+end
 
-let sexp_of_oracle _ =
-  Sexplib.Sexp.(Atom "[Conv_oracle.oracle: Abstract]")
+module B = SerType.Opaque(OpaqueOracle)
 
-let oracle_of_sexp _ = Conv_oracle.empty
+type oracle = B.t
+let sexp_of_oracle = B.sexp_of_t
+let oracle_of_sexp = B.t_of_sexp
+let oracle_of_yojson = B.of_yojson
+let oracle_to_yojson = B.to_yojson
+let hash_oracle = B.hash
+let hash_fold_oracle = B.hash_fold_t
+let compare_oracle = B.compare

--- a/serlib/ser_conv_oracle.mli
+++ b/serlib/ser_conv_oracle.mli
@@ -13,10 +13,5 @@
 (* Status: Very Experimental                                            *)
 (************************************************************************)
 
-open Sexplib
-
 type level = Conv_oracle.level [@@deriving sexp,yojson,hash,compare]
-
-type oracle = Conv_oracle.oracle
-val oracle_of_sexp : Sexp.t -> oracle
-val sexp_of_oracle : oracle -> Sexp.t
+type oracle = Conv_oracle.oracle [@@deriving sexp,yojson,hash,compare]

--- a/serlib/ser_cooking.ml
+++ b/serlib/ser_cooking.ml
@@ -17,6 +17,8 @@
 (************************************************************************)
 
 open Sexplib.Std
+open Ppx_hash_lib.Std.Hash.Builtin
+open Ppx_compare_lib.Builtin
 
 module Names = Ser_names
 module Univ = Ser_univ
@@ -26,24 +28,34 @@ type abstr_info = {
   abstr_ctx : Constr.named_context;
   abstr_auctx : Univ.AbstractContext.t;
   abstr_ausubst : Univ.Instance.t;
-} [@@deriving sexp]
+} [@@deriving sexp,yojson,hash,compare]
 
 type abstr_inst_info = {
   abstr_rev_inst : Names.Id.t list;
   abstr_uinst : Univ.Instance.t;
-} [@@deriving sexp]
+} [@@deriving sexp,yojson,hash,compare]
 
-type 'a entry_map = 'a Names.Cmap.t * 'a Names.Mindmap.t [@@deriving sexp]
-type expand_info = abstr_inst_info entry_map [@@deriving sexp]
+type 'a entry_map = 'a Names.Cmap.t * 'a Names.Mindmap.t [@@deriving sexp,yojson,hash,compare]
+type expand_info = abstr_inst_info entry_map [@@deriving sexp,yojson,hash,compare]
 
-type _cooking_info = {
+module CIP = struct
+type _t = {
   expand_info : expand_info;
   abstr_info : abstr_info;
-} [@@deriving sexp]
+} [@@deriving sexp,yojson,hash,compare]
 
-type cooking_info =
+type t =
   [%import: Cooking.cooking_info]
+end
 
-let sexp_of_cooking_info ci = sexp_of__cooking_info (Obj.magic ci)
-let cooking_info_of_sexp se = Obj.magic (_cooking_info_of_sexp se)
+module B_ = SerType.Pierce(CIP)
+
+type cooking_info = B_.t
+let sexp_of_cooking_info = B_.sexp_of_t
+let cooking_info_of_sexp = B_.t_of_sexp
+let cooking_info_of_yojson = B_.of_yojson
+let cooking_info_to_yojson = B_.to_yojson
+let hash_cooking_info = B_.hash
+let hash_fold_cooking_info = B_.hash_fold_t
+let compare_cooking_info = B_.compare
 

--- a/serlib/ser_cooking.mli
+++ b/serlib/ser_cooking.mli
@@ -16,9 +16,4 @@
 (* Status: Very Experimental                                            *)
 (************************************************************************)
 
-open Sexplib
-
-type cooking_info = Cooking.cooking_info
-
-val cooking_info_of_sexp : Sexp.t -> cooking_info
-val sexp_of_cooking_info : cooking_info -> Sexp.t
+type cooking_info = Cooking.cooking_info [@@deriving sexp,yojson,hash,compare]

--- a/serlib/ser_dAst.ml
+++ b/serlib/ser_dAst.ml
@@ -19,7 +19,8 @@ open Sexplib
 
 module CAst = Ser_cAst
 
-type ('a, 'b) thunk = [%import: ('a,'b) DAst.thunk]
+type ('a, 'b) thunk =
+  [%import: ('a,'b) DAst.thunk]
 
 let sexp_of_thunk : type a b. (a -> Sexp.t) -> (b -> Sexp.t) -> (a,b) thunk -> Sexp.t =
   fun f _ t -> match t with
@@ -29,6 +30,31 @@ let sexp_of_thunk : type a b. (a -> Sexp.t) -> (b -> Sexp.t) -> (a,b) thunk -> S
 let thunk_of_sexp : type a b. (Sexp.t -> a) -> (Sexp.t -> b) -> Sexp.t -> (a,b) thunk =
   fun f _ s -> Value (f s)
 
+let thunk_of_yojson : type a b. (Yojson.Safe.t -> (a, string) Result.result) -> (Yojson.Safe.t -> (b, string) Result.result) -> Yojson.Safe.t -> ((a,b) thunk, string) Result.result =
+  fun f _ s -> Result.map (fun s -> Value s) (f s)
+
+let thunk_to_yojson : type a b. (a -> Yojson.Safe.t) -> (b -> Yojson.Safe.t) -> (a,b) thunk -> Yojson.Safe.t =
+  fun f _ t -> match t with
+  | Value v -> f v
+  | Thunk t -> f (Lazy.force t)
+
+let _hash : type a b. (a -> int) -> (b -> int) -> (a,b) thunk -> int =
+  fun f _ t -> match t with
+  | Value v -> f v
+  | Thunk t -> f (Lazy.force t)
+
+let hash_fold_thunk : type a b. (a Ppx_hash_lib.Std.Hash.folder) -> (b Ppx_hash_lib.Std.Hash.folder) -> (a,b) thunk Ppx_hash_lib.Std.Hash.folder =
+    fun f _ st t -> match t with
+  | Value v -> f st v
+  | Thunk t -> f st (Lazy.force t)
+
+let compare_thunk : type a b. (a Ppx_compare_lib.compare) -> (b Ppx_compare_lib.compare) -> (a,b) thunk Ppx_compare_lib.compare =
+  fun f _ t1 t2 -> match t1,t2 with
+  | Value v1, Value v2 -> f v1 v2
+  | Thunk t1, Value v2 -> f (Lazy.force t1) v2
+  | Value v1, Thunk t2 -> f v1 (Lazy.force t2)
+  | Thunk t1, Thunk t2 -> f (Lazy.force t1) (Lazy.force t2)
+
 type ('a, 'b) t =
   [%import: ('a, 'b) DAst.t]
-  [@@deriving sexp]
+  [@@deriving sexp,yojson,hash,compare]

--- a/serlib/ser_dAst.mli
+++ b/serlib/ser_dAst.mli
@@ -1,7 +1,3 @@
-open Sexplib
-
 type ('a, 'b) t = ('a,'b) DAst.t
-
-val sexp_of_t : ('a -> Sexp.t) -> ('b -> Sexp.t) -> ('a, 'b) DAst.t -> Sexp.t
-val t_of_sexp : (Sexp.t -> 'a) -> (Sexp.t -> 'b) -> Sexp.t -> ('a, 'b) DAst.t
+  [@@deriving sexp,yojson,hash,compare]
 

--- a/serlib/ser_declarations.ml
+++ b/serlib/ser_declarations.ml
@@ -14,8 +14,10 @@
 (* Status: Very Experimental                                            *)
 (************************************************************************)
 
-open Sexplib.Conv
-open Declarations
+open Sexplib.Std
+open Ppx_hash_lib.Std.Hash.Builtin
+open Ppx_compare_lib.Builtin
+let hash_fold_array = hash_fold_array_frozen
 
 module Rtree   = Ser_rtree
 module Names   = Ser_names
@@ -33,36 +35,36 @@ module Retroknowledge = Ser_retroknowledge
 
 type template_arity =
   [%import: Declarations.template_arity]
-  [@@deriving sexp]
+  [@@deriving sexp,yojson,hash,compare]
 
 type ('a, 'b) declaration_arity =
   [%import: ('a, 'b) Declarations.declaration_arity]
-  [@@deriving sexp]
+  [@@deriving sexp,yojson,hash,compare]
 
 type nested_type =
   [%import: Declarations.nested_type]
-  [@@deriving sexp]
+  [@@deriving sexp,yojson,hash,compare]
 
 type recarg =
   [%import: Declarations.recarg]
-  [@@deriving sexp]
+  [@@deriving sexp,yojson,hash,compare]
 
 type wf_paths =
   [%import: Declarations.wf_paths]
-  [@@deriving sexp]
+  [@@deriving sexp,yojson,hash,compare]
 
 type regular_inductive_arity =
   [%import: Declarations.regular_inductive_arity
   [@with Term.sorts := Sorts.t;]]
-  [@@deriving sexp]
+  [@@deriving sexp,yojson,hash,compare]
 
 type inductive_arity =
   [%import: Declarations.inductive_arity]
-  [@@deriving sexp]
+  [@@deriving sexp,yojson,hash,compare]
 
 type one_inductive_body =
   [%import: Declarations.one_inductive_body]
-  [@@deriving sexp]
+  [@@deriving sexp,yojson,hash,compare]
 
 (* type set_predicativity =
  *   [%import: Declarations.set_predicativity]
@@ -74,19 +76,19 @@ type one_inductive_body =
 
 type inline =
   [%import: Declarations.inline]
-  [@@deriving sexp]
+  [@@deriving sexp,yojson,hash,compare]
 
 type universes =
   [%import: Declarations.universes]
-  [@@deriving sexp]
+  [@@deriving sexp,yojson,hash,compare]
 
 type ('a, 'b) constant_def =
   [%import: ('a, 'b) Declarations.constant_def]
-  [@@deriving sexp]
+  [@@deriving sexp,yojson,hash,compare]
 
 type typing_flags =
   [%import: Declarations.typing_flags]
-  [@@deriving sexp]
+  [@@deriving sexp,yojson,hash,compare]
 
 (* type work_list =
  *   [%import: Declarations.work_list]
@@ -102,84 +104,88 @@ type typing_flags =
 
 type 'a pconstant_body =
   [%import: 'a Declarations.pconstant_body]
-  [@@deriving sexp]
+  [@@deriving sexp,yojson,hash,compare]
 
 type constant_body =
   [%import: Declarations.constant_body]
-  [@@deriving sexp]
+  [@@deriving sexp,yojson,hash,compare]
 
 let sexp_of_constant_body e =
   (* We cannot handle VM values *)
   sexp_of_constant_body { e with const_body_code = None }
 
-(* XXX: At least one serializer can be done *)
-let sexp_of_module_retroknowledge _ =
-  Serlib_base.sexp_of_opaque ~typ:"Declarations.module_retroknowledge"
+module MRK = struct
+  type 'a t = 'a Declarations.module_retroknowledge
+  let name = "Declarations.module_retroknowledge"
+end
 
-let module_retroknowledge_of_sexp _ =
-  Serlib_base.opaque_of_sexp ~typ:"Declarations.module_retroknowledge"
+module B_ = SerType.Opaque1(MRK)
 
-(* type abstract_inductive_universes =
- *   [%import: Declarations.abstract_inductive_universes]
- *   [@@deriving sexp] *)
+type 'a module_retroknowledge = 'a B_.t
+let sexp_of_module_retroknowledge = B_.sexp_of_t
+let module_retroknowledge_of_sexp = B_.t_of_sexp
+let module_retroknowledge_of_yojson = B_.of_yojson
+let module_retroknowledge_to_yojson = B_.to_yojson
+let hash_fold_module_retroknowledge = B_.hash_fold_t
+let compare_module_retroknowledge = B_.compare
 
 type recursivity_kind =
   [%import: Declarations.recursivity_kind]
-  [@@deriving sexp,yojson]
+  [@@deriving sexp,yojson,hash,compare]
 
 type record_info =
   [%import: Declarations.record_info]
-  [@@deriving sexp]
+  [@@deriving sexp,yojson,hash,compare]
 
 type template_universes =
   [%import: Declarations.template_universes]
-  [@@deriving sexp,yojson]
+  [@@deriving sexp,yojson,hash,compare]
 
 type mutual_inductive_body =
   [%import: Declarations.mutual_inductive_body
   [@with Context.section_context := Context.Named.t;]]
-  [@@deriving sexp]
+  [@@deriving sexp,yojson,hash,compare]
 
 type ('ty,'a) functorize =
   [%import: ('ty, 'a) Declarations.functorize]
-  [@@deriving sexp]
+  [@@deriving sexp,yojson,hash,compare]
 
 type 'a with_declaration =
   [%import: 'a Declarations.with_declaration]
-  [@@deriving sexp]
+  [@@deriving sexp,yojson,hash,compare]
 
 type 'a module_alg_expr =
   [%import: 'a Declarations.module_alg_expr]
-  [@@deriving sexp]
+  [@@deriving sexp,yojson,hash,compare]
 
 type structure_field_body =
   [%import: Declarations.structure_field_body]
-  [@@deriving sexp]
+  [@@deriving sexp,yojson,hash,compare]
 
 and structure_body =
   [%import: Declarations.structure_body]
-  [@@deriving sexp]
+  [@@deriving sexp,yojson,hash,compare]
 
 and module_signature =
   [%import: Declarations.module_signature]
-  [@@deriving sexp]
+  [@@deriving sexp,yojson,hash,compare]
 
 and module_expression =
   [%import: Declarations.module_expression]
-  [@@deriving sexp]
+  [@@deriving sexp,yojson,hash,compare]
 
 and module_implementation =
   [%import: Declarations.module_implementation]
-  [@@deriving sexp]
+  [@@deriving sexp,yojson,hash,compare]
 
 and 'a generic_module_body =
   [%import: 'a Declarations.generic_module_body]
-  [@@deriving sexp]
+  [@@deriving sexp,yojson,hash,compare]
 
 and module_body =
   [%import: Declarations.module_body]
-  [@@deriving sexp]
+  [@@deriving sexp,yojson,hash,compare]
 
 and module_type_body =
   [%import: Declarations.module_type_body]
-  [@@deriving sexp]
+  [@@deriving sexp,yojson,hash,compare]

--- a/serlib/ser_declarations.mli
+++ b/serlib/ser_declarations.mli
@@ -81,8 +81,7 @@ val inline_of_sexp : Sexp.t -> inline
  * val cooking_info_of_sexp : Sexp.t -> cooking_info *)
 
 type constant_body = Declarations.constant_body
-val sexp_of_constant_body : constant_body -> Sexp.t
-val constant_body_of_sexp : Sexp.t -> constant_body
+  [@@deriving sexp,yojson,hash,compare]
 
 (* type record_body = Declarations.record_body
  * val record_body_of_sexp : Sexp.t -> record_body
@@ -95,21 +94,17 @@ val recursivity_kind_of_yojson : Yojson.Safe.t -> (recursivity_kind, string) Res
 val recursivity_kind_to_yojson : recursivity_kind -> Yojson.Safe.t
 
 type mutual_inductive_body = Declarations.mutual_inductive_body
-val mutual_inductive_body_of_sexp : Sexp.t -> mutual_inductive_body
-val sexp_of_mutual_inductive_body : mutual_inductive_body -> Sexp.t
+  [@@deriving sexp,yojson,hash,compare]
 
 type 'a module_alg_expr = 'a Declarations.module_alg_expr
 val sexp_of_module_alg_expr : ('a -> Sexp.t) -> 'a module_alg_expr -> Sexp.t
 val module_alg_expr_of_sexp : (Sexp.t -> 'a) -> Sexp.t -> 'a module_alg_expr
 
 type structure_body = Declarations.structure_body
-val sexp_of_structure_body : structure_body -> Sexp.t
-val structure_body_of_sexp : Sexp.t -> structure_body
+  [@@deriving sexp,yojson,hash,compare]
 
 type module_body = Declarations.module_body
-val sexp_of_module_body : module_body -> Sexp.t
-val module_body_of_sexp : Sexp.t -> module_body
+  [@@deriving sexp,yojson,hash,compare]
 
 type module_type_body = Declarations.module_type_body
-val sexp_of_module_type_body : module_type_body -> Sexp.t
-val module_type_body_of_sexp : Sexp.t -> module_type_body
+  [@@deriving sexp,yojson,hash,compare]

--- a/serlib/ser_eConstr.ml
+++ b/serlib/ser_eConstr.ml
@@ -20,9 +20,17 @@
 module Constr  = Ser_constr
 module Environ = Ser_environ
 
-type t = EConstr.t
-let t_of_sexp s = EConstr.of_constr (Ser_constr.constr_of_sexp s)
-let sexp_of_t c = Ser_constr.sexp_of_constr (EConstr.Unsafe.to_constr c)
+module ECtoC = struct
+
+  type t = EConstr.t
+  type _t = Constr.t
+  [@@deriving sexp,yojson,hash,compare]
+
+  let to_t = EConstr.of_constr
+  let of_t = EConstr.Unsafe.to_constr
+end
+
+include SerType.Biject(ECtoC)
 
 type existential =
   [%import: EConstr.existential]
@@ -30,7 +38,7 @@ type existential =
 
 type constr =
   [%import: EConstr.constr]
-  [@@deriving sexp]
+  [@@deriving sexp,yojson,hash,compare]
 
 type types =
   [%import: EConstr.types]

--- a/serlib/ser_eConstr.mli
+++ b/serlib/ser_eConstr.mli
@@ -17,9 +17,7 @@
 open Sexplib
 
 type t = EConstr.t
-
-val sexp_of_t : t -> Sexp.t
-val t_of_sexp : Sexp.t -> t
+  [@@deriving sexp,yojson,hash,compare]
 
 type existential = EConstr.existential
 
@@ -27,9 +25,7 @@ val existential_of_sexp : Sexp.t -> existential
 val sexp_of_existential : existential -> Sexp.t
 
 type constr = t
-
-val sexp_of_constr : constr -> Sexp.t
-val constr_of_sexp : Sexp.t -> constr
+  [@@deriving sexp,yojson,hash,compare]
 
 type types = t
 

--- a/serlib/ser_entries.ml
+++ b/serlib/ser_entries.ml
@@ -100,11 +100,7 @@ type constant_entry =
 
 type module_struct_entry =
   [%import: Entries.module_struct_entry]
-  (* [@@deriving sexp] *)
-
-(* XXX *)
-let module_struct_entry_of_sexp = Obj.magic
-let sexp_of_module_struct_entry = Obj.magic
+  [@@deriving sexp]
 
 type module_params_entry =
   [%import: Entries.module_params_entry]

--- a/serlib/ser_environ.ml
+++ b/serlib/ser_environ.ml
@@ -13,7 +13,9 @@
 (* Status: Experimental                                                 *)
 (************************************************************************)
 
-open Sexplib.Conv
+open Sexplib.Std
+open Ppx_hash_lib.Std.Hash.Builtin
+open Ppx_compare_lib.Builtin
 
 module Stdlib = Ser_stdlib
 module CEphemeron = Ser_cEphemeron
@@ -44,30 +46,28 @@ type named_context_val =
 
 type link_info =
   [%import: Environ.link_info]
-  [@@deriving sexp]
+  [@@deriving sexp,yojson,hash,compare]
 
 type key =
   [%import: Environ.key]
-  [@@deriving sexp]
+  [@@deriving sexp,yojson,hash,compare]
 
 type constant_key =
   [%import: Environ.constant_key]
-  [@@deriving sexp]
+  [@@deriving sexp,yojson,hash,compare]
 
 type mind_key =
   [%import: Environ.mind_key]
-  [@@deriving sexp]
+  [@@deriving sexp,yojson,hash,compare]
 
 module Globals = struct
 
-  type t = Environ.Globals.t
-
-  type _t =
-    [%import: Environ.Globals.view]
-    [@@deriving sexp]
-
-  let sexp_of_t g = sexp_of__t (Obj.magic g)
-  let _t_of_sexp s = Obj.magic (_t_of_sexp s)
+  module PierceSpec = struct
+    type t = Environ.Globals.t
+    type _t = [%import: Environ.Globals.view]
+    [@@deriving sexp,yojson,hash,compare]
+  end
+  include SerType.Pierce(PierceSpec)
 end
 
 type env =

--- a/serlib/ser_equality.ml
+++ b/serlib/ser_equality.ml
@@ -1,5 +1,7 @@
-open Sexplib.Conv
+open Sexplib.Std
+open Ppx_hash_lib.Std.Hash.Builtin
+open Ppx_compare_lib.Builtin
 
 type multi =
   [%import: Equality.multi]
-  [@@deriving sexp]
+  [@@deriving sexp,yojson,hash,compare]

--- a/serlib/ser_evar_kinds.mli
+++ b/serlib/ser_evar_kinds.mli
@@ -19,9 +19,7 @@ open Sexplib
 (* Evar_kinds.mli                                                       *)
 (************************************************************************)
 type matching_var_kind = Evar_kinds.matching_var_kind
-
-val matching_var_kind_of_sexp : Sexp.t -> matching_var_kind
-val sexp_of_matching_var_kind : matching_var_kind -> Sexp.t
+  [@@deriving sexp,yojson,hash,compare]
 
 type obligation_definition_status = Evar_kinds.obligation_definition_status
 

--- a/serlib/ser_evd.ml
+++ b/serlib/ser_evd.ml
@@ -23,8 +23,8 @@ type econstr =
   [%import: Evd.econstr]
 
 (* ahhh *)
-let econstr_of_sexp s = Obj.magic (Constr.t_of_sexp s)
-let sexp_of_econstr c = Constr.sexp_of_t (Obj.magic c)
+let econstr_of_sexp s = Evd.MiniEConstr.of_constr (Constr.t_of_sexp s)
+let sexp_of_econstr c = Constr.sexp_of_t (Evd.MiniEConstr.unsafe_to_constr c)
 
 type conv_pb = Reduction.conv_pb
   [@@deriving sexp]

--- a/serlib/ser_float64.ml
+++ b/serlib/ser_float64.ml
@@ -16,16 +16,13 @@
 (* Status: Very Experimental                                            *)
 (************************************************************************)
 
-type t = Float64.t
-
 open Sexplib.Std
-type _t = float [@@deriving sexp, yojson]
+open Ppx_hash_lib.Std.Hash.Builtin
+open Ppx_compare_lib.Builtin
 
-let _t_get = Obj.magic
-let _t_put = Obj.magic
+module PierceSpec = struct
+  type t = Float64.t
+  type _t = float [@@deriving sexp,yojson,hash,compare]
+end
 
-let t_of_sexp t = _t_put (_t_of_sexp t)
-let sexp_of_t t = sexp_of__t (_t_get t)
-
-let of_yojson json = Ppx_deriving_yojson_runtime.(_t_of_yojson json >|= _t_get)
-let to_yojson level = _t_to_yojson (_t_put level)
+include SerType.Pierce(PierceSpec)

--- a/serlib/ser_genarg.ml
+++ b/serlib/ser_genarg.ml
@@ -14,6 +14,11 @@
 (************************************************************************)
 
 open Sexplib
+open Ppx_hash_lib.Std
+open Ppx_compare_lib.Builtin
+
+let hash_tagged f st tag x = let st = Hash.fold_string st tag in f st x
+let hash_pair f1 f2 st (x1,x2) = let st = f1 st x1 in f2 st x2
 
 (**********************************************************************)
 (* GenArg                                                             *)
@@ -23,30 +28,35 @@ open Genarg
 
 type rlevel =
   [%import: Genarg.rlevel]
-  [@@deriving sexp,yojson,hash]
+  [@@deriving sexp,yojson,hash,compare]
 type glevel =
   [%import: Genarg.glevel]
-  [@@deriving sexp,yojson]
+  [@@deriving sexp,yojson,hash,compare]
 type tlevel =
   [%import: Genarg.tlevel]
-  [@@deriving sexp,yojson]
+  [@@deriving sexp,yojson,hash,compare]
 
-open Sexp
-
-let rec sexp_of_genarg_type : type a b c. (a, b, c) genarg_type -> t = fun gt ->
+let rec sexp_of_genarg_type : type a b c. (a, b, c) genarg_type -> Sexp.t = fun gt ->
   match gt with
   | ExtraArg tag   -> List [Atom "ExtraArg"; Atom (ArgT.repr tag)]
   | ListArg rt     -> List [Atom "ListArg"; sexp_of_genarg_type rt]
   | OptArg  rt     -> List [Atom "OptArg";  sexp_of_genarg_type rt]
   | PairArg(t1,t2) -> List [Atom "PairArg"; sexp_of_genarg_type t1; sexp_of_genarg_type t2]
 
-let sexp_of_abstract_argument_type : type lvl. ('o, lvl) abstract_argument_type -> t * t = fun  at ->
+let rec hash_fold_genarg_type : type a b c. (a, b, c) genarg_type Hash.folder = fun st gt ->
+  match gt with
+  | ExtraArg tag   -> hash_tagged Hash.fold_string st "ExtraArg" (ArgT.repr tag)
+  | ListArg rt     -> hash_tagged hash_fold_genarg_type st "ListArg" rt
+  | OptArg  rt     -> hash_tagged hash_fold_genarg_type st "OptArg" rt
+  | PairArg(t1,t2) -> hash_tagged (hash_pair hash_fold_genarg_type hash_fold_genarg_type) st "PairArg" (t1, t2)
+
+let sexp_of_abstract_argument_type : type lvl. ('o, lvl) abstract_argument_type -> Sexp.t * Sexp.t = fun  at ->
   match at with
   | Rawwit w -> Atom "raw", sexp_of_genarg_type w
   | Glbwit w -> Atom "glb", sexp_of_genarg_type w
   | Topwit w -> Atom "top", sexp_of_genarg_type w
 
-let rec argument_type_of_sexp : t -> argument_type = fun sexp ->
+let rec argument_type_of_sexp : Sexp.t -> argument_type = fun sexp ->
   match sexp with
   | List [Atom "ExtraArg"; Atom tag] ->
     begin match ArgT.name tag with
@@ -65,39 +75,71 @@ let rec argument_type_of_sexp : t -> argument_type = fun sexp ->
     ArgumentType (PairArg(t1,t2))
   | _ -> raise (Failure "SEXP Exception")
 
+let hash_fold_abstract_argument_type : type lvl. ('o, lvl) abstract_argument_type Hash.folder  = fun st at ->
+  match at with
+  | Rawwit w -> hash_tagged hash_fold_genarg_type st "raw" w
+  | Glbwit w -> hash_tagged hash_fold_genarg_type st "glb" w
+  | Topwit w -> hash_tagged hash_fold_genarg_type st "top" w
+
 type ('raw, 'glb, 'top) gen_ser =
-  { raw_ser : 'raw -> Sexp.t;
-    raw_des : Sexp.t -> 'raw;
+  { raw_ser : 'raw -> Sexp.t
+  ; raw_des : Sexp.t -> 'raw
+  ; raw_hash : 'raw Hash.folder
+  ; raw_compare : 'raw -> 'raw -> int
 
-    glb_ser : 'glb -> Sexp.t;
-    glb_des : Sexp.t -> 'glb;
+  ; glb_ser : 'glb -> Sexp.t
+  ; glb_des : Sexp.t -> 'glb
+  ; glb_hash : 'glb Hash.folder
+  ; glb_compare : 'glb -> 'glb -> int
 
-    top_ser : 'top -> Sexp.t;
-    top_des : Sexp.t -> 'top;
+  ; top_ser : 'top -> Sexp.t
+  ; top_des : Sexp.t -> 'top
+  ; top_hash : 'top Ppx_hash_lib.Std.Hash.folder
+  ; top_compare : 'top -> 'top -> int
   }
+
+module T2_ = struct
+  type ('a, 'b) t = 'a * 'b [@@deriving hash, compare]
+end
 
 let gen_ser_list :
   ('raw, 'glb, 'top) gen_ser ->
   ('raw list, 'glb list, 'top list) gen_ser = fun g ->
   let open Sexplib.Conv in
-  { raw_ser = sexp_of_list g.raw_ser;
-    raw_des = list_of_sexp g.raw_des;
-    glb_ser = sexp_of_list g.glb_ser;
-    glb_des = list_of_sexp g.glb_des;
-    top_ser = sexp_of_list g.top_ser;
-    top_des = list_of_sexp g.top_des;
+  { raw_ser = sexp_of_list g.raw_ser
+  ; raw_des = list_of_sexp g.raw_des
+  ; raw_hash = Hash.Builtin.hash_fold_list g.raw_hash
+  ; raw_compare = compare_list g.raw_compare
+
+  ; glb_ser = sexp_of_list g.glb_ser
+  ; glb_des = list_of_sexp g.glb_des
+  ; glb_hash = Hash.Builtin.hash_fold_list g.glb_hash
+  ; glb_compare = compare_list g.glb_compare
+
+  ; top_ser = sexp_of_list g.top_ser
+  ; top_des = list_of_sexp g.top_des
+  ; top_hash = Hash.Builtin.hash_fold_list g.top_hash
+  ; top_compare = compare_list g.top_compare
   }
 
 let gen_ser_opt :
   ('raw, 'glb, 'top) gen_ser ->
   ('raw option, 'glb option, 'top option) gen_ser = fun g ->
   let open Sexplib.Conv in
-  { raw_ser = sexp_of_option g.raw_ser;
-    raw_des = option_of_sexp g.raw_des;
-    glb_ser = sexp_of_option g.glb_ser;
-    glb_des = option_of_sexp g.glb_des;
-    top_ser = sexp_of_option g.top_ser;
-    top_des = option_of_sexp g.top_des;
+  { raw_ser = sexp_of_option g.raw_ser
+  ; raw_des = option_of_sexp g.raw_des
+  ; raw_hash = Hash.Builtin.hash_fold_option g.raw_hash
+  ; raw_compare = compare_option g.raw_compare
+
+  ; glb_ser = sexp_of_option g.glb_ser
+  ; glb_des = option_of_sexp g.glb_des
+  ; glb_hash = Hash.Builtin.hash_fold_option g.glb_hash
+  ; glb_compare = compare_option g.glb_compare
+
+  ; top_ser = sexp_of_option g.top_ser
+  ; top_des = option_of_sexp g.top_des
+  ; top_hash = Hash.Builtin.hash_fold_option g.top_hash
+  ; top_compare = compare_option g.top_compare
   }
 
 let gen_ser_pair :
@@ -105,12 +147,20 @@ let gen_ser_pair :
   ('raw2, 'glb2, 'top2) gen_ser ->
   (('raw1 * 'raw2), ('glb1 * 'glb2), ('top1 * 'top2)) gen_ser = fun g1 g2 ->
   let open Sexplib.Conv in
-  { raw_ser = sexp_of_pair g1.raw_ser g2.raw_ser;
-    raw_des = pair_of_sexp g1.raw_des g2.raw_des;
-    glb_ser = sexp_of_pair g1.glb_ser g2.glb_ser;
-    glb_des = pair_of_sexp g1.glb_des g2.glb_des;
-    top_ser = sexp_of_pair g1.top_ser g2.top_ser;
-    top_des = pair_of_sexp g1.top_des g2.top_des;
+  { raw_ser = sexp_of_pair g1.raw_ser g2.raw_ser
+  ; raw_des = pair_of_sexp g1.raw_des g2.raw_des
+  ; raw_hash = T2_.hash_fold_t g1.raw_hash g2.raw_hash
+  ; raw_compare = T2_.compare g1.raw_compare g2.raw_compare
+
+  ; glb_ser = sexp_of_pair g1.glb_ser g2.glb_ser
+  ; glb_des = pair_of_sexp g1.glb_des g2.glb_des
+  ; glb_hash = T2_.hash_fold_t g1.glb_hash g2.glb_hash
+  ; glb_compare = T2_.compare g1.glb_compare g2.glb_compare
+
+  ; top_ser = sexp_of_pair g1.top_ser g2.top_ser
+  ; top_des = pair_of_sexp g1.top_des g2.top_des
+  ; top_hash = T2_.hash_fold_t g1.top_hash g2.top_hash
+  ; top_compare = T2_.compare g1.top_compare g2.top_compare
   }
 
 module SerObj = struct
@@ -123,19 +173,26 @@ module SerObj = struct
 
   let name = "ser_arg"
   let default _ga =
-    Some {
-      (* raw_ser = (fun _ -> Sexp.(List [Atom "[XXX ser_gen]"; Atom "raw"; sexp_of_genarg_type ga])); *)
-      raw_ser = sexp_of_gen "raw" _ga;
-      raw_des = (Sexplib.Conv_error.no_matching_variant_found "raw_arg");
+    Some
+      {
+        (* raw_ser = (fun _ -> Sexp.(List [Atom "[XXX ser_gen]"; Atom "raw"; sexp_of_genarg_type ga])); *)
+        raw_ser = sexp_of_gen "raw" _ga
+      ; raw_des = (Sexplib.Conv_error.no_matching_variant_found "raw_arg")
+      ; raw_hash = (fun st a -> Hash.fold_int st (Hashtbl.hash a))
+      ; raw_compare = Stdlib.compare
 
       (* glb_ser = (fun _ -> Sexp.(List [Atom "[XXX ser_gen]"; Atom "glb"; sexp_of_genarg_type ga])); *)
-      glb_ser = sexp_of_gen "glb" _ga;
-      glb_des = (Sexplib.Conv_error.no_matching_variant_found "glb_arg");
+      ; glb_ser = sexp_of_gen "glb" _ga
+      ; glb_des = (Sexplib.Conv_error.no_matching_variant_found "glb_arg")
+      ; glb_hash = (fun st a -> Hash.fold_int st (Hashtbl.hash a))
+      ; glb_compare = Stdlib.compare
 
       (* top_ser = (fun _ -> Sexp.(List [Atom "[XXX ser_gen]"; Atom "top"; sexp_of_genarg_type ga])); *)
-      top_ser = sexp_of_gen "top" _ga;
-      top_des = (Sexplib.Conv_error.no_matching_variant_found "top_arg")
-    }
+      ; top_ser = sexp_of_gen "top" _ga
+      ; top_des = (Sexplib.Conv_error.no_matching_variant_found "top_arg")
+      ; top_hash = (fun st a -> Hash.fold_int st (Hashtbl.hash a))
+      ; top_compare = Stdlib.compare
+      }
 end
 
 module SerGen = Register(SerObj)
@@ -154,15 +211,27 @@ let get_gen_ser : type lvl. ('o,lvl) abstract_argument_type -> ('o -> 't) = fun 
   | Genarg.Glbwit ty -> (get_gen_ser_ty ty).glb_ser
   | Genarg.Topwit ty -> (get_gen_ser_ty ty).top_ser
 
-let generic_des : type lvl. ('o,lvl) abstract_argument_type -> t -> lvl generic_argument = fun ty s ->
+let generic_des : type lvl. ('o,lvl) abstract_argument_type -> Sexp.t -> lvl generic_argument = fun ty s ->
   match ty with
   | Genarg.Rawwit w -> GenArg(ty, (get_gen_ser_ty w).raw_des s)
   | Genarg.Glbwit w -> GenArg(ty, (get_gen_ser_ty w).glb_des s)
   | Genarg.Topwit w -> GenArg(ty, (get_gen_ser_ty w).top_des s)
 
+let hash_fold_generic : type lvl. ('o,lvl) abstract_argument_type -> 'o Ppx_hash_lib.Std.Hash.folder = fun aty ->
+  match aty with
+  | Genarg.Rawwit ty -> (get_gen_ser_ty ty).raw_hash
+  | Genarg.Glbwit ty -> (get_gen_ser_ty ty).glb_hash
+  | Genarg.Topwit ty -> (get_gen_ser_ty ty).top_hash
+
+let compare_generic : type lvl. ('o,lvl) abstract_argument_type -> 'o Ppx_compare_lib.compare = fun aty ->
+  match aty with
+  | Genarg.Rawwit ty -> (get_gen_ser_ty ty).raw_compare
+  | Genarg.Glbwit ty -> (get_gen_ser_ty ty).glb_compare
+  | Genarg.Topwit ty -> (get_gen_ser_ty ty).top_compare
+
 (* We need to generalize this to use the proper printers for opt *)
 let mk_sexparg (lvl, st) so =
-  List [Atom "GenArg"; lvl; st; so]
+  Sexp.List [Atom "GenArg"; lvl; st; so]
 
 (* XXX: There is still some duplication here in the traversal of g_ty, but
    we can live with that for now.  *)
@@ -171,12 +240,36 @@ let sexp_of_genarg_val : type a. a generic_argument -> Sexp.t =
   | GenArg (g_ty, g_val) ->
     mk_sexparg (sexp_of_abstract_argument_type g_ty) (get_gen_ser g_ty g_val)
 
-let sexp_of_generic_argument : type a. (a -> t) -> a generic_argument -> t =
+let sexp_of_generic_argument : type a. (a -> Sexp.t) -> a generic_argument -> Sexp.t =
   fun _level_tag g ->
   sexp_of_genarg_val g
 
 type rgen_argument = RG : 'lvl generic_argument -> rgen_argument
-let gen_abstype_of_sexp : t -> rgen_argument = fun s ->
+
+let hash_fold_genarg_val : type a. a generic_argument Hash.folder =
+  fun st g -> match g with
+  | GenArg (g_ty, g_val) ->
+    let st = hash_fold_abstract_argument_type st g_ty in
+    hash_fold_generic g_ty st g_val
+
+let hash_fold_generic_argument : type a. a Hash.folder -> a generic_argument Hash.folder =
+  fun _level_tag g -> hash_fold_genarg_val g
+
+let compare_genarg_val : type a. a generic_argument Ppx_compare_lib.compare =
+  fun g1 g2 -> match g1 with
+  | GenArg (g1_ty, g1_val) ->
+    match g2 with
+    | GenArg (g2_ty, g2_val) ->
+      match Genarg.abstract_argument_type_eq g1_ty g2_ty with
+      | Some Refl ->
+        compare_generic g1_ty g1_val g2_val
+      (* XXX: Technically, we should implement our own compare so ordering works *)
+      | None -> 1
+
+let compare_generic_argument : type a. a Ppx_compare_lib.compare -> a generic_argument Ppx_compare_lib.compare =
+  fun _level_tag g -> compare_genarg_val g
+
+let gen_abstype_of_sexp : Sexp.t -> rgen_argument = fun s ->
   match s with
   | List [Atom "GenArg"; Atom "raw"; sty; sobj] ->
     let (ArgumentType ty) = argument_type_of_sexp sty in
@@ -196,43 +289,66 @@ let generic_argument_of_sexp _lvl sexp : 'a Genarg.generic_argument =
 let generic_argument_of_yojson _lvl _json = Error "not supported generic_argument_of_yojson"
 let generic_argument_to_yojson _lvl _g = `String "foo"
 
-(* let hash_generic_argument = Hashtbl.hash *)
-open Ppx_hash_lib.Std.Hash
-(* XXX *)
-(* let hash_fold_generic_argument (_f : state -> rlevel -> state) (_st : state) (x : 'a generic_argument) =
- *   Builtin.hash_fold_string _st (Sexp.to_string (sexp_of_generic_argument _f x)) *)
-let _hash_fold_generic_argument _st _f _x = raise (Invalid_argument "genarg hash")
-
 type 'a generic_argument = 'a Genarg.generic_argument
 
 type glob_generic_argument =
   [%import: Genarg.glob_generic_argument]
-  [@@deriving sexp,yojson]
+  [@@deriving sexp,yojson,hash,compare]
 
 type raw_generic_argument =
   [%import: Genarg.raw_generic_argument]
-  [@@deriving sexp,yojson]
-
-let hash_raw_generic_argument x =
-  Builtin.hash_string (Sexp.to_string (sexp_of_raw_generic_argument x))
-
-let hash_fold_raw_generic_argument st x =
-  Builtin.hash_fold_string st (Sexp.to_string (sexp_of_raw_generic_argument x))
-
-open Ppx_compare_lib
-
-let compare_raw_generic_argument x y =
-  Builtin.compare_string (Sexp.to_string (sexp_of_raw_generic_argument x)) (Sexp.to_string (sexp_of_raw_generic_argument y))
+  [@@deriving sexp,yojson,hash,compare]
 
 type typed_generic_argument =
   [%import: Genarg.typed_generic_argument]
-  [@@deriving sexp,yojson]
+  [@@deriving sexp,yojson,hash,compare]
 
-let mk_uniform pin pout = {
-    raw_ser = pin;
-    glb_ser = pin;
-    top_ser = pin;
-    raw_des = pout;
-    glb_des = pout;
-    top_des = pout;
+let mk_uniform pin pout phash pcompare =
+  { raw_ser = pin
+  ; raw_des = pout
+  ; raw_hash = phash
+  ; raw_compare = pcompare
+
+  ; glb_ser = pin
+  ; glb_des = pout
+  ; glb_hash = phash
+  ; glb_compare = pcompare
+
+  ; top_ser = pin
+  ; top_des = pout
+  ; top_hash = phash
+  ; top_compare = pcompare
   }
+
+module type GenSer0 = sig
+  type t [@@deriving sexp,hash,compare]
+end
+
+module GS0 (M : GenSer0) = struct
+  let genser = mk_uniform M.sexp_of_t M.t_of_sexp M.hash_fold_t M.compare
+end
+
+module type GenSer = sig
+  type raw [@@deriving sexp,hash,compare]
+  type glb [@@deriving sexp,hash,compare]
+  type top [@@deriving sexp,hash,compare]
+end
+
+module GS (M : GenSer) = struct
+  let genser =
+    { raw_ser = M.sexp_of_raw
+    ; raw_des = M.raw_of_sexp
+    ; raw_hash = M.hash_fold_raw
+    ; raw_compare = M.compare_raw
+
+    ; glb_ser = M.sexp_of_glb
+    ; glb_des = M.glb_of_sexp
+    ; glb_hash = M.hash_fold_glb
+    ; glb_compare = M.compare_glb
+
+    ; top_ser = M.sexp_of_top
+    ; top_des = M.top_of_sexp
+    ; top_hash = M.hash_fold_top
+    ; top_compare = M.compare_top
+    }
+end

--- a/serlib/ser_genarg.mli
+++ b/serlib/ser_genarg.mli
@@ -23,29 +23,20 @@ open Sexplib
 (**********************************************************************)
 
 type rlevel = Genarg.rlevel
+  [@@deriving sexp,yojson,hash,compare]
 type glevel = Genarg.glevel
+  [@@deriving sexp,yojson,hash,compare]
 type tlevel = Genarg.tlevel
-
-val rlevel_of_sexp : Sexp.t -> rlevel
-val sexp_of_rlevel : rlevel -> Sexp.t
-
-val glevel_of_sexp : Sexp.t -> glevel
-val sexp_of_glevel : glevel -> Sexp.t
-
-val tlevel_of_sexp : Sexp.t -> tlevel
-val sexp_of_tlevel : tlevel -> Sexp.t
+  [@@deriving sexp,yojson,hash,compare]
 
 type 'a generic_argument = 'a Genarg.generic_argument
-
-val generic_argument_of_sexp : (Sexp.t -> 'a) -> Sexp.t -> 'a Genarg.generic_argument
-val sexp_of_generic_argument : ('a -> Sexp.t) -> 'a Genarg.generic_argument -> Sexp.t
+  [@@deriving sexp,yojson,hash,compare]
 
 type glob_generic_argument = Genarg.glob_generic_argument
+[@@deriving sexp,yojson,hash,compare]
 
-val glob_generic_argument_of_sexp : Sexp.t -> Genarg.glob_generic_argument
-val sexp_of_glob_generic_argument : Genarg.glob_generic_argument -> Sexp.t
-
-type raw_generic_argument = Genarg.raw_generic_argument [@@deriving sexp,yojson,hash,compare]
+type raw_generic_argument = Genarg.raw_generic_argument
+[@@deriving sexp,yojson,hash,compare]
 
 type typed_generic_argument = Genarg.typed_generic_argument
 val typed_generic_argument_of_sexp : Sexp.t -> Genarg.typed_generic_argument
@@ -53,14 +44,20 @@ val sexp_of_typed_generic_argument : Genarg.typed_generic_argument -> Sexp.t
 
 (* Registering serializing functions *)
 type ('raw, 'glb, 'top) gen_ser =
-  { raw_ser : 'raw -> Sexp.t;
-    raw_des : Sexp.t -> 'raw;
+  { raw_ser : 'raw -> Sexp.t
+  ; raw_des : Sexp.t -> 'raw
+  ; raw_hash : 'raw Ppx_hash_lib.Std.Hash.folder
+  ; raw_compare : 'raw -> 'raw -> int
 
-    glb_ser : 'glb -> Sexp.t;
-    glb_des : Sexp.t -> 'glb;
+  ; glb_ser : 'glb -> Sexp.t
+  ; glb_des : Sexp.t -> 'glb
+  ; glb_hash : 'glb Ppx_hash_lib.Std.Hash.folder
+  ; glb_compare : 'glb -> 'glb -> int
 
-    top_ser : 'top -> Sexp.t;
-    top_des : Sexp.t -> 'top;
+  ; top_ser : 'top -> Sexp.t
+  ; top_des : Sexp.t -> 'top
+  ; top_hash : 'top Ppx_hash_lib.Std.Hash.folder
+  ; top_compare : 'top -> 'top -> int
   }
 
 val register_genser :
@@ -76,5 +73,21 @@ val gen_ser_list :
   ('raw, 'glb, 'top) gen_ser ->
   ('raw list, 'glb list, 'top list) gen_ser
 
-val mk_uniform : ('t -> Sexp.t) -> (Sexp.t -> 't) -> ('t,'t,'t) gen_ser
+val mk_uniform : ('t -> Sexp.t) -> (Sexp.t -> 't) ->
+  't Ppx_hash_lib.Std.Hash.folder ->
+  't Ppx_compare_lib.compare ->
+  ('t,'t,'t) gen_ser
 
+module type GenSer0 = sig
+  type t [@@deriving sexp,hash,compare]
+end
+
+module GS0 (M : GenSer0) : sig val genser : (M.t,M.t,M.t) gen_ser end
+
+module type GenSer = sig
+  type raw [@@deriving sexp,hash,compare]
+  type glb [@@deriving sexp,hash,compare]
+  type top [@@deriving sexp,hash,compare]
+end
+
+module GS (M : GenSer) : sig val genser : (M.raw,M.glb,M.top) gen_ser end

--- a/serlib/ser_genintern.ml
+++ b/serlib/ser_genintern.ml
@@ -16,6 +16,8 @@
 (************************************************************************)
 
 open Sexplib.Conv
+open Ppx_hash_lib.Std.Hash.Builtin
+open Ppx_compare_lib.Builtin
 
 module Stdlib     = Ser_stdlib
 module Names      = Ser_names
@@ -26,16 +28,16 @@ module Pattern    = Ser_pattern
 module Notation_term = Ser_notation_term
 
 module Store = struct
-  type t = Genintern.Store.t
 
-  let t_of_sexp _ = CErrors.user_err Pp.(str "[GI Store: Cannot deserialize stores.")
-  let sexp_of_t _ = Sexplib.Sexp.Atom "[GENINTERN STORE]"
+  module StoreOpaque = struct type t = Genintern.Store.t let name = "Genintern.Store.t" end
+
+  include SerType.Opaque(StoreOpaque)
 
 end
 
 type intern_variable_status =
   [%import: Genintern.intern_variable_status]
-  [@@deriving sexp]
+  [@@deriving sexp,yojson,hash,compare]
 
 type glob_sign =
   [%import: Genintern.glob_sign]
@@ -43,8 +45,8 @@ type glob_sign =
 
 type glob_constr_and_expr =
   [%import: Genintern.glob_constr_and_expr]
-  [@@deriving sexp]
+  [@@deriving sexp,yojson,hash,compare]
 
 type glob_constr_pattern_and_expr =
   [%import: Genintern.glob_constr_pattern_and_expr]
-  [@@deriving sexp]
+  [@@deriving sexp,yojson,hash,compare]

--- a/serlib/ser_genintern.mli
+++ b/serlib/ser_genintern.mli
@@ -17,12 +17,10 @@
 
 open Sexplib
 
-module Store : SerType.S with type t = Genintern.Store.t
+module Store : SerType.SJHC with type t = Genintern.Store.t
 
 type intern_variable_status = Genintern.intern_variable_status
-
-val intern_variable_status_of_sexp : Sexp.t -> intern_variable_status
-val sexp_of_intern_variable_status : intern_variable_status -> Sexp.t
+  [@@deriving sexp, yojson, hash, compare]
 
 type glob_sign = Genintern.glob_sign
 
@@ -30,11 +28,7 @@ val glob_sign_of_sexp : Sexp.t -> glob_sign
 val sexp_of_glob_sign : glob_sign -> Sexp.t
 
 type glob_constr_and_expr = Genintern.glob_constr_and_expr
-
-val glob_constr_and_expr_of_sexp : Sexp.t -> glob_constr_and_expr
-val sexp_of_glob_constr_and_expr : glob_constr_and_expr -> Sexp.t
+  [@@deriving sexp, yojson, hash, compare]
 
 type glob_constr_pattern_and_expr = Genintern.glob_constr_pattern_and_expr
-
-val glob_constr_pattern_and_expr_of_sexp : Sexp.t -> glob_constr_pattern_and_expr
-val sexp_of_glob_constr_pattern_and_expr : glob_constr_pattern_and_expr -> Sexp.t
+  [@@deriving sexp, yojson, hash, compare]

--- a/serlib/ser_geninterp.ml
+++ b/serlib/ser_geninterp.ml
@@ -14,6 +14,8 @@
 (************************************************************************)
 
 open Sexplib.Conv
+open Ppx_hash_lib.Std.Hash.Builtin
+open Ppx_compare_lib.Builtin
 
 module Names      = Ser_names
 
@@ -30,14 +32,26 @@ module Val = struct
     [@@deriving sexp_of]
 
   let t_of_sexp x = Serlib_base.opaque_of_sexp ~typ:"Geninterp.Val.t" x
+  let of_yojson = Serlib_base.opaque_of_yojson ~typ:"Geninterp.Val.t"
+  let to_yojson x = Serlib_base.opaque_to_yojson ~typ:"Geninterp.Val.t" x
+
+  let hash = Hashtbl.hash
+  let hash_fold_t st d = Ppx_hash_lib.Std.Hash.Builtin.hash_fold_int st (Hashtbl.hash d)
+  let compare = Stdlib.compare
+
 end
 
 module TacStore = struct
   type t = Geninterp.TacStore.t
   let t_of_sexp = Serlib_base.opaque_of_sexp ~typ:"Geninterp.TacStore.t"
   let sexp_of_t = Serlib_base.sexp_of_opaque ~typ:"Geninterp.TacStore.t"
+  let to_yojson = Serlib_base.opaque_to_yojson ~typ:"Geninterp.TacStore.t"
+  let of_yojson = Serlib_base.opaque_of_yojson ~typ:"Geninterp.TacStore.t"
+  let _hash = Hashtbl.hash
+  let hash_fold_t st d = Ppx_hash_lib.Std.Hash.Builtin.hash_fold_int st (Hashtbl.hash d)
+  let compare = Stdlib.compare
 end
 
 type interp_sign =
   [%import: Geninterp.interp_sign]
-  [@@deriving sexp]
+  [@@deriving sexp,yojson,hash,compare]

--- a/serlib/ser_geninterp.mli
+++ b/serlib/ser_geninterp.mli
@@ -13,18 +13,12 @@
 (* Status: Very Experimental                                            *)
 (************************************************************************)
 
-open Sexplib
-
 module Val : sig
 
   type t = Geninterp.Val.t
-
-  (* val t_of_sexp : Sexp.t -> t *)
-  val sexp_of_t : t -> Sexp.t
-  val t_of_sexp : Sexp.t -> t
+  [@@deriving sexp,yojson,hash,compare]
 
 end
 
 type interp_sign = Geninterp.interp_sign
-val interp_sign_of_sexp : Sexp.t -> interp_sign
-val sexp_of_interp_sign : interp_sign -> Sexp.t
+  [@@deriving sexp,yojson,hash,compare]

--- a/serlib/ser_genredexpr.ml
+++ b/serlib/ser_genredexpr.ml
@@ -42,7 +42,7 @@ type ('a,'b,'c) red_expr_gen =
 
 type ('a,'b,'c) may_eval =
   [%import: ('a,'b,'c) Genredexpr.may_eval]
-  [@@deriving sexp]
+  [@@deriving sexp,yojson,hash,compare]
 
 (* Helpers for raw_red_expr *)
 type r_trm =
@@ -63,35 +63,30 @@ type raw_red_expr =
 
 type 'a and_short_name =
   [%import: 'a Genredexpr.and_short_name]
-  [@@deriving sexp]
+  [@@deriving sexp,yojson,hash,compare]
 
-type wrd_h1 =
-  (Ser_constrexpr.constr_expr,
-   Ser_libnames.qualid Ser_constrexpr.or_by_notation,
-   Ser_constrexpr.constr_expr) red_expr_gen
-  [@@deriving sexp]
+module A = struct
 
-type wrd_h2 =
-  (Ser_genintern.glob_constr_and_expr,
-   Ser_tacred.evaluable_global_reference and_short_name Ser_locus.or_var,
-   Ser_genintern.glob_constr_pattern_and_expr) red_expr_gen
-  [@@deriving sexp]
+  type raw =
+    (Ser_constrexpr.constr_expr,
+     Ser_libnames.qualid Ser_constrexpr.or_by_notation,
+     Ser_constrexpr.constr_expr) red_expr_gen
+  [@@deriving sexp,yojson,hash,compare]
 
-type wrd_h3 =
-  (Ser_eConstr.constr,
-   Ser_tacred.evaluable_global_reference,
-   Ser_pattern.constr_pattern) red_expr_gen
-  [@@deriving sexp]
+  type glb =
+    (Ser_genintern.glob_constr_and_expr,
+     Ser_tacred.evaluable_global_reference and_short_name Ser_locus.or_var,
+     Ser_genintern.glob_constr_pattern_and_expr) red_expr_gen
+  [@@deriving sexp,yojson,hash,compare]
 
-let ser_wit_red_expr = Ser_genarg.{
-    raw_ser = sexp_of_wrd_h1;
-    glb_ser = sexp_of_wrd_h2;
-    top_ser = sexp_of_wrd_h3;
+  type top =
+    (Ser_eConstr.constr,
+     Ser_tacred.evaluable_global_reference,
+     Ser_pattern.constr_pattern) red_expr_gen
+  [@@deriving sexp,yojson,hash,compare]
+end
 
-    raw_des = wrd_h1_of_sexp;
-    glb_des = wrd_h2_of_sexp;
-    top_des = wrd_h3_of_sexp;
-  }
+let ser_wit_red_expr = let module M = Ser_genarg.GS(A) in M.genser
 
 let register () =
     Ser_genarg.register_genser Genredexpr.wit_red_expr ser_wit_red_expr;

--- a/serlib/ser_genredexpr.mli
+++ b/serlib/ser_genredexpr.mli
@@ -28,46 +28,21 @@ val glob_red_flag_of_yojson : (Yojson.Safe.t -> ('a, string) Result.result) -> Y
 val glob_red_flag_to_yojson : ('a -> Yojson.Safe.t) -> 'a glob_red_flag -> Yojson.Safe.t
 
 type ('a, 'b, 'c) red_expr_gen =  ('a, 'b, 'c) Genredexpr.red_expr_gen
-
-val red_expr_gen_of_sexp :
-  (Sexp.t -> 'a) ->
-  (Sexp.t -> 'b) ->
-  (Sexp.t -> 'c) -> Sexp.t -> ('a, 'b, 'c) red_expr_gen
-val sexp_of_red_expr_gen :
-  ('a -> Sexp.t) ->
-  ('b -> Sexp.t) ->
-  ('c -> Sexp.t) -> ('a, 'b, 'c) red_expr_gen -> Sexp.t
+  [@@deriving sexp,yojson,hash,compare]
 
 type ('a, 'b, 'c) may_eval =  ('a, 'b, 'c) Genredexpr.may_eval
-val may_eval_of_sexp :
-  (Sexp.t -> 'a) ->
-  (Sexp.t -> 'b) ->
-  (Sexp.t -> 'c) -> Sexp.t -> ('a, 'b, 'c) may_eval
-val sexp_of_may_eval :
-  ('a -> Sexp.t) ->
-  ('b -> Sexp.t) ->
-  ('c -> Sexp.t) -> ('a, 'b, 'c) may_eval -> Sexp.t
+  [@@deriving sexp,yojson,hash,compare]
 
 type raw_red_expr = Genredexpr.raw_red_expr [@@deriving sexp,yojson,hash,compare]
 
 type r_cst = Genredexpr.r_cst
-val r_cst_of_sexp : Sexp.t -> r_cst
-val sexp_of_r_cst : r_cst -> Sexp.t
-val r_cst_of_yojson : Yojson.Safe.t -> (r_cst, string) Result.result
-val r_cst_to_yojson : r_cst -> Yojson.Safe.t
+  [@@deriving sexp,yojson,hash,compare]
 
 type r_trm = Genredexpr.r_trm
-val r_trm_of_sexp : Sexp.t -> r_trm
-val sexp_of_r_trm : r_trm -> Sexp.t
-val r_trm_of_yojson : Yojson.Safe.t -> (r_trm, string) Result.result
-val r_trm_to_yojson : r_trm -> Yojson.Safe.t
+  [@@deriving sexp,yojson,hash,compare]
 
 type r_pat = Genredexpr.r_pat
-val r_pat_of_sexp : Sexp.t -> r_pat
-val sexp_of_r_pat : r_pat -> Sexp.t
-val r_pat_of_yojson : Yojson.Safe.t -> (r_pat, string) Result.result
-val r_pat_to_yojson : r_pat -> Yojson.Safe.t
+  [@@deriving sexp,yojson,hash,compare]
 
 type 'a and_short_name = 'a Genredexpr.and_short_name
-val and_short_name_of_sexp : (Sexp.t -> 'a) -> Sexp.t -> 'a and_short_name
-val sexp_of_and_short_name : ('a -> Sexp.t) -> 'a and_short_name -> Sexp.t
+  [@@deriving sexp,yojson,hash,compare]

--- a/serlib/ser_glob_term.ml
+++ b/serlib/ser_glob_term.ml
@@ -17,6 +17,8 @@ open Ppx_hash_lib.Std.Hash.Builtin
 open Ppx_compare_lib.Builtin
 open Sexplib.Std
 
+let hash_fold_array = hash_fold_array_frozen
+
 module Loc        = Ser_loc
 module CAst       = Ser_cAst
 module DAst       = Ser_dAst
@@ -48,7 +50,7 @@ type binding_kind =
 
 type glob_sort_name =
   [%import: Glob_term.glob_sort_name]
-  [@@deriving sexp,yojson]
+  [@@deriving sexp,yojson,hash,compare]
 
 type 'a glob_sort_gen =
   [%import: 'a Glob_term.glob_sort_gen]
@@ -60,11 +62,11 @@ type 'a glob_sort_gen =
 
 type glob_level =
   [%import: Glob_term.glob_level]
-  [@@deriving sexp,yojson]
+  [@@deriving sexp,yojson,hash,compare]
 
 type glob_constraint =
   [%import: Glob_term.glob_constraint]
-  [@@deriving sexp,yojson]
+  [@@deriving sexp,yojson,hash,compare]
 
 (* type sort_info =
  *   [%import: Glob_term.sort_info]
@@ -72,7 +74,7 @@ type glob_constraint =
 
 type glob_sort =
   [%import: Glob_term.glob_sort]
-  [@@deriving sexp,yojson]
+  [@@deriving sexp,yojson,hash,compare]
 
 (* type 'a cast_type =
  *   [%import: 'a Glob_term.cast_type]
@@ -84,20 +86,21 @@ type existential_name =
 
 type 'a cases_pattern_r = [%import: 'a Glob_term.cases_pattern_r]
 and 'a cases_pattern_g  = [%import: 'a Glob_term.cases_pattern_g]
-  [@@deriving sexp]
+  [@@deriving sexp,yojson,hash,compare]
 
 type cases_pattern =
   [%import: Glob_term.cases_pattern]
-  [@@deriving sexp]
+  [@@deriving sexp,yojson,hash,compare]
 
 type glob_recarg =
   [%import: Glob_term.glob_recarg]
-  [@@deriving sexp]
+  [@@deriving sexp,yojson,hash,compare]
 
 type glob_fix_kind =
   [%import: Glob_term.glob_fix_kind]
-  [@@deriving sexp]
+  [@@deriving sexp,yojson,hash,compare]
 
+[@@@ocaml.warning "-27"]
 type 'a glob_constr_r        = [%import: 'a Glob_term.glob_constr_r]
 and 'a glob_constr_g         = [%import: 'a Glob_term.glob_constr_g]
 and 'a glob_decl_g           = [%import: 'a Glob_term.glob_decl_g]
@@ -106,28 +109,29 @@ and 'a tomatch_tuple_g       = [%import: 'a Glob_term.tomatch_tuple_g]
 and 'a tomatch_tuples_g      = [%import: 'a Glob_term.tomatch_tuples_g]
 and 'a cases_clause_g        = [%import: 'a Glob_term.cases_clause_g]
 and 'a cases_clauses_g       = [%import: 'a Glob_term.cases_clauses_g]
-  [@@deriving sexp]
+  [@@deriving sexp,yojson,hash,compare]
+[@@@ocaml.warning "+27"]
 
 type glob_constr =
   [%import: Glob_term.glob_constr]
-  [@@deriving sexp]
+  [@@deriving sexp,yojson,hash,compare]
 
 type glob_decl =
   [%import: Glob_term.glob_decl]
-  [@@deriving sexp]
+  [@@deriving sexp,yojson,hash,compare]
 
 type predicate_pattern   = [%import: Glob_term.predicate_pattern]
-  [@@deriving sexp]
+  [@@deriving sexp,yojson,hash,compare]
 
 type tomatch_tuple       = [%import: Glob_term.tomatch_tuple]
-  [@@deriving sexp]
+  [@@deriving sexp,yojson,hash,compare]
 
 type tomatch_tuples      = [%import: Glob_term.tomatch_tuples]
-  [@@deriving sexp]
+  [@@deriving sexp,yojson,hash,compare]
 
 type cases_clause        = [%import: Glob_term.cases_clause]
-  [@@deriving sexp]
+  [@@deriving sexp,yojson,hash,compare]
 
 type cases_clauses       = [%import: Glob_term.cases_clauses]
-  [@@deriving sexp]
+  [@@deriving sexp,yojson,hash,compare]
 

--- a/serlib/ser_glob_term.mli
+++ b/serlib/ser_glob_term.mli
@@ -53,27 +53,4 @@ and tomatch_tuple       = Glob_term.tomatch_tuple
 and tomatch_tuples      = Glob_term.tomatch_tuples
 and cases_clause        = Glob_term.cases_clause
 and cases_clauses       = Glob_term.cases_clauses
-
-val cases_pattern_of_sexp : Sexp.t -> cases_pattern
-val sexp_of_cases_pattern : cases_pattern -> Sexp.t
-
-val glob_constr_of_sexp : Sexp.t -> glob_constr
-val sexp_of_glob_constr : glob_constr -> Sexp.t
-
-val glob_decl_of_sexp : Sexp.t -> glob_decl
-val sexp_of_glob_decl : glob_decl -> Sexp.t
-
-val predicate_pattern_of_sexp : Sexp.t -> predicate_pattern
-val sexp_of_predicate_pattern : predicate_pattern -> Sexp.t
-
-val tomatch_tuple_of_sexp : Sexp.t -> tomatch_tuple
-val sexp_of_tomatch_tuple : tomatch_tuple -> Sexp.t
-
-val tomatch_tuples_of_sexp : Sexp.t -> tomatch_tuples
-val sexp_of_tomatch_tuples : tomatch_tuples -> Sexp.t
-
-val cases_clause_of_sexp : Sexp.t -> cases_clause
-val sexp_of_cases_clause : cases_clause -> Sexp.t
-
-val cases_clauses_of_sexp : Sexp.t -> cases_clauses
-val sexp_of_cases_clauses : cases_clauses -> Sexp.t
+  [@@deriving sexp,yojson,hash,compare]

--- a/serlib/ser_hints.ml
+++ b/serlib/ser_hints.ml
@@ -25,19 +25,19 @@ module Genarg      = Ser_genarg
 
 type hint_db_name =
   [%import: Hints.hint_db_name]
-  [@@deriving sexp,yojson]
+  [@@deriving sexp,yojson,hash,compare]
 
 type 'a hints_path_atom_gen =
   [%import: 'a Hints.hints_path_atom_gen]
-  [@@deriving sexp,yojson]
+  [@@deriving sexp,yojson,hash,compare]
 
 type 'a hints_path_gen =
   [%import: 'a Hints.hints_path_gen]
-  [@@deriving sexp,yojson]
+  [@@deriving sexp,yojson,hash,compare]
 
 type hints_path =
   [%import: Hints.hints_path]
-  [@@deriving sexp,yojson]
+  [@@deriving sexp,yojson,hash,compare]
 
 type hint_mode =
   [%import: Hints.hint_mode]

--- a/serlib/ser_hints.mli
+++ b/serlib/ser_hints.mli
@@ -13,27 +13,17 @@
 (* Status: Very Experimental                                            *)
 (************************************************************************)
 
-open Sexplib
-
 type hint_db_name = Hints.hint_db_name
-
-val sexp_of_hint_db_name : hint_db_name -> Sexp.t
-val hint_db_name_of_sexp : Sexp.t -> hint_db_name
+ [@@deriving sexp,yojson,hash,compare]
 
 type 'a hints_path_gen = 'a Hints.hints_path_gen
-
-val sexp_of_hints_path_gen : ('a -> Sexp.t) -> 'a hints_path_gen -> Sexp.t
-val hints_path_gen_of_sexp : (Sexp.t -> 'a) -> Sexp.t -> 'a hints_path_gen
+ [@@deriving sexp,yojson,hash,compare]
 
 type 'a hints_path_atom_gen = 'a Hints.hints_path_atom_gen
-
-val sexp_of_hints_path_atom_gen : ('a -> Sexp.t) -> 'a hints_path_atom_gen -> Sexp.t
-val hints_path_atom_gen_of_sexp : (Sexp.t -> 'a) -> Sexp.t -> 'a hints_path_atom_gen
+ [@@deriving sexp,yojson,hash,compare]
 
 type hints_path = Hints.hints_path
-
-val sexp_of_hints_path : hints_path -> Sexp.t
-val hints_path_of_sexp : Sexp.t -> hints_path
+ [@@deriving sexp,yojson,hash,compare]
 
 type 'a hints_transparency_target = 'a Hints.hints_transparency_target [@@deriving sexp,yojson,hash,compare]
 type hint_mode = Hints.hint_mode [@@deriving sexp,yojson,hash,compare]

--- a/serlib/ser_impargs.ml
+++ b/serlib/ser_impargs.ml
@@ -13,8 +13,9 @@
 (* Status: Very Experimental                                            *)
 (************************************************************************)
 
-open Sexplib
 open Sexplib.Std
+open Ppx_hash_lib.Std.Hash.Builtin
+open Ppx_compare_lib.Builtin
 
 module Names = Ser_names
 module Constrexpr = Ser_constrexpr
@@ -35,17 +36,21 @@ type force_inference =
   [%import: Impargs.force_inference]
   [@@deriving sexp]
 
-(* XXX: Careful here, we break abstraction, so this must be kept in sync with Coq. *)
-type _implicit_side_condition = DefaultImpArgs | LessArgsThan of int
-  [@@deriving sexp]
+module ISCPierceSpec = struct
+  type t = Impargs.implicit_side_condition
+  type _t = DefaultImpArgs | LessArgsThan of int
+  [@@deriving sexp,yojson,hash,compare]
+end
 
-type implicit_side_condition = Impargs.implicit_side_condition
-
-let implicit_side_condition_of_sexp (sexp : Sexp.t) : implicit_side_condition =
-  Obj.magic (_implicit_side_condition_of_sexp sexp)
-
-let sexp_of_implicit_side_condition (isc : implicit_side_condition) : Sexp.t =
-  sexp_of__implicit_side_condition (Obj.magic isc)
+module B_ = SerType.Pierce(ISCPierceSpec)
+type implicit_side_condition = B_.t
+let sexp_of_implicit_side_condition = B_.sexp_of_t
+let implicit_side_condition_of_sexp = B_.t_of_sexp
+let implicit_side_condition_of_yojson = B_.of_yojson
+let implicit_side_condition_to_yojson = B_.to_yojson
+let hash_implicit_side_condition = B_.hash
+let hash_fold_implicit_side_condition = B_.hash_fold_t
+let compare_implicit_side_condition = B_.compare
 
 type implicit_position =
   [%import: Impargs.implicit_position]

--- a/serlib/ser_impargs.mli
+++ b/serlib/ser_impargs.mli
@@ -36,9 +36,7 @@ val force_inference_of_sexp : Sexp.t -> force_inference
 val sexp_of_force_inference : force_inference -> Sexp.t
 
 type implicit_side_condition = Impargs.implicit_side_condition
-
-val implicit_side_condition_of_sexp : Sexp.t -> implicit_side_condition
-val sexp_of_implicit_side_condition : implicit_side_condition -> Sexp.t
+  [@@deriving sexp,yojson,hash,compare]
 
 type implicit_status = Impargs.implicit_status
 

--- a/serlib/ser_int.ml
+++ b/serlib/ser_int.ml
@@ -14,9 +14,11 @@
 (* Status: Very Experimental                                            *)
 (************************************************************************)
 
+open Ppx_hash_lib.Std.Hash.Builtin
+open Ppx_compare_lib.Builtin
 open Sexplib.Conv
 
 type t =
   [%import: Int.t]
-  [@@deriving sexp]
+  [@@deriving sexp,yojson,hash,compare]
 

--- a/serlib/ser_int.mli
+++ b/serlib/ser_int.mli
@@ -14,9 +14,5 @@
 (* Status: Very Experimental                                            *)
 (************************************************************************)
 
-open Sexplib
-
 type t = Int.t
-
-val t_of_sexp : Sexp.t -> t
-val sexp_of_t : t -> Sexp.t
+  [@@deriving sexp,yojson,hash,compare]

--- a/serlib/ser_inv.ml
+++ b/serlib/ser_inv.ml
@@ -15,4 +15,4 @@
 
 type inversion_kind =
   [%import: Inv.inversion_kind]
-  [@@deriving sexp]
+  [@@deriving sexp,yojson,hash,compare]

--- a/serlib/ser_inv.mli
+++ b/serlib/ser_inv.mli
@@ -13,9 +13,5 @@
 (* Status: Experimental                                                 *)
 (************************************************************************)
 
-open Sexplib
-
 type inversion_kind = Inv.inversion_kind
-
-val inversion_kind_of_sexp : Sexp.t -> inversion_kind
-val sexp_of_inversion_kind : inversion_kind -> Sexp.t
+  [@@deriving sexp,yojson,hash,compare]

--- a/serlib/ser_loc.ml
+++ b/serlib/ser_loc.ml
@@ -18,20 +18,21 @@
 (**********************************************************************)
 
 open Sexplib.Std
+open Ppx_hash_lib.Std.Hash.Builtin
+open Ppx_compare_lib.Builtin
 
 type source =
   [%import: Loc.source]
-  [@@deriving sexp,yojson]
+  [@@deriving sexp,yojson,hash,compare]
 
 type t =
   [%import: Loc.t]
-  [@@deriving sexp,yojson]
+  [@@deriving sexp,yojson,hash,compare]
 
 let omit_loc = ref false
 let sexp_of_t x =
   if !omit_loc then Sexplib.Sexp.Atom "[LOC]" else sexp_of_t x
 
 (* located: public *)
-type 'a located =
-  [%import: 'a Loc.located]
-  [@@deriving sexp,yojson]
+type 'a located = (t option [@ignore]) * 'a
+  [@@deriving sexp,yojson,hash,compare]

--- a/serlib/ser_loc.mli
+++ b/serlib/ser_loc.mli
@@ -17,21 +17,11 @@
 (* Loc.mli                                                            *)
 (**********************************************************************)
 
-open Sexplib
-
 type t = Loc.t
-
-val t_of_sexp : Sexp.t -> Loc.t
-val sexp_of_t : Loc.t -> Sexp.t
-
-val of_yojson : Yojson.Safe.t -> (t, string) Result.result
-val to_yojson : t -> Yojson.Safe.t
+  [@@deriving sexp,yojson,hash,compare]
 
 (* Don't print locations. Global-flag Hack. *)
 val omit_loc : bool ref
 
 type 'a located = 'a Loc.located
-val located_of_sexp : (Sexp.t -> 'a) -> Sexp.t -> 'a Loc.located
-val sexp_of_located : ('a -> Sexp.t) -> 'a Loc.located -> Sexp.t
-val located_of_yojson : (Yojson.Safe.t -> ('a, string) Result.result) -> Yojson.Safe.t -> ('a located, string) Result.result
-val located_to_yojson : ('a -> Yojson.Safe.t) -> 'a located -> Yojson.Safe.t
+  [@@deriving sexp,yojson,hash,compare]

--- a/serlib/ser_locus.ml
+++ b/serlib/ser_locus.ml
@@ -41,15 +41,15 @@ type occurrences =
 
 type hyp_location_flag =
   [%import: Locus.hyp_location_flag]
-  [@@deriving sexp]
+  [@@deriving sexp,yojson,hash,compare]
 
 type 'a hyp_location_expr =
   [%import: 'a Locus.hyp_location_expr]
-  [@@deriving sexp]
+  [@@deriving sexp,yojson,hash,compare]
 
 type 'id clause_expr =
   [%import: 'id Locus.clause_expr]
-  [@@deriving sexp]
+  [@@deriving sexp,yojson,hash,compare]
 
 type clause =
   [%import: Locus.clause]
@@ -65,7 +65,7 @@ type concrete_clause =
 
 type hyp_location =
   [%import: Locus.hyp_location]
-  [@@deriving sexp]
+  [@@deriving sexp,yojson,hash,compare]
 
 type goal_location =
   [%import: Locus.goal_location]

--- a/serlib/ser_locus.mli
+++ b/serlib/ser_locus.mli
@@ -16,10 +16,7 @@
 open Sexplib
 
 type 'a or_var = 'a Locus.or_var
-val or_var_of_sexp : (Sexp.t -> 'a) -> Sexp.t -> 'a or_var
-val sexp_of_or_var : ('a -> Sexp.t) -> 'a or_var -> Sexp.t
-val or_var_of_yojson : (Yojson.Safe.t -> ('a, string) Result.result) -> Yojson.Safe.t -> ('a or_var, string) Result.result
-val or_var_to_yojson : ('a -> Yojson.Safe.t) -> 'a or_var -> Yojson.Safe.t
+  [@@deriving sexp,yojson,hash,compare]
 
 type 'a occurrences_gen = 'a Locus.occurrences_gen
 val occurrences_gen_of_sexp : (Sexp.t -> 'a) -> Sexp.t -> 'a occurrences_gen
@@ -37,18 +34,14 @@ val occurrences_of_sexp : Sexp.t -> occurrences
 val sexp_of_occurrences : occurrences -> Sexp.t
 
 type hyp_location_flag = Locus.hyp_location_flag
-
-val hyp_location_flag_of_sexp : Sexp.t -> hyp_location_flag
-val sexp_of_hyp_location_flag : hyp_location_flag -> Sexp.t
+  [@@deriving sexp,hash,compare]
 
 type 'a hyp_location_expr = 'a Locus.hyp_location_expr
 val hyp_location_expr_of_sexp : (Sexp.t -> 'a) -> Sexp.t -> 'a hyp_location_expr
 val sexp_of_hyp_location_expr : ('a -> Sexp.t) -> 'a hyp_location_expr -> Sexp.t
 
 type 'id clause_expr = 'id Locus.clause_expr
-
-val clause_expr_of_sexp : (Sexp.t -> 'id) -> Sexp.t -> 'id clause_expr
-val sexp_of_clause_expr : ('id -> Sexp.t) -> 'id clause_expr -> Sexp.t
+  [@@deriving sexp,yojson,hash,compare]
 
 type clause = Locus.clause
 
@@ -66,9 +59,7 @@ val concrete_clause_of_sexp : Sexp.t -> concrete_clause
 val sexp_of_concrete_clause : concrete_clause -> Sexp.t
 
 type hyp_location = Locus.hyp_location
-
-val hyp_location_of_sexp : Sexp.t -> hyp_location
-val sexp_of_hyp_location : hyp_location -> Sexp.t
+  [@@deriving sexp,yojson,hash,compare]
 
 type goal_location = Locus.goal_location
 

--- a/serlib/ser_ltac_pretype.ml
+++ b/serlib/ser_ltac_pretype.ml
@@ -14,6 +14,9 @@
 (************************************************************************)
 
 open Sexplib.Conv
+open Ppx_compare_lib.Builtin
+open Ppx_hash_lib.Std.Hash.Builtin
+
 module Names     = Ser_names
 module Constr    = Ser_constr
 module Glob_term = Ser_glob_term
@@ -23,9 +26,9 @@ module Geninterp = Ser_geninterp
 
 type constr_under_binders =
   [%import: Ltac_pretype.constr_under_binders]
-  [@@deriving sexp]
+  [@@deriving sexp,hash,compare]
 
 type closure = [%import: Ltac_pretype.closure]
 and closed_glob_constr = [%import: Ltac_pretype.closed_glob_constr]
-  [@@deriving sexp]
+  [@@deriving sexp,hash,compare]
 

--- a/serlib/ser_ltac_pretype.mli
+++ b/serlib/ser_ltac_pretype.mli
@@ -16,13 +16,12 @@
 open Sexplib
 
 type closure = Ltac_pretype.closure
-type closed_glob_constr = Ltac_pretype.closed_glob_constr
 
 val closure_of_sexp : Sexp.t -> closure
 val sexp_of_closure : closure -> Sexp.t
 
-val closed_glob_constr_of_sexp : Sexp.t -> closed_glob_constr
-val sexp_of_closed_glob_constr : closed_glob_constr -> Sexp.t
+type closed_glob_constr = Ltac_pretype.closed_glob_constr
+  [@@deriving sexp,hash,compare]
 
 type constr_under_binders = Ltac_pretype.constr_under_binders
 

--- a/serlib/ser_mod_subst.ml
+++ b/serlib/ser_mod_subst.ml
@@ -17,31 +17,34 @@
 
 module Names = Ser_names
 
-type delta_resolver =
-  [%import: Mod_subst.delta_resolver]
+module OD = struct
+  type t = Mod_subst.delta_resolver
+  let name = "Mod_subst.delta_resolver"
+end
 
-let sexp_of_delta_resolver =
-  Serlib_base.sexp_of_opaque ~typ:"Mod_subst.delta_resolver"
+module A_ = SerType.Opaque(OD)
 
-let delta_resolver_of_sexp =
-  Serlib_base.opaque_of_sexp ~typ:"Mod_subst.delta_resolver"
+type delta_resolver = A_.t
+let sexp_of_delta_resolver = A_.sexp_of_t
+let delta_resolver_of_sexp = A_.t_of_sexp
+let delta_resolver_of_yojson = A_.of_yojson
+let delta_resolver_to_yojson = A_.to_yojson
+let hash_delta_resolver = A_.hash
+let hash_fold_delta_resolver = A_.hash_fold_t
+let compare_delta_resolver = A_.compare
 
-(* type substitution = (Names.ModPath.t * delta_resolver) Names.Umap.t
- *   [@@deriving sexp] *)
+module OS = struct
+  type t = Mod_subst.substitution
+  let name = "Mod_subst.substitution"
+end
 
-type substitution =
-  [%import: Mod_subst.substitution]
+module B_ = SerType.Opaque(OS)
 
-let sexp_of_substitution = Serlib_base.sexp_of_opaque ~typ:"Mod_subst.substitution"
-let substitution_of_sexp = Serlib_base.opaque_of_sexp ~typ:"Mod_subst.substitution"
-
-(* type 'a _substituted = {
- *   mutable subst_value : 'a;
- *   mutable subst_subst : substitution list;
- * } [@@deriving sexp]
- * 
- * type 'a substituted =
- *   [%import: 'a Mod_subst.substituted]
- * 
- * let sexp_of_substituted f x = sexp_of__substituted f (Obj.magic x)
- * let substituted_of_sexp f x = Obj.magic (_substituted_of_sexp f x) *)
+type substitution = B_.t
+let sexp_of_substitution = B_.sexp_of_t
+let substitution_of_sexp = B_.t_of_sexp
+let substitution_of_yojson = B_.of_yojson
+let substitution_to_yojson = B_.to_yojson
+let hash_substitution = B_.hash
+let hash_fold_substitution = B_.hash_fold_t
+let compare_substitution = B_.compare

--- a/serlib/ser_mod_subst.mli
+++ b/serlib/ser_mod_subst.mli
@@ -13,15 +13,11 @@
 (* Status: Experimental                                                 *)
 (************************************************************************)
 
-open Sexplib
-
 type delta_resolver = Mod_subst.delta_resolver
-val sexp_of_delta_resolver : delta_resolver -> Sexp.t
-val delta_resolver_of_sexp : Sexp.t -> delta_resolver
+ [@@deriving sexp,yojson,hash,compare]
 
 type substitution = Mod_subst.substitution
-val sexp_of_substitution : substitution -> Sexp.t
-val substitution_of_sexp : Sexp.t -> substitution
+ [@@deriving sexp,yojson,hash,compare]
 
 (* type 'a substituted = 'a Mod_subst.substituted
  * val sexp_of_substituted : ('a -> Sexp.t) -> 'a substituted -> Sexp.t

--- a/serlib/ser_names.ml
+++ b/serlib/ser_names.ml
@@ -16,9 +16,9 @@
 (* Status: Very Experimental                                            *)
 (************************************************************************)
 
+open Sexplib.Std
 open Ppx_hash_lib.Std.Hash.Builtin
 open Ppx_compare_lib.Builtin
-open Sexplib.Std
 
 open Names
 
@@ -29,32 +29,22 @@ module CAst = Ser_cAst
 (* Serialization of Names.mli                                           *)
 (************************************************************************)
 
-(* Id.t: private *)
 module Id = struct
 
-module Self = struct
-type t   = [%import: Names.Id.t]
+  (* Id.t: private *)
+  module Id_ = struct
+    type t = Names.Id.t
+    type _t = Id of string [@@deriving sexp, yojson, hash, compare]
+    let of_t id = Id (Id.to_string id)
+    let to_t (Id id) = Id.of_string_soft id
+  end
 
-type _t            = Id of string [@@deriving sexp, yojson, hash, compare]
-let _t_put  id     = Id (Id.to_string id)
-let _t_get (Id id) = Id.of_string_soft id
+  module Self = SerType.Biject(Id_)
 
-let t_of_sexp sexp = _t_get (_t_of_sexp sexp)
-let sexp_of_t id   = sexp_of__t (_t_put id)
+  include Self
 
-let of_yojson json = Ppx_deriving_yojson_runtime.(_t_of_yojson json >|= _t_get)
-let to_yojson level = _t_to_yojson (_t_put level)
-
-let hash x = hash__t (_t_put x)
-let hash_fold_t st id = hash_fold__t st (_t_put id)
-
-let compare x y = compare__t (_t_put x) (_t_put y)
-end
-
-include Self
-
-module Set = Ser_cSet.Make(Names.Id.Set)(Self)
-module Map = Ser_cMap.Make(Names.Id.Map)(Self)
+  module Set = Ser_cSet.Make(Names.Id.Set)(Self)
+  module Map = Ser_cMap.Make(Names.Id.Map)(Self)
 
 end
 
@@ -69,25 +59,17 @@ end
 
 module DirPath = struct
 
-(* DirPath.t: private *)
-type t = [%import: Names.DirPath.t]
+  (* DirPath.t: private *)
+  module DirPath_ = struct
+    type t = Names.DirPath.t
+    type _t = DirPath of Id.t list
+    [@@deriving sexp,yojson,hash,compare]
 
-type _t = DirPath of Id.t list
-      [@@deriving sexp,yojson,hash,compare]
+    let of_t dp = DirPath (DirPath.repr dp)
+    let to_t (DirPath dpl) = DirPath.make dpl
+  end
 
-let _t_put dp            = DirPath (DirPath.repr dp)
-let _t_get (DirPath dpl) = DirPath.make dpl
-
-let t_of_sexp sexp = _t_get (_t_of_sexp sexp)
-let sexp_of_t dp   = sexp_of__t (_t_put dp)
-
-let of_yojson json = Ppx_deriving_yojson_runtime.(_t_of_yojson json >|= _t_get)
-let to_yojson level = _t_to_yojson (_t_put level)
-
-let hash x = hash__t (_t_put x)
-let hash_fold_t st id = hash_fold__t st (_t_put id)
-
-let compare x y = compare__t (_t_put x) (_t_put y)
+  include SerType.Biject(DirPath_)
 
 end
 
@@ -95,46 +77,33 @@ module DPmap = Ser_cMap.Make(DPmap)(DirPath)
 
 module Label = struct
 
-(* Label.t: private *)
-type t = [%import: Names.Label.t]
+  (* Label.t: private *)
+  module Label_= struct
+    type t = [%import: Names.Label.t]
 
-(* XXX: This will miss the tag *)
-let t_of_sexp sexp  = Label.of_id (Id.t_of_sexp sexp)
-let sexp_of_t label = Id.sexp_of_t (Label.to_id label)
+    (* XXX: This will miss the tag *)
+    type _t = Id.t
+    [@@deriving sexp,yojson,hash,compare]
 
-let of_yojson json = Ppx_deriving_yojson_runtime.(Id.of_yojson json >|= Label.of_id)
-let to_yojson level = Id.to_yojson (Label.to_id level)
+    let to_t = Label.of_id
+    let of_t = Label.to_id
+  end
 
-(* let hash x = Id.hash (Label.to_id x) *)
-let hash_fold_t st id = Id.hash_fold_t st (Label.to_id id)
-
-let _t_put x = Label.to_id x
-let compare x y = Id.compare (_t_put x) (_t_put y)
-
+  include SerType.Biject(Label_)
 end
 
 module MBId = struct
 
-(* MBId.t: private *)
-type t = [%import: Names.MBId.t]
+  (* MBId.t: private *)
+  module MBIdBij = struct
+    type t = [%import: Names.MBId.t]
 
-type _t = Mbid of int * Id.t * DirPath.t
-      [@@deriving sexp,yojson,hash,compare]
+    type _t = Mbid of int * Id.t * DirPath.t
+    [@@deriving sexp,yojson,hash,compare]
 
-let _t_put dp              =
-  let i, n, dp = MBId.repr dp in Mbid (i,n,dp)
-let _t_get (Mbid (i, n, dp)) = Obj.magic (i, n, dp)
+  end
 
-let t_of_sexp sexp = _t_get (_t_of_sexp sexp)
-let sexp_of_t dp   = sexp_of__t (_t_put dp)
-
-let of_yojson json = Ppx_deriving_yojson_runtime.(_t_of_yojson json >|= _t_get)
-let to_yojson level = _t_to_yojson (_t_put level)
-
-(* let hash x = hash__t (_t_put x) *)
-let hash_fold_t st id = hash_fold__t st (_t_put id)
-
-let compare x y = compare__t (_t_put x) (_t_put y)
+include SerType.Pierce(MBIdBij)
 
 end
 
@@ -211,29 +180,21 @@ module Cmap_env = Ser_cMap.Make(Cmap_env)(Constant)
 module MutInd = struct
 
 (* MutInd.t: private *)
-type t = [%import: Names.MutInd.t]
+  module BijectSpec = struct
+    type t = [%import: Names.MutInd.t]
+    type _t = MutInd of KerName.t * KerName.t option
+    [@@deriving sexp,yojson,hash,compare]
 
-type _t = MutInd of KerName.t * KerName.t option
-      [@@deriving sexp,yojson,hash,compare]
+    let of_t cs =
+      let cu, cc = MutInd.(user cs, canonical cs) in
+      if KerName.equal cu cc then MutInd (cu, None) else MutInd (cu, Some cc)
 
-let _t_put cs              =
-  let cu, cc = MutInd.(user cs, canonical cs) in
-  if KerName.equal cu cc then MutInd (cu, None) else MutInd (cu, Some cc)
-let _t_get = function
-  | MutInd (cu, None) -> MutInd.make1 cu
-  | MutInd (cu, Some cc) -> MutInd.make cu cc
+    let to_t = function
+      | MutInd (cu, None) -> MutInd.make1 cu
+      | MutInd (cu, Some cc) -> MutInd.make cu cc
+  end
 
-let t_of_sexp sexp = _t_get (_t_of_sexp sexp)
-let sexp_of_t dp   = sexp_of__t (_t_put dp)
-
-let of_yojson json = Ppx_deriving_yojson_runtime.(_t_of_yojson json >|= _t_get)
-let to_yojson level = _t_to_yojson (_t_put level)
-
-(* let hash x = hash__t (_t_put x) *)
-let hash_fold_t st id = hash_fold__t st (_t_put id)
-
-let compare x y = compare__t (_t_put x) (_t_put y)
-
+  include SerType.Biject(BijectSpec)
 end
 
 module Mindmap = Ser_cMap.Make(Mindmap)(MutInd)
@@ -274,35 +235,25 @@ type constructor =
 module Projection = struct
 
   module Repr = struct
-    type _t =
-      { proj_ind : inductive
-      ; proj_npars : int
-      ; proj_arg : int
-      ; proj_name : Label.t
-      } [@@deriving sexp,yojson]
-
-    (* missing from OCaml 4.07 , after, it is [Result.map] *)
-    let result_map f = function
-      | Ok x -> Ok (f x)
-      | Error e -> Error e
-
-    type t = Names.Projection.Repr.t
-    let t_of_sexp p = Obj.magic (_t_of_sexp p)
-    let sexp_of_t p = sexp_of__t (Obj.magic p)
-    let to_yojson p = _t_to_yojson (Obj.magic p)
-    let of_yojson p = _t_of_yojson p |> result_map Obj.magic
+    module PierceSpec = struct
+      type t = Names.Projection.Repr.t
+      type _t =
+        { proj_ind : inductive
+        ; proj_relevant : bool
+        ; proj_npars : int
+        ; proj_arg : int
+        ; proj_name : Label.t
+        } [@@deriving sexp,yojson,hash,compare]
+    end
+    include SerType.Pierce(PierceSpec)
   end
 
-  type _t = Repr.t * bool
-  [@@deriving sexp,yojson]
-
-  type t = [%import: Names.Projection.t]
-
-  let t_of_sexp se = Obj.magic (_t_of_sexp se)
-  let sexp_of_t dp = sexp_of__t (Obj.magic dp)
-
-  let of_yojson json = Ppx_deriving_yojson_runtime.(_t_of_yojson json >|= Obj.magic)
-  let to_yojson level = _t_to_yojson (Obj.magic level)
+  module PierceSpec = struct
+    type t = [%import: Names.Projection.t]
+    type _t = Repr.t * bool
+    [@@deriving sexp,yojson,hash,compare]
+  end
+  include SerType.Pierce(PierceSpec)
 end
 
 module GlobRef = struct

--- a/serlib/ser_names.mli
+++ b/serlib/ser_names.mli
@@ -22,17 +22,17 @@ open Sexplib
 module Id : sig
   include SerType.SJHC with type t = Id.t
 
-  module Set : SerType.S with type t = Id.Set.t
-  module Map : SerType.S1 with type 'a t = 'a Id.Map.t
+  module Set : SerType.SJHC with type t = Id.Set.t
+  module Map : SerType.SJHC1 with type 'a t = 'a Id.Map.t
 end
 
 module Name    : SerType.SJHC with type t = Name.t
 module DirPath : SerType.SJHC with type t = DirPath.t
 module DPmap   : Ser_cMap.ExtS with type key = DirPath.t and type 'a t = 'a DPmap.t
 
-module Label   : SerType.SJ with type t = Label.t
-module MBId    : SerType.SJ with type t = MBId.t
-module ModPath : SerType.SJ with type t = ModPath.t
+module Label   : SerType.SJHC with type t = Label.t
+module MBId    : SerType.SJHC with type t = MBId.t
+module ModPath : SerType.SJHC with type t = ModPath.t
 module MPmap   : Ser_cMap.ExtS with type key = ModPath.t and type 'a t = 'a MPmap.t
 
 module KerName  : SerType.SJHC with type t = KerName.t
@@ -61,7 +61,7 @@ type constructor = Names.constructor [@@deriving sexp, yojson, hash, compare]
 
 module Projection : sig
 
-  include SerType.SJ with type t = Projection.t
+  include SerType.SJHC with type t = Projection.t
 
   module Repr : sig
     include SerType.S with type t = Projection.Repr.t

--- a/serlib/ser_notation_term.ml
+++ b/serlib/ser_notation_term.ml
@@ -19,19 +19,21 @@ module Loc        = Ser_loc
 module Names      = Ser_names
 module Tok        = Ser_tok
 
-open Sexplib.Conv
+open Sexplib.Std
+open Ppx_hash_lib.Std.Hash.Builtin
+open Ppx_compare_lib.Builtin
 
 type scope_name =
   [%import: Notation_term.scope_name]
-  [@@deriving sexp,yojson]
+  [@@deriving sexp,yojson,hash,compare]
 
 type tmp_scope_name =
   [%import: Notation_term.tmp_scope_name]
-  [@@deriving sexp]
+  [@@deriving sexp,yojson,hash,compare]
 
 type subscopes =
   [%import: Notation_term.subscopes]
-  [@@deriving sexp]
+  [@@deriving sexp,yojson,hash,compare]
 
 (* type notation_spec = *)
 (*   [%import: Notation_term.notation_spec] *)
@@ -47,5 +49,5 @@ type constr_as_binder_kind =
 
 type notation_var_internalization_type =
   [%import: Notation_term.notation_var_internalization_type]
-  [@@deriving sexp]
+  [@@deriving sexp,yojson,hash,compare]
 

--- a/serlib/ser_notation_term.mli
+++ b/serlib/ser_notation_term.mli
@@ -13,14 +13,11 @@
 (* Status: Very Experimental                                            *)
 (************************************************************************)
 
-open Sexplib
-
 type subscopes = Notation_term.subscopes
-val subscopes_of_sexp : Sexp.t -> subscopes
-val sexp_of_subscopes : subscopes -> Sexp.t
+  [@@deriving sexp,yojson,hash,compare]
 
-type constr_as_binder_kind = Notation_term.constr_as_binder_kind [@@deriving sexp,yojson,hash,compare]
+type constr_as_binder_kind = Notation_term.constr_as_binder_kind
+  [@@deriving sexp,yojson,hash,compare]
 
 type notation_var_internalization_type = Notation_term.notation_var_internalization_type
-val notation_var_internalization_type_of_sexp : Sexp.t -> notation_var_internalization_type
-val sexp_of_notation_var_internalization_type : notation_var_internalization_type -> Sexp.t
+  [@@deriving sexp,yojson,hash,compare]

--- a/serlib/ser_numTok.ml
+++ b/serlib/ser_numTok.ml
@@ -31,20 +31,16 @@ type 'a exp =
 
 module Unsigned = struct
 
-  type _t = {
-    int : string;
-    frac : string;
-    exp : string
-  } [@@deriving sexp,yojson,hash,compare]
+  module PierceSpec = struct
+    type t = NumTok.Unsigned.t
+    type _t = {
+      int : string;
+      frac : string;
+      exp : string
+    } [@@deriving sexp,yojson,hash,compare]
+  end
 
-  type t = NumTok.Unsigned.t
-  let t_of_sexp s = Obj.magic (_t_of_sexp s)
-  let sexp_of_t s = sexp_of__t (Obj.magic s)
-  let of_yojson s = Obj.magic (_t_of_yojson s)
-  let to_yojson s = _t_to_yojson (Obj.magic s)
-  let hash level = hash__t (Obj.magic level)
-  let hash_fold_t st level = hash_fold__t st (Obj.magic level)
-  let compare x y = compare__t (Obj.magic x) (Obj.magic y)
+  include SerType.Pierce(PierceSpec)
 end
 
 module Signed = struct

--- a/serlib/ser_opaqueproof.mli
+++ b/serlib/ser_opaqueproof.mli
@@ -13,20 +13,8 @@
 (* Status: Experimental                                                 *)
 (************************************************************************)
 
-open Sexplib
-
-(* type work_list = Opaqueproof.work_list
- * val sexp_of_work_list : work_list -> Sexp.t
- * val work_list_of_sexp : Sexp.t -> work_list *)
-
-(* type cooking_info = Opaqueproof.cooking_info
- * val sexp_of_cooking_info : cooking_info -> Sexp.t
- * val cooking_info_of_sexp : Sexp.t -> cooking_info *)
-
 type opaque = Opaqueproof.opaque
-val sexp_of_opaque : opaque -> Sexp.t
-val opaque_of_sexp : Sexp.t -> opaque
+  [@@deriving sexp,yojson,hash,compare]
 
 type opaquetab = Opaqueproof.opaquetab
-val sexp_of_opaquetab : opaquetab -> Sexp.t
-val opaquetab_of_sexp : Sexp.t -> opaquetab
+  [@@deriving sexp,yojson,hash,compare]

--- a/serlib/ser_pattern.ml
+++ b/serlib/ser_pattern.ml
@@ -14,6 +14,8 @@
 (************************************************************************)
 
 open Sexplib.Std
+open Ppx_hash_lib.Std.Hash.Builtin
+open Ppx_compare_lib.Builtin
 
 module Names     = Ser_names
 module Uint63    = Ser_uint63
@@ -30,8 +32,10 @@ type patvar =
 
 type case_info_pattern =
   [%import: Pattern.case_info_pattern]
-  [@@deriving sexp]
+  [@@deriving sexp,yojson,hash,compare]
+
+let hash_fold_array = hash_fold_array_frozen
 
 type constr_pattern =
   [%import: Pattern.constr_pattern]
-  [@@deriving sexp]
+  [@@deriving sexp,yojson,hash,compare]

--- a/serlib/ser_pattern.mli
+++ b/serlib/ser_pattern.mli
@@ -23,6 +23,4 @@ val case_info_pattern_of_sexp : Sexp.t -> case_info_pattern
 val sexp_of_case_info_pattern : case_info_pattern -> Sexp.t
 
 type constr_pattern = Pattern.constr_pattern
-
-val constr_pattern_of_sexp : Sexp.t -> constr_pattern
-val sexp_of_constr_pattern : constr_pattern -> Sexp.t
+  [@@deriving sexp,yojson,hash,compare]

--- a/serlib/ser_rtree.ml
+++ b/serlib/ser_rtree.ml
@@ -14,15 +14,20 @@
 (* Status: Very Experimental                                            *)
 (************************************************************************)
 
-open Sexplib.Conv
+open Sexplib.Std
+open Ppx_compare_lib.Builtin
+open Ppx_hash_lib.Std.Hash.Builtin
 
-type 'a _t =
-    Param of int * int
-  | Node of 'a * 'a _t array
-  | Rec of int * 'a _t array
-[@@deriving sexp]
+let hash_fold_array = hash_fold_array_frozen
 
-type 'a t = 'a Rtree.t
+module RTreePierce = struct
 
-let sexp_of_t f r = sexp_of__t f (Obj.magic r)
-let t_of_sexp f r = Obj.magic (_t_of_sexp f r)
+  type 'a t = 'a Rtree.t
+  type 'a _t =
+    | Param of int * int
+    | Node of 'a * 'a _t array
+    | Rec of int * 'a _t array
+  [@@deriving sexp,yojson,hash,compare]
+end
+
+include SerType.Pierce1(RTreePierce)

--- a/serlib/ser_safe_typing.ml
+++ b/serlib/ser_safe_typing.ml
@@ -16,6 +16,8 @@
 (* Status: Very Experimental                                            *)
 (************************************************************************)
 
+open Ppx_hash_lib.Std.Hash.Builtin
+open Ppx_compare_lib.Builtin
 open Sexplib.Std
 
 module ONames = Names
@@ -31,34 +33,39 @@ module Univ = Ser_univ
 type certificate = {
   certif_struc : Declarations.structure_body;
   certif_univs : Univ.ContextSet.t;
-} [@@deriving sexp]
+} [@@deriving sexp,yojson,hash,compare]
 
 type side_effect = {
   from_env : certificate CEphemeron.key;
   seff_constant : Names.Constant.t;
   seff_body : Declarations.constant_body;
-} [@@deriving sexp]
+} [@@deriving sexp,yojson,hash,compare]
 
 module SeffOrd = struct
   type t = side_effect
-  let compare e1 e2 = ONames.Constant.CanOrd.compare e1.seff_constant e2.seff_constant
-  let t_of_sexp = side_effect_of_sexp
-  let sexp_of_t = sexp_of_side_effect
+  [@@deriving sexp,yojson,hash,compare]
 end
 
 module SeffSet = Set.Make(SeffOrd)
 module SerSeffSet = Ser_cSet.Make(SeffSet)(SeffOrd)
 
-type _t = { seff : side_effect list; elts : SerSeffSet.t }
- [@@deriving sexp]
+module PC = struct
+  (* t  private_constants *)
+  type t = Safe_typing.private_constants
+  type _t = { seff : side_effect list; elts : SerSeffSet.t }
+  [@@deriving sexp,yojson,hash,compare]
+end
 
-type _private_constants = _t
- [@@deriving sexp]
+module B_ = SerType.Pierce(PC)
 
 type private_constants = Safe_typing.private_constants
-
-let sexp_of_private_constants x = sexp_of__private_constants (Obj.magic x)
-let private_constants_of_sexp x = Obj.magic (_private_constants_of_sexp x)
+let sexp_of_private_constants = B_.sexp_of_t
+let private_constants_of_sexp = B_.t_of_sexp
+let private_constants_of_yojson = B_.of_yojson
+let private_constants_to_yojson = B_.to_yojson
+let hash_private_constants = B_.hash
+let hash_fold_private_constants = B_.hash_fold_t
+let compare_private_constants = B_.compare
 
 (*
 type 'a effect_entry =
@@ -70,9 +77,9 @@ let _effect_entry_of_sexp (_f : Sexp.t -> 'a) (x : Sexp.t) : 'a effect_entry =
   let open Sexp in
   match x with
   | Atom "PureEntry" ->
-    Obj.magic PureEntry
+    Obj__magic PureEntry
   | Atom "EffectEntry" ->
-    Obj.magic EffectEntry
+    Obj__magic EffectEntry
   | _ ->
     Sexplib.Conv_error.no_variant_match ()
 *)

--- a/serlib/ser_safe_typing.mli
+++ b/serlib/ser_safe_typing.mli
@@ -19,8 +19,7 @@
 open Sexplib
 
 type private_constants = Safe_typing.private_constants
-val private_constants_of_sexp : Sexp.t -> private_constants
-val sexp_of_private_constants : private_constants -> Sexp.t
+  [@@deriving sexp,yojson,hash,compare]
 
 type global_declaration = Safe_typing.global_declaration
 val global_declaration_of_sexp : Sexp.t -> global_declaration

--- a/serlib/ser_sorts.ml
+++ b/serlib/ser_sorts.ml
@@ -19,19 +19,17 @@ type family =
   [%import: Sorts.family]
   [@@deriving sexp,yojson,hash,compare]
 
-type _t =
-  | SProp
-  | Prop
-  | Set
-  | Type of Univ.Universe.t
-  [@@deriving of_sexp,yojson,hash,compare]
+module PierceSpec = struct
+  type t = Sorts.t
+  type _t =
+    | SProp
+    | Prop
+    | Set
+    | Type of Univ.Universe.t
+  [@@deriving sexp,yojson,hash,compare]
+end
 
-type t =
-  [%import: Sorts.t]
-  [@@deriving sexp_of,to_yojson,hash,compare]
-
-let t_of_sexp x = Obj.magic (_t_of_sexp x)
-let of_yojson json = Ppx_deriving_yojson_runtime.(_t_of_yojson json >|= Obj.magic)
+include SerType.Pierce(PierceSpec)
 
 type relevance =
   [%import: Sorts.relevance]

--- a/serlib/ser_stdarg.ml
+++ b/serlib/ser_stdarg.ml
@@ -18,11 +18,11 @@ open Sexplib.Conv
 module Names      = Ser_names
 module Genredexpr = Ser_genredexpr
 
-let ser_wit_unit   = Ser_genarg.mk_uniform sexp_of_unit unit_of_sexp
-let ser_wit_bool   = Ser_genarg.mk_uniform sexp_of_bool bool_of_sexp
-let ser_wit_int    = Ser_genarg.mk_uniform sexp_of_int int_of_sexp
-let ser_wit_string = Ser_genarg.mk_uniform sexp_of_string string_of_sexp
-let ser_wit_pre_ident = Ser_genarg.mk_uniform sexp_of_string string_of_sexp
+let ser_wit_unit   = Ser_genarg.mk_uniform sexp_of_unit unit_of_sexp Ppx_hash_lib.Std.Hash.Builtin.hash_fold_unit Ppx_compare_lib.Builtin.compare_unit
+let ser_wit_bool   = Ser_genarg.mk_uniform sexp_of_bool bool_of_sexp Ppx_hash_lib.Std.Hash.Builtin.hash_fold_bool Ppx_compare_lib.Builtin.compare_bool
+let ser_wit_int    = Ser_genarg.mk_uniform sexp_of_int int_of_sexp Ppx_hash_lib.Std.Hash.Builtin.hash_fold_int Ppx_compare_lib.Builtin.compare_int
+let ser_wit_string = Ser_genarg.mk_uniform sexp_of_string string_of_sexp Ppx_hash_lib.Std.Hash.Builtin.hash_fold_string Ppx_compare_lib.Builtin.compare_string
+let ser_wit_pre_ident = Ser_genarg.mk_uniform sexp_of_string string_of_sexp Ppx_hash_lib.Std.Hash.Builtin.hash_fold_string Ppx_compare_lib.Builtin.compare_string
 
 let ser_wit_hyp : (Ser_names.lident, Ser_names.lident, Ser_names.Id.t) Ser_genarg.gen_ser = Ser_genarg.
   { raw_ser = Ser_names.sexp_of_lident
@@ -32,83 +32,149 @@ let ser_wit_hyp : (Ser_names.lident, Ser_names.lident, Ser_names.Id.t) Ser_genar
   ; raw_des = Ser_names.lident_of_sexp
   ; glb_des = Ser_names.lident_of_sexp
   ; top_des = Ser_names.Id.t_of_sexp
+
+  ; raw_hash = Ser_names.hash_fold_lident
+  ; glb_hash = Ser_names.hash_fold_lident
+  ; top_hash = Ser_names.Id.hash_fold_t
+
+  ; raw_compare = Ser_names.compare_lident
+  ; glb_compare = Ser_names.compare_lident
+  ; top_compare = Ser_names.Id.compare
   }
 
 (* Same *)
 let ser_wit_identref = ser_wit_hyp
 
-let ser_wit_nat_or_var = Ser_genarg.{
-    raw_ser = Ser_locus.sexp_of_or_var sexp_of_int;
-    glb_ser = Ser_locus.sexp_of_or_var sexp_of_int;
-    top_ser = sexp_of_int;
+let ser_wit_nat_or_var = Ser_genarg.
+  { raw_ser = Ser_locus.sexp_of_or_var sexp_of_int
+  ; glb_ser = Ser_locus.sexp_of_or_var sexp_of_int
+  ; top_ser = sexp_of_int
 
-    raw_des = Ser_locus.or_var_of_sexp int_of_sexp;
-    glb_des = Ser_locus.or_var_of_sexp int_of_sexp;
-    top_des = int_of_sexp;
+  ; raw_des = Ser_locus.or_var_of_sexp int_of_sexp
+  ; glb_des = Ser_locus.or_var_of_sexp int_of_sexp
+  ; top_des = int_of_sexp
+
+  ; raw_hash = Ser_locus.hash_fold_or_var Ppx_hash_lib.Std.Hash.Builtin.hash_fold_int
+  ; glb_hash = Ser_locus.hash_fold_or_var Ppx_hash_lib.Std.Hash.Builtin.hash_fold_int
+  ; top_hash = Ppx_hash_lib.Std.Hash.Builtin.hash_fold_int
+
+  ; raw_compare = Ser_locus.compare_or_var Ppx_compare_lib.Builtin.compare_int
+  ; glb_compare = Ser_locus.compare_or_var Ppx_compare_lib.Builtin.compare_int
+  ; top_compare = Ppx_compare_lib.Builtin.compare_int
   }
 
-let ser_wit_int_or_var = Ser_genarg.{
-    raw_ser = Ser_locus.sexp_of_or_var sexp_of_int;
-    glb_ser = Ser_locus.sexp_of_or_var sexp_of_int;
-    top_ser = sexp_of_int;
+let ser_wit_int_or_var = Ser_genarg.
+  { raw_ser = Ser_locus.sexp_of_or_var sexp_of_int
+  ; glb_ser = Ser_locus.sexp_of_or_var sexp_of_int
+  ; top_ser = sexp_of_int
 
-    raw_des = Ser_locus.or_var_of_sexp int_of_sexp;
-    glb_des = Ser_locus.or_var_of_sexp int_of_sexp;
-    top_des = int_of_sexp;
+  ; raw_des = Ser_locus.or_var_of_sexp int_of_sexp
+  ; glb_des = Ser_locus.or_var_of_sexp int_of_sexp
+  ; top_des = int_of_sexp
+
+  ; raw_hash = Ser_locus.hash_fold_or_var Ppx_hash_lib.Std.Hash.Builtin.hash_fold_int
+  ; glb_hash = Ser_locus.hash_fold_or_var Ppx_hash_lib.Std.Hash.Builtin.hash_fold_int
+  ; top_hash = Ppx_hash_lib.Std.Hash.Builtin.hash_fold_int
+
+  ; raw_compare = Ser_locus.compare_or_var Ppx_compare_lib.Builtin.compare_int
+  ; glb_compare = Ser_locus.compare_or_var Ppx_compare_lib.Builtin.compare_int
+  ; top_compare = Ppx_compare_lib.Builtin.compare_int
   }
 
-let ser_wit_ident  = Ser_genarg.mk_uniform Ser_names.Id.sexp_of_t Ser_names.Id.t_of_sexp
+let ser_wit_ident  = Ser_genarg.mk_uniform Ser_names.Id.sexp_of_t Ser_names.Id.t_of_sexp Ser_names.Id.hash_fold_t Ser_names.Id.compare
 
 let ser_wit_ref = Ser_genarg.{
-    raw_ser = Ser_libnames.sexp_of_qualid;
-    glb_ser = Ser_locus.sexp_of_or_var Ser_loc.(sexp_of_located Ser_names.GlobRef.sexp_of_t);
-    top_ser = Ser_names.GlobRef.sexp_of_t;
+    raw_ser = Ser_libnames.sexp_of_qualid
+  ; glb_ser = Ser_locus.sexp_of_or_var Ser_loc.(sexp_of_located Ser_names.GlobRef.sexp_of_t)
+  ; top_ser = Ser_names.GlobRef.sexp_of_t
 
-    raw_des = Ser_libnames.qualid_of_sexp;
-    glb_des = Ser_locus.or_var_of_sexp Ser_loc.(located_of_sexp Ser_names.GlobRef.t_of_sexp);
-    top_des = Ser_names.GlobRef.t_of_sexp;
+  ; raw_des = Ser_libnames.qualid_of_sexp
+  ; glb_des = Ser_locus.or_var_of_sexp Ser_loc.(located_of_sexp Ser_names.GlobRef.t_of_sexp)
+  ; top_des = Ser_names.GlobRef.t_of_sexp
+
+  ; raw_hash = Ser_libnames.hash_fold_qualid
+  ; glb_hash = Ser_locus.hash_fold_or_var Ser_loc.(hash_fold_located Ser_names.GlobRef.hash_fold_t)
+  ; top_hash = Ser_names.GlobRef.hash_fold_t
+
+  ; raw_compare = Ser_libnames.compare_qualid
+  ; glb_compare = Ser_locus.compare_or_var Ser_loc.(compare_located Ser_names.GlobRef.compare)
+  ; top_compare = Ser_names.GlobRef.compare
+
   }
 
 let ser_wit_sort_family = Ser_genarg.{
-    raw_ser = Ser_sorts.sexp_of_family;
-    glb_ser = sexp_of_unit;
-    top_ser = sexp_of_unit;
+    raw_ser = Ser_sorts.sexp_of_family
+  ; glb_ser = sexp_of_unit
+  ; top_ser = sexp_of_unit
 
-    raw_des = Ser_sorts.family_of_sexp;
-    glb_des = unit_of_sexp;
-    top_des = unit_of_sexp;
+  ; raw_des = Ser_sorts.family_of_sexp
+  ; glb_des = unit_of_sexp
+  ; top_des = unit_of_sexp
+
+  ; raw_hash = Ser_sorts.hash_fold_family
+  ; glb_hash = Ppx_hash_lib.Std.Hash.Builtin.hash_fold_unit
+  ; top_hash = Ppx_hash_lib.Std.Hash.Builtin.hash_fold_unit
+
+  ; raw_compare = Ser_sorts.compare_family
+  ; glb_compare = Ppx_compare_lib.Builtin.compare_unit
+  ; top_compare = Ppx_compare_lib.Builtin.compare_unit
   }
 
 (* let ser_ref  *)
 
 let ser_wit_constr = Ser_genarg.{
-    raw_ser = Ser_constrexpr.sexp_of_constr_expr;
-    glb_ser = Ser_genintern.sexp_of_glob_constr_and_expr;
-    top_ser = Ser_eConstr.sexp_of_t;
+    raw_ser = Ser_constrexpr.sexp_of_constr_expr
+  ; glb_ser = Ser_genintern.sexp_of_glob_constr_and_expr
+  ; top_ser = Ser_eConstr.sexp_of_t
 
-    raw_des = Ser_constrexpr.constr_expr_of_sexp;
-    glb_des = Ser_genintern.glob_constr_and_expr_of_sexp;
-    top_des = Ser_eConstr.t_of_sexp;
+  ; raw_des = Ser_constrexpr.constr_expr_of_sexp
+  ; glb_des = Ser_genintern.glob_constr_and_expr_of_sexp
+  ; top_des = Ser_eConstr.t_of_sexp
+
+  ; raw_hash = Ser_constrexpr.hash_fold_constr_expr
+  ; glb_hash = Ser_genintern.hash_fold_glob_constr_and_expr
+  ; top_hash = Ser_eConstr.hash_fold_t
+
+  ; raw_compare = Ser_constrexpr.compare_constr_expr
+  ; glb_compare = Ser_genintern.compare_glob_constr_and_expr
+  ; top_compare = Ser_eConstr.compare
   }
 
 let ser_wit_uconstr = Ser_genarg.{
-    raw_ser = Ser_constrexpr.sexp_of_constr_expr;
-    glb_ser = Ser_genintern.sexp_of_glob_constr_and_expr;
-    top_ser = Ser_ltac_pretype.sexp_of_closed_glob_constr;
+    raw_ser = Ser_constrexpr.sexp_of_constr_expr
+  ; glb_ser = Ser_genintern.sexp_of_glob_constr_and_expr
+  ; top_ser = Ser_ltac_pretype.sexp_of_closed_glob_constr
 
-    raw_des = Ser_constrexpr.constr_expr_of_sexp;
-    glb_des = Ser_genintern.glob_constr_and_expr_of_sexp;
-    top_des = Ser_ltac_pretype.closed_glob_constr_of_sexp;
+  ; raw_des = Ser_constrexpr.constr_expr_of_sexp
+  ; glb_des = Ser_genintern.glob_constr_and_expr_of_sexp
+  ; top_des = Ser_ltac_pretype.closed_glob_constr_of_sexp
+
+  ; raw_hash = Ser_constrexpr.hash_fold_constr_expr
+  ; glb_hash = Ser_genintern.hash_fold_glob_constr_and_expr
+  ; top_hash = Ser_ltac_pretype.hash_fold_closed_glob_constr
+
+  ; raw_compare = Ser_constrexpr.compare_constr_expr
+  ; glb_compare = Ser_genintern.compare_glob_constr_and_expr
+  ; top_compare = Ser_ltac_pretype.compare_closed_glob_constr
   }
 
 let ser_wit_clause_dft_concl = Ser_genarg.{
-    raw_ser = Ser_locus.sexp_of_clause_expr Ser_names.sexp_of_lident;
-    glb_ser = Ser_locus.sexp_of_clause_expr Ser_names.sexp_of_lident;
-    top_ser = Ser_locus.sexp_of_clause_expr Ser_names.Id.sexp_of_t;
+    raw_ser = Ser_locus.sexp_of_clause_expr Ser_names.sexp_of_lident
+  ; glb_ser = Ser_locus.sexp_of_clause_expr Ser_names.sexp_of_lident
+  ; top_ser = Ser_locus.sexp_of_clause_expr Ser_names.Id.sexp_of_t
 
-    raw_des = Ser_locus.clause_expr_of_sexp Ser_names.lident_of_sexp;
-    glb_des = Ser_locus.clause_expr_of_sexp Ser_names.lident_of_sexp;
-    top_des = Ser_locus.clause_expr_of_sexp Ser_names.Id.t_of_sexp;
+  ; raw_des = Ser_locus.clause_expr_of_sexp Ser_names.lident_of_sexp
+  ; glb_des = Ser_locus.clause_expr_of_sexp Ser_names.lident_of_sexp
+  ; top_des = Ser_locus.clause_expr_of_sexp Ser_names.Id.t_of_sexp
+
+  ; raw_hash = Ser_locus.hash_fold_clause_expr Ser_names.hash_fold_lident
+  ; glb_hash = Ser_locus.hash_fold_clause_expr Ser_names.hash_fold_lident
+  ; top_hash = Ser_locus.hash_fold_clause_expr Ser_names.Id.hash_fold_t
+
+  ; raw_compare = Ser_locus.compare_clause_expr Ser_names.compare_lident
+  ; glb_compare = Ser_locus.compare_clause_expr Ser_names.compare_lident
+  ; top_compare = Ser_locus.compare_clause_expr Ser_names.Id.compare
+
   }
 
 let register () =

--- a/serlib/ser_stdlib.ml
+++ b/serlib/ser_stdlib.ml
@@ -13,7 +13,9 @@
 (* Status: Experimental                                                 *)
 (************************************************************************)
 
-open Sexplib.Conv
+open Sexplib.Std
+open Ppx_hash_lib.Std.Hash.Builtin
+open Ppx_compare_lib.Builtin
 
 type nonrec 'a ref = 'a Stdlib.ref
 
@@ -22,6 +24,10 @@ let (!) x = !x
 let (:=) x v = x := v
 let ref_of_sexp = ref_of_sexp
 let sexp_of_ref = sexp_of_ref
+let ref_to_yojson f x = f !x
+let ref_of_yojson f x = Result.map (fun x -> ref x) (f x)
+let hash_fold_ref = hash_fold_ref_frozen
+let compare_ref = compare_ref
 
 module Lazy = struct
   type 'a t = 'a lazy_t

--- a/serlib/ser_tacred.ml
+++ b/serlib/ser_tacred.ml
@@ -21,4 +21,4 @@ module Names = Ser_names
 
 type evaluable_global_reference =
   [%import: Tacred.evaluable_global_reference]
-  [@@deriving sexp]
+  [@@deriving sexp,yojson,hash,compare]

--- a/serlib/ser_tactics.ml
+++ b/serlib/ser_tactics.ml
@@ -14,18 +14,20 @@
 (************************************************************************)
 
 open Sexplib.Conv
+open Ppx_hash_lib.Std.Hash.Builtin
+open Ppx_compare_lib.Builtin
 
 module Names     = Ser_names
 
 type clear_flag =
   [%import: Tactics.clear_flag]
-  [@@deriving sexp]
+  [@@deriving sexp,yojson,hash,compare]
 
 type 'a core_destruction_arg =
   [%import: 'a Tactics.core_destruction_arg]
-  [@@deriving sexp]
+  [@@deriving sexp,yojson,hash,compare]
 
 type 'a destruction_arg =
   [%import: 'a Tactics.destruction_arg]
-  [@@deriving sexp]
+  [@@deriving sexp,yojson,hash,compare]
 

--- a/serlib/ser_tactics.mli
+++ b/serlib/ser_tactics.mli
@@ -13,21 +13,10 @@
 (* Status: Very Experimental                                            *)
 (************************************************************************)
 
-open Sexplib
-
 type clear_flag = Tactics.clear_flag
 
 type 'a core_destruction_arg = 'a Tactics.core_destruction_arg
-
-val core_destruction_arg_of_sexp :
-  (Sexp.t -> 'a) -> Sexp.t -> 'a core_destruction_arg
-val sexp_of_core_destruction_arg :
-  ('a -> Sexp.t) -> 'a core_destruction_arg -> Sexp.t
+  [@@deriving sexp,yojson,hash,compare]
 
 type 'a destruction_arg = clear_flag * 'a core_destruction_arg
-
-val destruction_arg_of_sexp :
-  (Sexp.t -> 'a) -> Sexp.t -> 'a destruction_arg
-
-val sexp_of_destruction_arg :
-  ('a -> Sexp.t) -> 'a destruction_arg -> Sexp.t
+  [@@deriving sexp,yojson,hash,compare]

--- a/serlib/ser_tactypes.ml
+++ b/serlib/ser_tactypes.ml
@@ -14,6 +14,8 @@
 (************************************************************************)
 
 open Sexplib.Conv
+open Ppx_compare_lib.Builtin
+open Ppx_hash_lib.Std.Hash.Builtin
 
 module CAst        = Ser_cAst
 module Names       = Ser_names
@@ -26,36 +28,45 @@ and 'a intro_pattern_expr =
   [%import: 'a Tactypes.intro_pattern_expr]
 and 'a or_and_intro_pattern_expr =
   [%import: 'a Tactypes.or_and_intro_pattern_expr]
-  [@@deriving sexp]
+  [@@deriving sexp,yojson,hash,compare]
 
 type quantified_hypothesis =
   [%import: Tactypes.quantified_hypothesis]
-  [@@deriving sexp]
+  [@@deriving sexp,yojson,hash,compare]
 
 type 'a explicit_bindings =
   [%import: 'a Tactypes.explicit_bindings]
-  [@@deriving sexp]
+  [@@deriving sexp,yojson,hash,compare]
 
 type 'a bindings =
   [%import: 'a Tactypes.bindings]
-  [@@deriving sexp]
+  [@@deriving sexp,yojson,hash,compare]
 
 type 'a with_bindings =
   [%import: 'a Tactypes.with_bindings]
-  [@@deriving sexp]
+  [@@deriving sexp,yojson,hash,compare]
 
-type 'a delayed_open =
-  [%import: 'a Tactypes.delayed_open]
-  [@@deriving sexp]
+module DO = struct
+  type 'a t = 'a Tactypes.delayed_open
+  let name = "Tactypes.delayed.open"
+end
 
-let sexp_of_delayed_open _ = Serlib_base.sexp_of_opaque ~typ:"wit_bindings/top"
-let delayed_open_of_sexp _ = Serlib_base.opaque_of_sexp ~typ:"wit_bindings/top";
+module B = SerType.Opaque1(DO)
+
+type 'a delayed_open = 'a B.t
+let sexp_of_delayed_open = B.sexp_of_t
+let delayed_open_of_sexp = B.t_of_sexp
+let delayed_open_of_yojson = B.of_yojson
+let delayed_open_to_yojson = B.to_yojson
+(* let hash_delayed_open = B.hash *)
+let hash_fold_delayed_open = B.hash_fold_t
+let compare_delayed_open = B.compare
 
 type delayed_open_constr =
   [%import: Tactypes.delayed_open_constr]
-  [@@deriving sexp]
+  [@@deriving sexp,yojson,hash,compare]
 
 type delayed_open_constr_with_bindings =
   [%import: Tactypes.delayed_open_constr_with_bindings]
-  [@@deriving sexp]
+  [@@deriving sexp,yojson,hash,compare]
 

--- a/serlib/ser_uint63.ml
+++ b/serlib/ser_uint63.ml
@@ -27,3 +27,9 @@ let sexp_of_t (x : Uint63.t) : Sexp.t = Conv.sexp_of_string (_t_put x)
 
 let of_yojson json = Ppx_deriving_yojson_runtime.(_t_of_yojson json >|= _t_get)
 let to_yojson level = _t_to_yojson (_t_put level)
+
+let hash_fold_t st i =
+  Ppx_hash_lib.Std.Hash.Builtin.hash_fold_int64 st (Uint63.to_int64 i)
+
+let compare i1 i2 =
+  Ppx_compare_lib.Builtin.compare_int64 (Uint63.to_int64 i1) (Uint63.to_int64 i2)

--- a/serlib/ser_univ.mli
+++ b/serlib/ser_univ.mli
@@ -19,7 +19,7 @@ module Level : SerType.SJHC with type t = Univ.Level.t
 module Universe : SerType.SJHC with type t = Univ.Universe.t
 
 module Variance : SerType.SJHC with type t = Univ.Variance.t
-module Instance : SerType.SJ with type t = Univ.Instance.t
+module Instance : SerType.SJHC with type t = Univ.Instance.t
 
 type constraint_type = Univ.constraint_type [@@deriving sexp,yojson,hash,compare]
 
@@ -31,9 +31,9 @@ val sexp_of_univ_constraint : univ_constraint -> Sexp.t
 module Constraints : SerType.SJ with type t = Univ.Constraints.t
 module UContext : SerType.S with type t = Univ.UContext.t
 
-module AbstractContext : SerType.S with type t = Univ.AbstractContext.t
+module AbstractContext : SerType.SJHC with type t = Univ.AbstractContext.t
 
-module ContextSet : SerType.SJ with type t = Univ.ContextSet.t
+module ContextSet : SerType.SJHC with type t = Univ.ContextSet.t
 
 (** A value in a universe context (resp. context set). *)
 type 'a in_universe_context = 'a Univ.in_universe_context
@@ -45,12 +45,7 @@ val in_universe_context_set_of_sexp : (Sexp.t -> 'a) -> Sexp.t -> 'a in_universe
 val sexp_of_in_universe_context_set : ('a -> Sexp.t) -> 'a in_universe_context_set -> Sexp.t
 
 type 'a puniverses = 'a * Instance.t
-
-val puniverses_of_sexp : (Sexp.t -> 'a) -> Sexp.t -> 'a puniverses
-val sexp_of_puniverses : ('a -> Sexp.t) -> 'a puniverses -> Sexp.t
-
-val puniverses_of_yojson : (Yojson.Safe.t -> ('a, string) Result.result) -> Yojson.Safe.t -> ('a puniverses, string) Result.result
-val puniverses_to_yojson : ('a -> Yojson.Safe.t) -> 'a puniverses -> Yojson.Safe.t
+ [@@deriving sexp,yojson,hash,compare]
 
 type explanation = Univ.explanation
 

--- a/serlib/ser_vernacexpr.mli
+++ b/serlib/ser_vernacexpr.mli
@@ -128,8 +128,7 @@ val definition_expr_of_sexp : Sexp.t -> definition_expr
 val sexp_of_definition_expr : definition_expr -> Sexp.t
 
 type fixpoint_expr = Vernacexpr.fixpoint_expr
-val fixpoint_expr_of_sexp : Sexp.t -> fixpoint_expr
-val sexp_of_fixpoint_expr : fixpoint_expr -> Sexp.t
+  [@@deriving sexp,hash,compare]
 
 type cofixpoint_expr = Vernacexpr.cofixpoint_expr
 val cofixpoint_expr_of_sexp : Sexp.t -> cofixpoint_expr

--- a/serlib/ser_vmbytecodes.ml
+++ b/serlib/ser_vmbytecodes.ml
@@ -16,14 +16,18 @@
 (************************************************************************)
 
 open Sexplib.Std
+open Ppx_hash_lib.Std.Hash.Builtin
+open Ppx_compare_lib.Builtin
 
 module Names = Ser_names
 module Evar = Ser_evar
 
+let hash_fold_array = hash_fold_array_frozen
+
 type fv_elem =
   [%import: Vmbytecodes.fv_elem]
-  [@@deriving sexp]
+  [@@deriving sexp,yojson,hash,compare]
 
 type fv =
   [%import: Vmbytecodes.fv]
-  [@@deriving sexp]
+  [@@deriving sexp,yojson,hash,compare]

--- a/serlib/ser_vmemitcodes.mli
+++ b/serlib/ser_vmemitcodes.mli
@@ -16,13 +16,10 @@
 (* Status: Very Experimental                                            *)
 (************************************************************************)
 
-open Sexplib
-
 type body_code = Vmemitcodes.body_code
-val sexp_of_body_code : body_code -> Sexp.t
-val body_code_of_sexp : Sexp.t -> body_code
+ [@@deriving sexp,yojson,hash,compare]
 
 (* type to_patch_substituted = Vmemitcodes.to_patch_substituted
- * 
+ *
  * val sexp_of_to_patch_substituted : to_patch_substituted -> Sexp.t
  * val to_patch_substituted_of_sexp : Sexp.t -> to_patch_substituted *)

--- a/serlib/ser_vmvalues.ml
+++ b/serlib/ser_vmvalues.ml
@@ -15,6 +15,8 @@
 (************************************************************************)
 
 open Sexplib.Conv
+open Ppx_hash_lib.Std.Hash.Builtin
+open Ppx_compare_lib.Builtin
 
 module Sorts = Ser_sorts
 module Names = Ser_names
@@ -24,21 +26,34 @@ module Float64 = Ser_float64
 
 type tag =
   [%import: Vmvalues.tag]
-  [@@deriving sexp]
+  [@@deriving sexp,yojson,hash,compare]
 
-type structured_values = Vmvalues.structured_values
+module OpaqueSV = struct
+  type t = Vmvalues.structured_values
+  let name = "Vmvalues.structured_values"
+end
 
-let structured_values_of_sexp _ = assert false
-let sexp_of_structured_values _ = assert false
+module B = SerType.Opaque(OpaqueSV)
+
+type structured_values = B.t
+let sexp_of_structured_values = B.sexp_of_t
+let structured_values_of_sexp = B.t_of_sexp
+let structured_values_of_yojson = B.of_yojson
+let structured_values_to_yojson = B.to_yojson
+(* let hash_structured_values = B.hash *)
+let hash_fold_structured_values = B.hash_fold_t
+let compare_structured_values = B.compare
 
 type structured_constant =
   [%import: Vmvalues.structured_constant]
-  [@@deriving sexp]
+  [@@deriving sexp,yojson,hash,compare]
+
+let hash_fold_array = hash_fold_array_frozen
 
 type reloc_table =
   [%import: Vmvalues.reloc_table]
-  [@@deriving sexp]
+  [@@deriving sexp,yojson,hash,compare]
 
 type annot_switch =
   [%import: Vmvalues.annot_switch]
-  [@@deriving sexp]
+  [@@deriving sexp,yojson,hash,compare]

--- a/serlib/ser_vmvalues.mli
+++ b/serlib/ser_vmvalues.mli
@@ -22,14 +22,10 @@ val tag_of_sexp : Sexp.t -> tag
 val sexp_of_tag : tag -> Sexp.t
 
 type structured_constant = Vmvalues.structured_constant
-
-val structured_constant_of_sexp : Sexp.t -> structured_constant
-val sexp_of_structured_constant : structured_constant -> Sexp.t
+ [@@deriving sexp,yojson,hash,compare]
 
 type reloc_table = Vmvalues.reloc_table
-val reloc_table_of_sexp : Sexp.t -> reloc_table
-val sexp_of_reloc_table : reloc_table -> Sexp.t
+ [@@deriving sexp,yojson,hash,compare]
 
 type annot_switch = Vmvalues.annot_switch
-val annot_switch_of_sexp : Sexp.t -> annot_switch
-val sexp_of_annot_switch : annot_switch -> Sexp.t
+ [@@deriving sexp,yojson,hash,compare]

--- a/serlib/serlib_base.ml
+++ b/serlib/serlib_base.ml
@@ -32,3 +32,18 @@ let sexp_of_opaque ~typ _exp =
     raise (Ser_error msg)
   else
     Sexplib.Sexp.Atom ("["^typ^": ABSTRACT]")
+
+let opaque_of_yojson ~typ _obj =
+  raise (Ser_error ("["^typ^": ABSTRACT / cannot deserialize]"))
+
+let opaque_to_yojson ~typ _obj =
+  let msg = "["^typ^": ABSTRACT]" in
+  if !exn_on_opaque then
+    raise (Ser_error msg)
+  else
+    `String ("["^typ^": ABSTRACT]")
+
+let hash_opaque ~typ:_ x = Hashtbl.hash x
+let hash_fold_opaque ~typ st x = Ppx_hash_lib.Std.Hash.Builtin.hash_fold_int st (hash_opaque ~typ x)
+let compare_opaque ~typ:_ x y = Stdlib.compare x y
+

--- a/serlib/serlib_base.mli
+++ b/serlib/serlib_base.mli
@@ -21,3 +21,11 @@ val exn_on_opaque : bool ref
 
 val sexp_of_opaque : typ:string -> 'a -> Sexp.t
 val opaque_of_sexp : typ:string -> Sexp.t -> 'a
+
+val opaque_of_yojson : typ:string -> Yojson.Safe.t -> ('a, string) Result.t
+val opaque_to_yojson : typ:string -> 'a -> Yojson.Safe.t
+
+val hash_opaque : typ:string -> 'a -> Ppx_hash_lib.Std.Hash.hash_value
+val hash_fold_opaque : typ:string -> Ppx_hash_lib.Std.Hash.state -> 'a -> Ppx_hash_lib.Std.Hash.state
+
+val compare_opaque : typ:string -> 'a -> 'a -> int

--- a/sertop/dune
+++ b/sertop/dune
@@ -13,21 +13,6 @@
  (link_flags -linkall)
  (libraries sertop))
 
-(executable
- (name sertop_js)
- (modules sertop_async sertop_js)
- (modes js)
- (preprocess (staged_pps ppx_import ppx_sexp_conv))
- (js_of_ocaml
-  (javascript_files
-    ../jscoq/coq-libjs/mutex.js
-    ../jscoq/coq-libjs/unix.js
-    ../jscoq/coq-libjs/str.js
-    ../jscoq/coq-libjs/coq_vm.js)
-  (flags :standard --dynlink +dynlink.js +toplevel.js))
- (link_flags -linkall -noautolink -no-check-prims)
- (libraries sertop ppx_deriving_yojson.runtime zarith_stubs_js jscoq_lib))
-
 (rule
  (targets ser_version.ml)
  (action (write-file %{targets} "let ser_git_version = \"%{version:coq-serapi}\";;")))


### PR DESCRIPTION
We perform a very large refactoring of `serlib`, moving all the
`Obj.magic` hacks to a more principled solution based on interfaces,
mainly exported by `SerType`. Moreover, we use a similar technique to
improve the handling of generic arguments.

Using this new infrastructure, we provide support for `ppx_hash` /
`ppx_compare` support for most data objects. We have chosen to ignore
locations by default, see the ignore attributes to tweak this.