### PR TITLE
[sertop] Understand COQLIB variable to set --coqlib

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,9 @@
+## Version 0.16.1:
+
+ - [sertop] Allow to set `--coqlib` using the `COQLIB` environment
+            variable. The cmdline argument option still has
+            precedence.
+
 ## Version 0.16.0:
 
  - [serapi] (!) support for Coq 8.16, see upstream changes and SerAPI

--- a/sertop/sertop_arg.ml
+++ b/sertop/sertop_arg.ml
@@ -18,10 +18,15 @@
 
 open Cmdliner
 
+let coqlib_from_env_or_config =
+  match Sys.getenv_opt "COQLIB" with
+  | Some coqlib -> coqlib
+  | None -> Coq_config.coqlib
+
 [@@@ocaml.warning "-44-45"]
 let prelude =
   let doc = "Load Coq.Init.Prelude from $(docv); plugins/ and theories/ should live there." in
-  Arg.(value & opt string Coq_config.coqlib & info ["coqlib"] ~docv:"COQPATH" ~doc)
+  Arg.(value & opt string coqlib_from_env_or_config & info ["coqlib"] ~docv:"COQPATH" ~doc)
 
 let require_lib =
   let doc = "Coq module to require." in


### PR DESCRIPTION
The command line argument variable still has precedence.