### PR TITLE
[serapi] Allow to parse different entries (expressions added)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,8 @@
  - [sertop] Allow to set `--coqlib` using the `COQLIB` environment
             variable. The cmdline argument option still has
             precedence.
+ - [serapi] Allow to parse expressions too with
+            `(Parse (entry Constr) $text)` (@ejgallego, fixes #272)
 
 ## Version 0.16.0:
 

--- a/serapi/serapi_protocol.mli
+++ b/serapi/serapi_protocol.mli
@@ -187,7 +187,7 @@ type coq_object =
   | CoqDP        of Names.DirPath.t
   (** Coq "Logical" Paths, used for module and section names *)
   | CoqAst       of Vernacexpr.vernac_control
-  (** Coq Abstract Syntax tress, as produced by the parser *)
+  (** Coq Abstract Syntax trees for statements, as produced by the parser *)
   | CoqOption    of Goptions.option_name * Goptions.option_state
   (** Coq Options, as in [Set Resolution Depth] *)
   | CoqConstr    of Constr.constr
@@ -377,11 +377,13 @@ end
 
 (** {4 Adding a new sentence } *)
 
+type parse_entry = Vernac | Constr
+
+(** parse [ontop] of the given sentence with entry [entry] *)
 type parse_opt =
   { ontop  : Stateid.t option [@sexp.option]
-  (** parse [ontop] of the given sentence *)
+  ; entry : parse_entry [@default Vernac]
   }
-
 
 (** [Add] will take a string and parse all the sentences on it, until an error of the end is found.
     Options for [Add] are: *)

--- a/sertop/sertop_ser.ml
+++ b/sertop/sertop_ser.ml
@@ -273,6 +273,10 @@ type save_opts =
   [%import: Serapi.Serapi_protocol.save_opts]
   [@@deriving sexp]
 
+type parse_entry =
+  [%import: Serapi.Serapi_protocol.parse_entry]
+  [@@deriving sexp]
+
 type parse_opt =
   [%import: Serapi.Serapi_protocol.parse_opt
   [@with


### PR DESCRIPTION
Now users can do

```
(Parse (entry Constr) $text)
```

to parse normal expressions. By default, `Parse` is still bound to the parsing entry for a top level vernacular command.

Fixes #272