### PR TITLE
[serlib] Support a few more plugins from Coq's stdlib.

### DIFF
--- a/serlib/plugins/cc/dune
+++ b/serlib/plugins/cc/dune
@@ -1,0 +1,6 @@
+(library
+ (name serlib_cc)
+ (public_name coq-serapi.serlib.cc)
+ (synopsis "Serialization Library for Coq Congruence Plugin")
+ (preprocess (staged_pps ppx_import ppx_sexp_conv ppx_deriving_yojson ppx_hash ppx_compare))
+ (libraries coq-core.plugins.cc serlib sexplib))

--- a/serlib/plugins/micromega/dune
+++ b/serlib/plugins/micromega/dune
@@ -1,0 +1,6 @@
+(library
+ (name serlib_micromega)
+ (public_name coq-serapi.serlib.micromega)
+ (synopsis "Serialization Library for Coq Congruence Plugin")
+ (preprocess (staged_pps ppx_import ppx_sexp_conv ppx_deriving_yojson ppx_hash ppx_compare))
+ (libraries coq-core.plugins.micromega serlib sexplib))

--- a/serlib/plugins/syntax/dune
+++ b/serlib/plugins/syntax/dune
@@ -1,0 +1,6 @@
+(library
+ (name serlib_number_string_notation_plugin)
+ (public_name coq-serapi.serlib.number_string_notation)
+ (synopsis "Serialization Library for Coq Number and String Syntax Plugin")
+ (preprocess (staged_pps ppx_import ppx_sexp_conv ppx_deriving_yojson ppx_hash ppx_compare))
+ (libraries coq-core.plugins.number_string_notation serlib sexplib))

--- a/serlib/plugins/syntax/ser_g_number_syntax.ml
+++ b/serlib/plugins/syntax/ser_g_number_syntax.ml
@@ -1,0 +1,85 @@
+open Serlib
+
+open Sexplib.Conv
+open Ppx_compare_lib.Builtin
+open Ppx_hash_lib.Std.Hash.Builtin
+
+module Libnames = Ser_libnames
+module Notation = Ser_notation
+
+module A1 = struct
+  type raw = Notation.numnot_option
+  [@@deriving sexp,hash,compare]
+  type glb = unit
+  [@@deriving sexp,hash,compare]
+  type top = unit
+  [@@deriving sexp,hash,compare]
+end
+
+let ser_wit_deprecated_number_modifier = let module M = Ser_genarg.GS(A1) in M.genser
+
+module A2 = struct
+  type raw = Ser_number.number_option
+  [@@deriving sexp,hash,compare]
+  type glb = unit
+  [@@deriving sexp,hash,compare]
+  type top = unit
+  [@@deriving sexp,hash,compare]
+end
+
+let ser_wit_number_modifier = let module M = Ser_genarg.GS(A2) in M.genser
+
+module A3 = struct
+  type raw = Ser_number.number_option list
+  [@@deriving sexp,hash,compare]
+  type glb = unit
+  [@@deriving sexp,hash,compare]
+  type top = unit
+  [@@deriving sexp,hash,compare]
+end
+
+let ser_wit_number_options = let module M = Ser_genarg.GS(A3) in M.genser
+
+module A4 = struct
+  type raw = bool * Libnames.qualid * Libnames.qualid
+  [@@deriving sexp,hash,compare]
+  type glb = unit
+  [@@deriving sexp,hash,compare]
+  type top = unit
+  [@@deriving sexp,hash,compare]
+end
+
+let ser_wit_number_string_mapping = let module M = Ser_genarg.GS(A4) in M.genser
+
+module A5 = struct
+  type raw = Libnames.qualid * (bool * Libnames.qualid * Libnames.qualid) list
+  [@@deriving sexp,hash,compare]
+  type glb = unit
+  [@@deriving sexp,hash,compare]
+  type top = unit
+  [@@deriving sexp,hash,compare]
+end
+
+let ser_wit_number_string_via = let module M = Ser_genarg.GS(A5) in M.genser
+
+module A6 = struct
+  type raw = Libnames.qualid * (bool * Libnames.qualid * Libnames.qualid) list
+  [@@deriving sexp,hash,compare]
+  type glb = unit
+  [@@deriving sexp,hash,compare]
+  type top = unit
+  [@@deriving sexp,hash,compare]
+end
+
+let ser_wit_string_option = let module M = Ser_genarg.GS(A6) in M.genser
+
+let register () =
+  Ser_genarg.register_genser Number_string_notation_plugin.G_number_string.wit_deprecated_number_modifier ser_wit_deprecated_number_modifier;
+  Ser_genarg.register_genser Number_string_notation_plugin.G_number_string.wit_number_modifier ser_wit_number_modifier;
+  Ser_genarg.register_genser Number_string_notation_plugin.G_number_string.wit_number_options ser_wit_number_options;
+  Ser_genarg.register_genser Number_string_notation_plugin.G_number_string.wit_number_string_mapping ser_wit_number_string_mapping;
+  Ser_genarg.register_genser Number_string_notation_plugin.G_number_string.wit_number_string_via ser_wit_number_string_via;
+  Ser_genarg.register_genser Number_string_notation_plugin.G_number_string.wit_string_option ser_wit_string_option;
+  ()
+
+let _ = register ()

--- a/serlib/plugins/syntax/ser_number.ml
+++ b/serlib/plugins/syntax/ser_number.ml
@@ -1,0 +1,14 @@
+open Sexplib.Std
+open Ppx_hash_lib.Std.Hash.Builtin
+open Ppx_compare_lib.Builtin
+
+module Libnames = Serlib.Ser_libnames
+module Notation = Serlib.Ser_notation
+
+type number_string_via =
+  [%import: Number_string_notation_plugin.Number.number_string_via]
+  [@@deriving sexp,yojson,hash,compare]
+
+type number_option =
+  [%import: Number_string_notation_plugin.Number.number_option]
+  [@@deriving sexp,yojson,hash,compare]

--- a/serlib/plugins/tauto/dune
+++ b/serlib/plugins/tauto/dune
@@ -1,0 +1,6 @@
+(library
+ (name serlib_tauto)
+ (public_name coq-serapi.serlib.tauto)
+ (synopsis "Serialization Library for Coq Tauto Plugin")
+ (preprocess (staged_pps ppx_import ppx_sexp_conv ppx_deriving_yojson ppx_hash ppx_compare))
+ (libraries coq-core.plugins.tauto serlib sexplib))

--- a/serlib/plugins/zify/dune
+++ b/serlib/plugins/zify/dune
@@ -1,0 +1,6 @@
+(library
+ (name serlib_zify)
+ (public_name coq-serapi.serlib.zify)
+ (synopsis "Serialization Library for Coq Congruence Plugin")
+ (preprocess (staged_pps ppx_import ppx_sexp_conv ppx_deriving_yojson ppx_hash ppx_compare))
+ (libraries coq-core.plugins.zify serlib sexplib))

--- a/serlib/ser_constrexpr.ml
+++ b/serlib/ser_constrexpr.ml
@@ -88,15 +88,15 @@ type notation_entry =
 
 type entry_level =
   [%import: Constrexpr.entry_level]
-  [@@deriving sexp,yojson]
+  [@@deriving sexp,yojson,hash,compare]
 
 type entry_relative_level =
   [%import: Constrexpr.entry_relative_level]
-  [@@deriving sexp,yojson]
+  [@@deriving sexp,yojson,hash,compare]
 
 type notation_entry_level =
   [%import: Constrexpr.notation_entry_level]
-  [@@deriving sexp,yojson]
+  [@@deriving sexp,yojson,hash,compare]
 
 type notation_key =
   [%import: Constrexpr.notation_key]

--- a/serlib/ser_constrexpr.mli
+++ b/serlib/ser_constrexpr.mli
@@ -19,23 +19,11 @@ type 'a or_by_notation = 'a Constrexpr.or_by_notation [@@deriving sexp, yojson, 
 
 type notation_entry = Constrexpr.notation_entry [@@deriving sexp, yojson, hash,compare]
 
-type entry_level = Constrexpr.entry_level
-val entry_level_of_sexp : Sexp.t -> entry_level
-val sexp_of_entry_level : entry_level -> Sexp.t
-val entry_level_of_yojson : Yojson.Safe.t -> (entry_level, string) Result.result
-val entry_level_to_yojson : entry_level -> Yojson.Safe.t
+type entry_level = Constrexpr.entry_level [@@deriving sexp, yojson, hash,compare]
 
-type notation_entry_level = Constrexpr.notation_entry_level
-val notation_entry_level_of_sexp : Sexp.t -> notation_entry_level
-val sexp_of_notation_entry_level : notation_entry_level -> Sexp.t
-val notation_entry_level_of_yojson : Yojson.Safe.t -> (notation_entry_level, string) Result.result
-val notation_entry_level_to_yojson : notation_entry_level -> Yojson.Safe.t
+type notation_entry_level = Constrexpr.notation_entry_level [@@deriving sexp, yojson, hash,compare]
 
-type entry_relative_level = Constrexpr.entry_relative_level
-val entry_relative_level_of_sexp : Sexp.t -> entry_relative_level
-val sexp_of_entry_relative_level : entry_relative_level -> Sexp.t
-val entry_relative_level_of_yojson : Yojson.Safe.t -> (entry_relative_level, string) Result.result
-val entry_relative_level_to_yojson : entry_relative_level -> Yojson.Safe.t
+type entry_relative_level = Constrexpr.entry_relative_level [@@deriving sexp, yojson, hash,compare]
 
 type universe_decl_expr = Constrexpr.universe_decl_expr [@@deriving sexp, yojson, hash,compare]
 type ident_decl = Constrexpr.ident_decl [@@deriving sexp, yojson, hash,compare]

--- a/serlib/ser_notation.ml
+++ b/serlib/ser_notation.ml
@@ -14,14 +14,20 @@
 (************************************************************************)
 
 open Sexplib.Std
+open Ppx_hash_lib.Std.Hash.Builtin
+open Ppx_compare_lib.Builtin
 
 (* module Ppextend = Ser_ppextend
  * module Notation_term = Ser_notation_term *)
 
+module NumTok = Ser_numTok
 module Constrexpr = Ser_constrexpr
 
 type level =
   [%import: Notation.level]
-  [@@deriving sexp,yojson]
+  [@@deriving sexp,yojson,hash,compare]
 
+type numnot_option =
+  [%import: Notation.numnot_option]
+  [@@deriving sexp,yojson,hash,compare]
 

--- a/serlib/ser_notation.mli
+++ b/serlib/ser_notation.mli
@@ -13,8 +13,5 @@
 (* Status: Very Experimental                                            *)
 (************************************************************************)
 
-open Sexplib
-
-type level = Notation.level
-val level_of_sexp : Sexp.t -> level
-val sexp_of_level : level -> Sexp.t
+type level = Notation.level [@@deriving sexp,yojson,hash,compare]
+type numnot_option = Notation.numnot_option [@@deriving sexp,yojson,hash,compare]

--- a/serlib/ser_numTok.ml
+++ b/serlib/ser_numTok.ml
@@ -43,6 +43,16 @@ module Unsigned = struct
   include SerType.Pierce(PierceSpec)
 end
 
+module UnsignedNat = struct
+  module USNBij = struct
+    type t = NumTok.UnsignedNat.t
+    type _t = string [@@deriving sexp,yojson,hash,compare]
+    let to_t = NumTok.UnsignedNat.of_string
+    let of_t = NumTok.UnsignedNat.to_string
+  end
+  include SerType.Biject(USNBij)
+end
+
 module Signed = struct
 
   type t =

--- a/sertop/sertop_loader.ml
+++ b/sertop/sertop_loader.ml
@@ -33,6 +33,7 @@ let map_serlib fl_pkg =
     | "coq-core.plugins.ssrmatching"      (* ssrmatching *)
     | "coq-core.plugins.ssreflect"        (* ssr *)
     | "coq-core.plugins.number_string_notation" (* syntax *)
+    | "coq-core.plugins.tauto"            (* tauto *)
       -> true
     | _ ->
       if debug then Format.eprintf "missing serlib: %s@\n%!" fl_pkg;

--- a/sertop/sertop_loader.ml
+++ b/sertop/sertop_loader.ml
@@ -32,6 +32,7 @@ let map_serlib fl_pkg =
     | "coq-core.plugins.extraction"       (* setoid_ring *)
     | "coq-core.plugins.ssrmatching"      (* ssrmatching *)
     | "coq-core.plugins.ssreflect"        (* ssr *)
+    | "coq-core.plugins.number_string_notation" (* syntax *)
       -> true
     | _ ->
       if debug then Format.eprintf "missing serlib: %s@\n%!" fl_pkg;

--- a/sertop/sertop_loader.ml
+++ b/sertop/sertop_loader.ml
@@ -30,11 +30,13 @@ let map_serlib fl_pkg =
     | "coq-core.plugins.extraction"       (* extraction  *)
     | "coq-core.plugins.firstorder"       (* firstorder  *)
     | "coq-core.plugins.funind"           (* funind      *)
-    | "coq-core.plugins.ring"             (* ring *)
-    | "coq-core.plugins.ssreflect"        (* ssreflect *)
+    | "coq-core.plugins.micromega"        (* micromega   *)
+    | "coq-core.plugins.ring"             (* ring        *)
+    | "coq-core.plugins.ssreflect"        (* ssreflect   *)
     | "coq-core.plugins.ssrmatching"      (* ssrmatching *)
     | "coq-core.plugins.number_string_notation" (* syntax *)
     | "coq-core.plugins.tauto"            (* tauto *)
+    | "coq-core.plugins.zify"             (* zify *)
       -> true
     | _ ->
       if debug then Format.eprintf "missing serlib: %s@\n%!" fl_pkg;

--- a/sertop/sertop_loader.ml
+++ b/sertop/sertop_loader.ml
@@ -26,12 +26,13 @@ let map_serlib fl_pkg =
     | "coq-core.plugins.ltac." -> false
     (* | "tauto_plugin" -> false *)
     (* Supported *)
+    | "coq-core.plugins.cc"               (* cc  *)
+    | "coq-core.plugins.extraction"       (* extraction  *)
     | "coq-core.plugins.firstorder"       (* firstorder  *)
     | "coq-core.plugins.funind"           (* funind      *)
-    | "coq-core.plugins.ring"             (* setoid_ring *)
-    | "coq-core.plugins.extraction"       (* setoid_ring *)
+    | "coq-core.plugins.ring"             (* ring *)
+    | "coq-core.plugins.ssreflect"        (* ssreflect *)
     | "coq-core.plugins.ssrmatching"      (* ssrmatching *)
-    | "coq-core.plugins.ssreflect"        (* ssr *)
     | "coq-core.plugins.number_string_notation" (* syntax *)
     | "coq-core.plugins.tauto"            (* tauto *)
       -> true


### PR DESCRIPTION
- [x] `coq-core.plugins.number_string_notation`
- [x] `coq-core.plugins.tauto`
- [x] `coq-core.plugins.cc`
- [x] `coq-core.plugins.zify`
- [x] `coq-core.plugins.micromega`
