### PR TITLE
Don't call init_known_plugins

### DIFF
--- a/sertop/sertop_init.ml
+++ b/sertop/sertop_init.ml
@@ -58,9 +58,6 @@ let init_runtime opts =
   (* Core Coq initialization *)
   Lib.init();
 
-  (* This is only needed when statically linking *)
-  Mltop.init_known_plugins ();
-
   (* --impredicative-set option *)
   Global.set_impredicative_set opts.set_impredicative_set;
 


### PR DESCRIPTION
It is not actually needed and will go away in https://github.com/coq/coq/pull/17069