### PR TITLE
Adapt to #17117: level is now in notationterm.ml, side in constrexpr.ml

### DIFF
--- a/serlib/ser_constrexpr.ml
+++ b/serlib/ser_constrexpr.ml
@@ -87,6 +87,10 @@ type notation_with_optional_scope =
   [%import: Constrexpr.notation_with_optional_scope]
   [@@deriving sexp,yojson,hash,compare]
 
+type side =
+  [%import: Constrexpr.side]
+  [@@deriving sexp,yojson,hash,compare]
+
 type notation_entry =
   [%import: Constrexpr.notation_entry]
   [@@deriving sexp,yojson,hash,compare]

--- a/serlib/ser_constrexpr.mli
+++ b/serlib/ser_constrexpr.mli
@@ -33,6 +33,8 @@ type name_decl = Constrexpr.name_decl [@@deriving sexp, yojson, hash,compare]
 
 type notation_with_optional_scope = Constrexpr.notation_with_optional_scope [@@deriving sexp, yojson, hash,compare]
 
+type side = Constrexpr.side [@@deriving sexp, yojson, hash,compare]
+
 type notation = Constrexpr.notation
 
 val notation_of_sexp : Sexp.t -> notation

--- a/serlib/ser_extend.ml
+++ b/serlib/ser_extend.ml
@@ -22,10 +22,6 @@ module Notation_term = Ser_notation_term
 module Constrexpr    = Ser_constrexpr
 module Gramlib       = Ser_gramlib
 
-type side =
-  [%import: Extend.side]
-  [@@deriving sexp,yojson,hash,compare]
-
 type production_position =
   [%import: Extend.production_position]
   [@@deriving sexp,yojson,hash,compare]

--- a/serlib/ser_extend.mli
+++ b/serlib/ser_extend.mli
@@ -15,10 +15,6 @@
 
 open Sexplib
 
-type side = Extend.side
-val side_of_sexp : Sexp.t -> side
-val sexp_of_side : side -> Sexp.t
-
 type production_position = Extend.production_position
 val production_position_of_sexp : Sexp.t -> production_position
 val sexp_of_production_position : production_position -> Sexp.t

--- a/serlib/ser_notation.ml
+++ b/serlib/ser_notation.ml
@@ -13,19 +13,11 @@
 (* Status: Very Experimental                                            *)
 (************************************************************************)
 
-open Sexplib.Std
-open Ppx_hash_lib.Std.Hash.Builtin
-open Ppx_compare_lib.Builtin
-
 (* module Ppextend = Ser_ppextend
  * module Notation_term = Ser_notation_term *)
 
 module NumTok = Ser_numTok
 module Constrexpr = Ser_constrexpr
-
-type level =
-  [%import: Notation.level]
-  [@@deriving sexp,yojson,hash,compare]
 
 type numnot_option =
   [%import: Notation.numnot_option]

--- a/serlib/ser_notation.mli
+++ b/serlib/ser_notation.mli
@@ -13,5 +13,4 @@
 (* Status: Very Experimental                                            *)
 (************************************************************************)
 
-type level = Notation.level [@@deriving sexp,yojson,hash,compare]
 type numnot_option = Notation.numnot_option [@@deriving sexp,yojson,hash,compare]

--- a/serlib/ser_notation_gram.ml
+++ b/serlib/ser_notation_gram.ml
@@ -21,6 +21,7 @@ module Tok           = Ser_tok
 module Extend        = Ser_extend
 module Gramlib       = Ser_gramlib
 module Notation      = Ser_notation
+module Notationextern = Ser_notationextern
 
 (* type precedence =
  *   [%import: Notation_gram.precedence]

--- a/serlib/ser_notationextern.ml
+++ b/serlib/ser_notationextern.ml
@@ -13,6 +13,17 @@
 (* Status: Very Experimental                                            *)
 (************************************************************************)
 
+open Ppx_hash_lib.Std
+open Ppx_compare_lib.Builtin
+open Sexplib.Conv
+open Hash.Builtin
+
+module Constrexpr = Ser_constrexpr
+
+type level =
+  [%import: Notationextern.level]
+  [@@deriving sexp,yojson,hash,compare]
+
 type notation_use =
   [%import: Notationextern.notation_use]
   [@@deriving sexp,yojson,hash,compare]

--- a/serlib/ser_notationextern.mli
+++ b/serlib/ser_notationextern.mli
@@ -13,6 +13,12 @@
 (* Status: Very Experimental                                            *)
 (************************************************************************)
 
+module Constrexpr = Ser_constrexpr
+
+type level =
+  [%import: Notationextern.level]
+  [@@deriving sexp,yojson,hash,compare]
+
 type notation_use =
   [%import: Notationextern.notation_use]
   [@@deriving sexp,yojson,hash,compare]


### PR DESCRIPTION
This is a partial adaptation of coq/coq#17117 to serapi but I failed to complete it. I seem to meet the ml/mli problem: `type side` is in `constrexpr.ml` (no `constrexpr.mli`) and
```ocaml
type side =
  [%import: Constrexpr.side] 
  [@@deriving sexp,yojson,hash,compare]
```
fails with `Error: Unbound type constructor Constrexpr.side`.

Is there some incantation I should use? Or move `side` in a file that has an `mli`?