### PR TITLE
[serapi] New protocol call `SecVars`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,8 @@
 ## Version 0.17.1:
 
- - [sertop] Don't initialize `CoqworkmgrApi` (@ejgallego, #)
+ - [sertop] Don't initialize `CoqworkmgrApi` (@ejgallego, #340)
+ - [serapi] New query `SecVars` that will print section variables used
+            by a constant (#342, fixes #339, reported by @HazardousPeach)
 
 ## Version 0.17.0:
 

--- a/serapi/serapi_protocol.mli
+++ b/serapi/serapi_protocol.mli
@@ -240,6 +240,8 @@ type coq_object =
      improved support *)
   | CoqLibObjects of { library_segment : Summary.Interp.frozen Lib.library_segment; path_prefix : Nametab.object_prefix }
   (** Meta-logical Objects in Coq's library / module system *)
+  | CoqNamedContext of Constr.named_context
+  (** Named context such as the one for section variables *)
 
 (** There are some Coq types that cannot be seralizaled properly, in
    this case, the types can be "opaque", or we will perform some
@@ -374,6 +376,8 @@ type query_cmd =
   (** Get all comments of a document *)
   | Objects
   (** Get Coq meta-logical module objects *)
+  | SecVars of string
+  (** Get section variables that a definition is using  *)
 
 module QueryUtil : sig
   val info_of_id : Environ.env -> string -> coq_object list * coq_object list


### PR DESCRIPTION
Fixes #339

Example:

```lisp
(Add () "Section foo. Variable (a : nat). Definition b : nat. Proof. exact a. Qed. End foo.")
(Exec 7)
(Query ((sid 7)) (SecVars b))
(Answer 2(ObjList((CoqNamedContext((LocalAssum((binder_name(Id a))(binder_relevance Relevant))(Ind(((MutInd(KerName(MPfile(DirPath((Id Datatypes)(Id Init)(Id Coq))))(Id nat))())0)(Instance())))))))))
```

Note that due to limitations of SerAPI interpreter the `((sid ...))` parameter won't fully work here, so an `(Exec sid)` to the right state is required before this call.

I'm open to take a PR for fixing this, but requires some rework of the interpreter (coq-lsp has the correct design)