### PR TITLE
Adapt to #17827: new type Notation_term.notation_var_binders

### DIFF
--- a/serlib/ser_notation_term.ml
+++ b/serlib/ser_notation_term.ml
@@ -51,3 +51,6 @@ type notation_var_internalization_type =
   [%import: Notation_term.notation_var_internalization_type]
   [@@deriving sexp,yojson,hash,compare]
 
+type notation_var_binders =
+  [%import: Notation_term.notation_var_binders]
+  [@@deriving sexp,yojson,hash,compare]

--- a/serlib/ser_notation_term.mli
+++ b/serlib/ser_notation_term.mli
@@ -21,3 +21,6 @@ type notation_binder_kind = Notation_term.notation_binder_kind
 
 type notation_var_internalization_type = Notation_term.notation_var_internalization_type
   [@@deriving sexp,yojson,hash,compare]
+
+type notation_var_binders = Notation_term.notation_var_binders
+  [@@deriving sexp,yojson,hash,compare]


### PR DESCRIPTION
I guess I made the canonical fix?

To be merged synchronously with coq/coq#17827