### PR TITLE
remove all references to deprecated Arith modules from genarg tests

### DIFF
--- a/tests/genarg/functional_induction.v
+++ b/tests/genarg/functional_induction.v
@@ -1,23 +1,22 @@
 Set Implicit Arguments.
 
 Require Import Arith.
-Require Import Div2.
 Require Import Recdef.
 
 Function ceil_log2_S (n: nat) {wf lt n}: nat :=
   match n with
   | 0 => 0
-  | S _ => S (ceil_log2_S (div2 n))
+  | S _ => S (ceil_log2_S (Nat.div2 n))
   end.
 Proof.
   intros.
-  apply lt_div2; auto with arith.
+  apply Nat.lt_div2; auto with arith.
   apply lt_wf.
 Defined.
 
 Lemma ceil_log2_S_def n: ceil_log2_S n =
   match n with
   | 0 => 0
-  | S _ => S (ceil_log2_S (div2 n))
+  | S _ => S (ceil_log2_S (Nat.div2 n))
   end.
 Proof. functional induction (ceil_log2_S n); auto. Qed.

--- a/tests/genarg/mbid.v
+++ b/tests/genarg/mbid.v
@@ -5,7 +5,7 @@
  *)
 
 Require Export NumPrelude NZAxioms.
-Require Import NZBase NZOrder NZAddOrder Plus Minus.
+Require Import NZBase NZOrder NZAddOrder.
 
 (** In this file, we investigate the shape of domains satisfying
     the [NZDomainSig] interface. In particular, we define a

--- a/tests/genarg/setoid_rewrite.v
+++ b/tests/genarg/setoid_rewrite.v
@@ -1,5 +1,5 @@
 Require Setoid.
-Require Import PeanoNat Le Gt Minus Bool Lt List.
+Require Import PeanoNat Bool List.
 Require Import Lia.
 
 Section ReDun.


### PR DESCRIPTION
This is to address https://github.com/coq/coq/pull/18164