### PR TITLE
Adapt to #18229: nested_type is now recarg_type (no more "nested" mark)

### DIFF
--- a/serlib/ser_declarations.ml
+++ b/serlib/ser_declarations.ml
@@ -42,8 +42,8 @@ type ('a, 'b) declaration_arity =
   [%import: ('a, 'b) Declarations.declaration_arity]
   [@@deriving sexp,yojson,hash,compare]
 
-type nested_type =
-  [%import: Declarations.nested_type]
+type recarg_type =
+  [%import: Declarations.recarg_type]
   [@@deriving sexp,yojson,hash,compare]
 
 type recarg =


### PR DESCRIPTION
This is to be merged synchronously with coq/coq#18229.