### PR TITLE
Adapt to coq/coq#18094: rewrite strategies: fix

### DIFF
--- a/serlib/plugins/ltac/ser_rewrite.ml
+++ b/serlib/plugins/ltac/ser_rewrite.ml
@@ -29,8 +29,8 @@ type nary_strategy =
   [%import: Rewrite.nary_strategy]
   [@@deriving sexp,hash,compare]
 
-type ('a,'b) strategy_ast =
-  [%import: ('a,'b) Rewrite.strategy_ast]
+type ('a,'b,'c) strategy_ast =
+  [%import: ('a,'b,'c) Rewrite.strategy_ast]
   [@@deriving sexp,hash,compare]
 
 type strategy = Rewrite.strategy

--- a/serlib/plugins/ltac/ser_rewrite.mli
+++ b/serlib/plugins/ltac/ser_rewrite.mli
@@ -19,7 +19,7 @@ type unary_strategy = Rewrite.unary_strategy
 type binary_strategy = Rewrite.binary_strategy
   [@@deriving sexp, hash, compare]
 
-type ('a,'b) strategy_ast = ('a,'b) Rewrite.strategy_ast
+type ('a,'b,'c) strategy_ast = ('a,'b,'c) Rewrite.strategy_ast
   [@@deriving sexp, hash, compare]
 
 type strategy = Rewrite.strategy

--- a/serlib/plugins/ltac/ser_tacarg.ml
+++ b/serlib/plugins/ltac/ser_tacarg.ml
@@ -275,17 +275,17 @@ let wit_rewstrategy = Ltac_plugin.G_rewrite.wit_rewstrategy
 
 module GT2 = struct
   type raw =
-    [%import: Ltac_plugin.G_rewrite.raw_strategy]
+    [%import: Ltac_plugin.Tacexpr.raw_strategy]
   [@@deriving sexp,hash,compare]
   type glb =
-    [%import: Ltac_plugin.G_rewrite.glob_strategy]
+    [%import: Ltac_plugin.Tacexpr.glob_strategy]
   [@@deriving sexp,hash,compare]
   type top = Ltac_plugin.Rewrite.strategy
   [@@deriving sexp,hash,compare]
 end
 
 
-(* (G_rewrite.raw_strategy, G_rewrite.glob_strategy, Rewrite.strategy) *)
+(* (Tacexpr.raw_strategy, Tacexpr.glob_strategy, Rewrite.strategy) *)
 
 let ser_wit_rewstrategy = let module M = Ser_genarg.GS(GT2) in M.genser
 


### PR DESCRIPTION
The type constructor `Rewrite.strategy_ast` now expects 3 arguments (the third one is for bound fixpoint identifiers).

To be merged synchronously with coq/coq#18094