### PR TITLE
Keep the Vmlibrary.t type opaque.

### DIFF
--- a/serlib/ser_vmlibrary.ml
+++ b/serlib/ser_vmlibrary.ml
@@ -13,63 +13,23 @@
 (* Status: Experimental                                                 *)
 (************************************************************************)
 
-open Sexplib.Std
-open Ppx_compare_lib.Builtin
-open Ppx_hash_lib.Std.Hash.Builtin
-
-module Stdlib = Ser_stdlib
-module Names  = Ser_names
 module Vmemitcodes = Ser_vmemitcodes
 
-module Map = Ser_cMap.Make(Int.Map)(Ser_int)
-
-module Delayed =
-struct
-
-type delayed = {
-  del_file : string;
-  del_off : int64;
-  del_digest : string;
-} [@@deriving sexp,yojson,hash,compare]
-
-type 'a node = ToFetch of delayed | Fetched of 'a [@@deriving sexp,yojson,hash,compare]
-
-type 'a t = 'a node Stdlib.ref [@@deriving sexp,yojson,hash,compare]
-
-end
-
-module VmTable =
-struct
-
-type t = {
-  table_len : int;
-  table_dir : Names.DirPath.t;
-  table_val : Vmemitcodes.to_patch Map.t;
-} [@@deriving sexp,yojson,hash,compare]
-
-type index = Names.DirPath.t * int [@@deriving sexp,yojson,hash,compare]
-
-end
-
 module OP = struct
-type t = [%import: Vmlibrary.t]
-type _t = {
-  local : VmTable.t;
-  foreign : VmTable.t Delayed.t Names.DPmap.t;
-}
-[@@deriving sexp,yojson,hash,compare]
+type t = Vmlibrary.t
+let name = "Vmlibrary.t"
 end
 
-module B = SerType.Pierce(OP)
+module B = SerType.Opaque(OP)
 type t = B.t
  [@@deriving sexp,yojson,hash,compare]
 
 module OQ = struct
-type t = [%import: Vmlibrary.index]
-type _t = VmTable.index [@@deriving sexp,yojson,hash,compare]
+type t = Vmlibrary.index
+let name = "Vmlibrary.index"
 end
 
-module C = SerType.Pierce(OQ)
+module C = SerType.Opaque(OQ)
 type index = C.t
  [@@deriving sexp,yojson,hash,compare]
 


### PR DESCRIPTION
Follow-up and clean-up of #389, after some pondering.

Exposing the internal through Obj.magic is very fragile, and I do not think that accessing the VM bytecode is useful in practice. The corresponding code for declarations replaces the body by None anyways.