### PR TITLE
[test] Don't require math-comp to run the test suite.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,8 @@ on:
     - v8.16
     - v8.17
     - v8.18
+    - v8.19
+    - v8.20
     - main
   pull_request:
     branches:
@@ -28,6 +30,8 @@ on:
     - v8.16
     - v8.17
     - v8.18
+    - v8.19
+    - v8.20
     - main
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
       matrix:
         ocaml-compiler: [4.09.x, 4.10.x, 4.11.x, 4.12.x, 4.13.x, 4.14.x]
         test-target: [test]
-        extra-opam: [coq.dev coq-mathcomp-ssreflect.1.dev]
+        extra-opam: [coq.dev]
         include:
         - ocaml-compiler: 4.13.1
           test-target: test
@@ -72,8 +72,6 @@ jobs:
           eval $(opam env)
           opam repos add coq-released http://coq.inria.fr/opam/released
           opam repos add coq-core-dev http://coq.inria.fr/opam/core-dev
-          # Only for mathcomp.dev which is needed for 8.16, remove when math-comp is fixed
-          opam repos add coq-extra-dev http://coq.inria.fr/opam/extra-dev
           # coq-serapi already pinned by the setup-ocaml@v2 action
           opam install --deps-only coq-serapi
       - name: Display OPAM Setup
@@ -95,12 +93,6 @@ jobs:
           ./configure -prefix "$HOME/coq-$COQ_BRANCH/_build/install/default/"
           make dunestrap
           dune build -p coq-core,coq-stdlib,coq
-          cd "$HOME"
-          # Install math-comp using Coq from git
-          PATH="$HOME/coq-$COQ_BRANCH/_build/install/default/bin:$PATH"
-          git clone --depth=3 -b mathcomp-1 https://github.com/math-comp/math-comp.git
-          make -C math-comp/mathcomp/ssreflect
-          make -C math-comp/mathcomp/ssreflect install
       - name: Extra OPAM Setup (Coq.dev, misc extra tools)
         if: ${{ matrix.extra-opam != '' }}
         run: |

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 ## unreleased
 
+ - [test] Don't require math-comp to run genarg tests (@ejgallego, #399 ,
+          fixes #395 , thanks to @SnarkBoojum for the report)
+
+## Version 0.19.1
+
  - [serlib] Support `btauto` Coq plugin (@ejgallego, #362)
  - [serlib] Support `extraction` Coq plugin (@ejgallego, @toku-sa-n,
             #375, fixes #371)

--- a/coq-serapi.opam
+++ b/coq-serapi.opam
@@ -36,12 +36,6 @@ depends: [
   "ppx_hash"            {           >= "v0.13.0"             }
   "yojson"              {           >= "1.7.0"               }
   "ppx_deriving_yojson" {           >= "3.4"                 }
-
-  # math-comp ssreflect is needed to run the tests.
-  #
-  # We can't enable this due to coq-mathcomp-ssreflect not being in
-  # the main opam repos, that would make opam's CI fail.
-  # "coq-mathcomp-ssreflect" { with-test & >= "1.15" }
 ]
 
 conflicts: [
@@ -49,3 +43,4 @@ conflicts: [
 ]
 
 build: [ "dune" "build" "-p" name "-j" jobs ]
+run-test: [ [ "dune" "runtest" "-p" name "-j" jobs ] ]


### PR DESCRIPTION
Fixes #399

This means we can enable `@with-test` in the opam file!