### PR TITLE
 [serlib] [ltac2] Test for Ltac2 serialization

### DIFF
--- a/tests/genarg/dune
+++ b/tests/genarg/dune
@@ -168,8 +168,8 @@
  (action (run ./test_roundtrip %{input})))
 
 ; Disabled until we implement ltac2 extension serialization
-;
-; (rule
-;  (alias runtest)
-;  (deps (:input ltac2.v))
-;  (action (run ./test_roundtrip %{input})))
+
+(rule
+ (alias runtest)
+ (deps (:input ltac2.v))
+ (action (run ./test_roundtrip %{input})))


### PR DESCRIPTION
This fails for now, as we need to implement support for yet another
generic arguments setup.

To be fixed under-demand.