### PR TITLE
[serlib] Don't use compat type Result.result

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 ## unreleased
 
  - [serlib] Support `micromega_core` plugin (@ejgallego)
+ - [serlib] Compat with ppx_deriving 6 (@ejgallego)
 
 ## Version 0.19.3
 

--- a/serlib/ser_constrexpr.mli
+++ b/serlib/ser_constrexpr.mli
@@ -97,13 +97,8 @@ and local_binder_expr    = Constrexpr.local_binder_expr
 and constr_notation_substitution = Constrexpr.constr_notation_substitution
 [@@deriving sexp, yojson, hash,compare]
 
-type constr_pattern_expr = Constrexpr.constr_pattern_expr [@@deriving sexp, yojson, hash,compare]
+type constr_pattern_expr = Constrexpr.constr_pattern_expr [@@deriving sexp,yojson,hash,compare]
 
-type with_declaration_ast = Constrexpr.with_declaration_ast
-
-val with_declaration_ast_of_sexp : Sexp.t -> with_declaration_ast
-val sexp_of_with_declaration_ast : with_declaration_ast -> Sexp.t
-val with_declaration_ast_of_yojson : Yojson.Safe.t -> (with_declaration_ast, string) Result.result
-val with_declaration_ast_to_yojson : with_declaration_ast -> Yojson.Safe.t
+type with_declaration_ast = Constrexpr.with_declaration_ast [@@deriving sexp,yojson,hash,compare]
 
 type module_ast = Constrexpr.module_ast [@@deriving sexp,yojson,hash,compare]

--- a/serlib/ser_dAst.ml
+++ b/serlib/ser_dAst.ml
@@ -31,7 +31,7 @@ let sexp_of_thunk : type a b. (a -> Sexp.t) -> (b -> Sexp.t) -> (a,b) thunk -> S
 let thunk_of_sexp : type a b. (Sexp.t -> a) -> (Sexp.t -> b) -> Sexp.t -> (a,b) thunk =
   fun f _ s -> Value (f s)
 
-let thunk_of_yojson : type a b. (Yojson.Safe.t -> (a, string) Result.result) -> (Yojson.Safe.t -> (b, string) Result.result) -> Yojson.Safe.t -> ((a,b) thunk, string) Result.result =
+let thunk_of_yojson : type a b. (Yojson.Safe.t -> (a, string) Result.t) -> (Yojson.Safe.t -> (b, string) Result.t) -> Yojson.Safe.t -> ((a,b) thunk, string) Result.t =
   fun f _ s -> Result.map (fun s -> Value s) (f s)
 
 let thunk_to_yojson : type a b. (a -> Yojson.Safe.t) -> (b -> Yojson.Safe.t) -> (a,b) thunk -> Yojson.Safe.t =

--- a/serlib/ser_deprecation.ml
+++ b/serlib/ser_deprecation.ml
@@ -16,8 +16,10 @@
 (* Written by: Emilio J. Gallego Arias and others                       *)
 (************************************************************************)
 
+open Ppx_hash_lib.Std.Hash.Builtin
+open Ppx_compare_lib.Builtin
 open Sexplib.Std
 
 type t =
   [%import: Deprecation.t]
-  [@@deriving sexp,yojson]
+  [@@deriving sexp,yojson,hash,compare]

--- a/serlib/ser_feedback.mli
+++ b/serlib/ser_feedback.mli
@@ -16,38 +16,17 @@
 (* Written by: Emilio J. Gallego Arias and others                       *)
 (************************************************************************)
 
-open Sexplib
-
 type doc_id = Feedback.doc_id
-
-val doc_id_of_sexp : Sexp.t -> doc_id
-val sexp_of_doc_id : doc_id -> Sexp.t
-val doc_id_of_yojson : Yojson.Safe.t -> (doc_id, string) Result.result
-val doc_id_to_yojson : doc_id -> Yojson.Safe.t
+ [@@deriving sexp,yojson]
 
 type level = Feedback.level
-
-val level_of_sexp : Sexp.t -> level
-val sexp_of_level : level -> Sexp.t
-val level_of_yojson : Yojson.Safe.t -> (level, string) Result.result
-val level_to_yojson : level -> Yojson.Safe.t
+ [@@deriving sexp,yojson]
 
 type route_id = Feedback.route_id
-val route_id_of_sexp : Sexp.t -> route_id
-val sexp_of_route_id : route_id -> Sexp.t
-val route_id_of_yojson : Yojson.Safe.t -> (route_id, string) Result.result
-val route_id_to_yojson : route_id -> Yojson.Safe.t
+ [@@deriving sexp,yojson]
 
 type feedback_content = Feedback.feedback_content
-
-val feedback_content_of_sexp : Sexp.t -> feedback_content
-val sexp_of_feedback_content : feedback_content -> Sexp.t
-val feedback_content_of_yojson : Yojson.Safe.t -> (feedback_content, string) Result.result
-val feedback_content_to_yojson : feedback_content -> Yojson.Safe.t
+ [@@deriving sexp,yojson]
 
 type feedback = Feedback.feedback
-
-val feedback_of_sexp : Sexp.t -> feedback
-val sexp_of_feedback : feedback -> Sexp.t
-val feedback_of_yojson : Yojson.Safe.t -> (feedback, string) Result.result
-val feedback_to_yojson : feedback -> Yojson.Safe.t
+ [@@deriving sexp,yojson]

--- a/serlib/ser_genredexpr.ml
+++ b/serlib/ser_genredexpr.ml
@@ -31,7 +31,7 @@ module Evaluable = Ser_evaluable
 
 type 'a red_atom =
   [%import: 'a Genredexpr.red_atom]
-  [@@deriving sexp]
+  [@@deriving sexp,yojson,hash,compare]
 
 type strength =
   [%import: Genredexpr.strength]

--- a/serlib/ser_genredexpr.mli
+++ b/serlib/ser_genredexpr.mli
@@ -16,19 +16,11 @@
 (* Written by: Emilio J. Gallego Arias and others                       *)
 (************************************************************************)
 
-open Sexplib
-
 type 'a red_atom = 'a Genredexpr.red_atom
-
-val red_atom_of_sexp : (Sexp.t -> 'a) -> Sexp.t -> 'a red_atom
-val sexp_of_red_atom : ('a -> Sexp.t) -> 'a red_atom -> Sexp.t
+ [@@deriving sexp,yojson,hash,compare]
 
 type 'a glob_red_flag =  'a Genredexpr.glob_red_flag
-
-val glob_red_flag_of_sexp : (Sexp.t -> 'a) -> Sexp.t -> 'a glob_red_flag
-val sexp_of_glob_red_flag : ('a -> Sexp.t) -> 'a glob_red_flag -> Sexp.t
-val glob_red_flag_of_yojson : (Yojson.Safe.t -> ('a, string) Result.result) -> Yojson.Safe.t -> ('a glob_red_flag, string) Result.result
-val glob_red_flag_to_yojson : ('a -> Yojson.Safe.t) -> 'a glob_red_flag -> Yojson.Safe.t
+ [@@deriving sexp,yojson,hash,compare]
 
 type ('a, 'b, 'c, 'd) red_expr_gen =  ('a, 'b, 'c, 'd) Genredexpr.red_expr_gen
   [@@deriving sexp,yojson,hash,compare]

--- a/serlib/ser_glob_term.mli
+++ b/serlib/ser_glob_term.mli
@@ -16,35 +16,23 @@
 (* Written by: Emilio J. Gallego Arias and others                       *)
 (************************************************************************)
 
-open Sexplib
-
 type binding_kind = Glob_term.binding_kind [@@deriving sexp,yojson,hash,compare]
 type 'a glob_sort_gen = 'a Glob_term.glob_sort_gen [@@deriving sexp,yojson,hash,compare]
 
 type glob_level = Glob_term.glob_level
-val glob_level_of_sexp : Sexp.t -> Glob_term.glob_level
-val sexp_of_glob_level : Glob_term.glob_level -> Sexp.t
-
-val glob_level_of_yojson : Yojson.Safe.t -> (glob_level,string) result
-val glob_level_to_yojson : Glob_term.glob_level -> Yojson.Safe.t
+ [@@deriving sexp,yojson,hash,compare]
 
 type glob_sort = Glob_term.glob_sort
-val glob_sort_of_sexp : Sexp.t -> Glob_term.glob_sort
-val sexp_of_glob_sort : Glob_term.glob_sort -> Sexp.t
-val glob_sort_of_yojson : Yojson.Safe.t -> (glob_sort, string) Result.result
-val glob_sort_to_yojson : glob_sort -> Yojson.Safe.t
+ [@@deriving sexp,yojson,hash,compare]
 
 (* type 'a cast_type = 'a Glob_term.cast_type
  * val cast_type_of_sexp : (Sexp.t -> 'a) -> Sexp.t -> 'a Glob_term.cast_type
  * val sexp_of_cast_type : ('a -> Sexp.t) -> 'a Glob_term.cast_type -> Sexp.t
- * val cast_type_of_yojson : (Yojson.Safe.t -> ('a,string) result ) -> Yojson.Safe.t -> ('a cast_type, string) Result.result
+ * val cast_type_of_yojson : (Yojson.Safe.t -> ('a,string) result ) -> Yojson.Safe.t -> ('a cast_type, string) Result.t
  * val cast_type_to_yojson : ('a -> Yojson.Safe.t) -> 'a cast_type -> Yojson.Safe.t *)
 
 type glob_constraint = Glob_term.glob_constraint
-val glob_constraint_of_sexp : Sexp.t -> Glob_term.glob_constraint
-val sexp_of_glob_constraint : Glob_term.glob_constraint -> Sexp.t
-val glob_constraint_of_yojson : Yojson.Safe.t -> (glob_constraint, string) Result.result
-val glob_constraint_to_yojson : glob_constraint -> Yojson.Safe.t
+ [@@deriving sexp,yojson,hash,compare]
 
 type existential_name = Glob_term.existential_name [@@deriving sexp,yojson,hash,compare]
 type cases_pattern    = Glob_term.cases_pattern

--- a/serlib/ser_goptions.ml
+++ b/serlib/ser_goptions.ml
@@ -33,11 +33,11 @@ type option_name =
 
 type option_value =
   [%import: Goptions.option_value]
-  [@@deriving sexp,yojson]
+  [@@deriving sexp,yojson,hash,compare]
 
 type option_state =
   [%import: Goptions.option_state]
-  [@@deriving sexp]
+  [@@deriving sexp,yojson,hash,compare]
 
 type table_value =
   [%import: Goptions.table_value]

--- a/serlib/ser_goptions.mli
+++ b/serlib/ser_goptions.mli
@@ -16,8 +16,6 @@
 (* Written by: Emilio J. Gallego Arias and others                       *)
 (************************************************************************)
 
-open Sexplib
-
 type option_locality = Goptions.option_locality
 [@@deriving sexp, yojson, hash,compare]
 
@@ -25,15 +23,9 @@ type option_name = Goptions.option_name
 [@@deriving sexp, yojson, hash,compare]
 
 type option_value = Goptions.option_value
-
-val option_value_of_sexp : Sexp.t -> option_value
-val sexp_of_option_value : option_value -> Sexp.t
-val option_value_of_yojson : Yojson.Safe.t -> (option_value, string) Result.result
-val option_value_to_yojson : option_value -> Yojson.Safe.t
+ [@@deriving sexp,yojson,hash,compare]
 
 type option_state = Goptions.option_state
-
-val option_state_of_sexp : Sexp.t -> option_state
-val sexp_of_option_state : option_state -> Sexp.t
+ [@@deriving sexp,yojson,hash,compare]
 
 type table_value = Goptions.table_value [@@deriving sexp, yojson, hash,compare]

--- a/serlib/ser_pp.mli
+++ b/serlib/ser_pp.mli
@@ -16,17 +16,8 @@
 (* Written by: Emilio J. Gallego Arias and others                       *)
 (************************************************************************)
 
-open Sexplib
-
 type t = Pp.t
+ [@@deriving sexp,yojson,hash,compare]
+
 type doc_view = Pp.doc_view
-
-val t_of_sexp : Sexp.t -> t
-val sexp_of_t : t -> Sexp.t
-val of_yojson : Yojson.Safe.t -> (t, string) Result.result
-val to_yojson : t -> Yojson.Safe.t
-
-val doc_view_of_sexp : Sexp.t -> doc_view
-val sexp_of_doc_view : doc_view -> Sexp.t
-val doc_view_of_yojson : Yojson.Safe.t -> (doc_view, string) Result.result
-val doc_view_to_yojson : doc_view -> Yojson.Safe.t
+ [@@deriving sexp,yojson,hash,compare]

--- a/serlib/ser_xml_datatype.mli
+++ b/serlib/ser_xml_datatype.mli
@@ -16,18 +16,8 @@
 (* Written by: Emilio J. Gallego Arias and others                       *)
 (************************************************************************)
 
-open Sexplib
-
 type 'a gxml = 'a Xml_datatype.gxml
-
-val gxml_of_sexp : (Sexp.t -> 'a) -> Sexp.t -> 'a gxml
-val sexp_of_gxml : ('a -> Sexp.t) -> 'a gxml -> Sexp.t
-val gxml_of_yojson : (Yojson.Safe.t -> ('a, string) Result.result) -> Yojson.Safe.t -> ('a gxml, string) Result.result
-val gxml_to_yojson : ('a -> Yojson.Safe.t) -> 'a gxml -> Yojson.Safe.t
+ [@@deriving sexp,yojson]
 
 type xml = Xml_datatype.xml
-
-val xml_of_sexp : Sexp.t -> xml
-val sexp_of_xml : xml -> Sexp.t
-val xml_of_yojson : Yojson.Safe.t -> (xml, string) Result.result
-val xml_to_yojson : xml -> Yojson.Safe.t
+ [@@deriving sexp,yojson]


### PR DESCRIPTION
This was a long overdue TODO.

cc: https://github.com/ocaml/opam-repository/pull/25951